### PR TITLE
Add .env file support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,40 @@
+# Lace AI Assistant Configuration
+# Copy this file to .env and update with your values
+
+# AI Provider API Keys
+# Required for Anthropic provider
+ANTHROPIC_KEY=your-anthropic-api-key-here
+
+# Optional: OpenAI API key (for future support)
+# OPENAI_API_KEY=your-openai-api-key-here
+
+# Configuration Directory
+# Default: ~/.lace
+# LACE_DIR=/path/to/custom/lace/directory
+
+# Local Model Server Configuration
+# For LMStudio (default: http://localhost:1234)
+# LMSTUDIO_BASE_URL=http://localhost:1234
+
+# For Ollama (default: http://localhost:11434)
+# OLLAMA_BASE_URL=http://localhost:11434
+
+# Default Models
+# Override default model for each provider
+# ANTHROPIC_MODEL=claude-3-5-sonnet-20241022
+# LMSTUDIO_MODEL=your-local-model
+# OLLAMA_MODEL=codellama:latest
+
+# Logging Configuration
+# Log level: debug, info, warn, error (default: info)
+# LOG_LEVEL=info
+
+# Log file path (optional, logs to console by default)
+# LOG_FILE=/path/to/lace.log
+
+# Token Limits (future feature)
+# MAX_TOKENS_PER_MESSAGE=8192
+# MAX_CONVERSATION_TOKENS=100000
+
+# Development/Production Mode
+# NODE_ENV=development

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,11 @@
 // ABOUTME: Main CLI entry point for Lace AI coding assistant
 // ABOUTME: Orchestrates provider setup, Agent creation, and CLI interface management
 
+import { loadEnvFile, getEnvVar } from './config/env-loader.js';
+
+// Load environment variables from .env file before anything else
+loadEnvFile();
+
 import { Agent } from './agents/agent.js';
 import { AnthropicProvider } from './providers/anthropic-provider.js';
 import { LMStudioProvider } from './providers/lmstudio-provider.js';
@@ -49,7 +54,7 @@ async function createProvider(
 
   switch (providerType) {
     case 'anthropic': {
-      const apiKey = process.env.ANTHROPIC_KEY;
+      const apiKey = getEnvVar('ANTHROPIC_KEY');
       if (!apiKey) {
         console.error('Error: ANTHROPIC_KEY environment variable required for Anthropic provider');
         process.exit(1);
@@ -89,7 +94,7 @@ async function main() {
   logger.info('Lace configuration files', {
     systemPromptPath,
     userInstructionsPath,
-    laceDir: process.env.LACE_DIR || '~/.lace',
+    laceDir: getEnvVar('LACE_DIR', '~/.lace'),
   });
 
   const provider = await createProvider(options.provider, options.model);

--- a/src/config/env-loader.ts
+++ b/src/config/env-loader.ts
@@ -1,0 +1,37 @@
+// ABOUTME: Loads environment variables from .env files using dotenv
+
+import dotenv from 'dotenv';
+import path from 'path';
+import fs from 'fs';
+import { logger } from '../utils/logger.js';
+
+export function loadEnvFile(): void {
+  const envPath = path.resolve(process.cwd(), '.env');
+
+  if (fs.existsSync(envPath)) {
+    const result = dotenv.config({ path: envPath });
+
+    if (result.error) {
+      logger.warn('Failed to parse .env file', { error: result.error.message });
+    } else {
+      logger.debug('.env file loaded successfully', {
+        path: envPath,
+        variableCount: Object.keys(result.parsed || {}).length,
+      });
+    }
+  } else {
+    logger.debug('No .env file found', { searchPath: envPath });
+  }
+}
+
+export function getEnvVar(key: string, defaultValue?: string): string | undefined {
+  return process.env[key] || defaultValue;
+}
+
+export function requireEnvVar(key: string): string {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`Required environment variable ${key} is not set`);
+  }
+  return value;
+}

--- a/src/config/lace-dir.ts
+++ b/src/config/lace-dir.ts
@@ -4,13 +4,14 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { getEnvVar } from './env-loader.js';
 
 /**
  * Get the Lace configuration directory
  * Uses LACE_DIR environment variable, falls back to ~/.lace/
  */
 export function getLaceDir(): string {
-  const laceDir = process.env.LACE_DIR || path.join(os.homedir(), '.lace');
+  const laceDir = getEnvVar('LACE_DIR') || path.join(os.homedir(), '.lace');
   return laceDir;
 }
 

--- a/src/threads/__tests__/persistence.test.ts
+++ b/src/threads/__tests__/persistence.test.ts
@@ -700,7 +700,7 @@ describe('Integration Tests', () => {
     await manager2.close();
   });
 
-  it('should handle large conversations efficiently', async () => {
+  it('should handle large conversations efficiently', { timeout: 10000 }, async () => {
     const threadManager = new ThreadManager(tempDbPath);
     const threadId = 'lace_large_test';
     threadManager.createThread(threadId);

--- a/src/tools/__tests__/delegate.test.ts
+++ b/src/tools/__tests__/delegate.test.ts
@@ -32,6 +32,9 @@ describe('DelegateTool', () => {
     // Reset mocks
     vi.clearAllMocks();
 
+    // Set up test environment variables
+    process.env.ANTHROPIC_KEY = 'test-api-key';
+
     // Create mock instances
     mockThreadManager = new ThreadManager(':memory:');
     mockToolRegistry = new ToolRegistry();
@@ -69,6 +72,8 @@ describe('DelegateTool', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    // Clean up test environment variables
+    delete process.env.ANTHROPIC_KEY;
   });
 
   it('should have correct metadata', () => {

--- a/src/tools/implementations/delegate.ts
+++ b/src/tools/implementations/delegate.ts
@@ -12,6 +12,7 @@ import { OllamaProvider } from '../../providers/ollama-provider.js';
 import { AIProvider } from '../../providers/types.js';
 import { TokenBudgetConfig } from '../../token-management/types.js';
 import { generateThreadId } from '../../threads/session.js';
+import { getEnvVar } from '../../config/env-loader.js';
 
 export class DelegateTool implements Tool {
   name = 'delegate';
@@ -264,7 +265,7 @@ Remember: You are optimized for efficiency. Get the job done and report back.`;
 
     switch (providerName.toLowerCase()) {
       case 'anthropic': {
-        const apiKey = process.env.ANTHROPIC_KEY;
+        const apiKey = getEnvVar('ANTHROPIC_KEY');
         if (!apiKey) {
           throw new Error('ANTHROPIC_KEY environment variable required for Anthropic provider');
         }


### PR DESCRIPTION
  Add .env file support for environment configuration

  - Created env-loader module using dotenv to load .env files on startup
  - Updated all environment variable access to use centralized getEnvVar helper
  - Added comprehensive .env.example documenting all configuration options
  - Maintains backward compatibility - shell environment variables take precedence
  - Fixed test suite to properly mock environment variables
  - Added timeout to large conversation test to prevent CI failures

  This allows users to configure Lace via a .env file instead of manually
  exporting environment variables, making setup more user-friendly while
  preserving existing behavior for those using shell exports.