### PR TITLE
Erans/OpenAI support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "better-sqlite3": "^11.10.0",
         "dotenv": "^16.5.0",
         "ollama": "^0.5.16",
+        "openai": "^4.77.0",
         "pino": "^9.7.0",
         "pino-pretty": "^13.0.0"
       },
@@ -1368,10 +1369,19 @@
       "version": "22.15.32",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.32.tgz",
       "integrity": "sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1757,6 +1767,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1778,6 +1800,18 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -1869,6 +1903,12 @@
         "estree-walker": "^3.0.3",
         "js-tokens": "^9.0.1"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
@@ -1994,6 +2034,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2110,6 +2163,18 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
@@ -2210,6 +2275,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -2229,6 +2303,20 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -2267,12 +2355,57 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.5",
@@ -2600,6 +2733,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -2802,6 +2944,41 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -2823,6 +3000,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
@@ -2834,6 +3020,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/github-from-package": {
@@ -2889,6 +3112,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -2905,6 +3140,45 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/help-me": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
@@ -2917,6 +3191,15 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
     },
     "node_modules/husky": {
       "version": "9.1.7",
@@ -3422,6 +3705,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3444,6 +3736,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-function": {
@@ -3516,7 +3829,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nano-spawn": {
@@ -3576,6 +3888,46 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ollama": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/ollama/-/ollama-0.5.16.tgz",
@@ -3618,6 +3970,51 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.112",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.112.tgz",
+      "integrity": "sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -4704,6 +5101,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -4760,7 +5163,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {
@@ -4991,11 +5393,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "better-sqlite3": "^11.10.0",
     "dotenv": "^16.5.0",
     "ollama": "^0.5.16",
+    "openai": "^4.77.0",
     "pino": "^9.7.0",
     "pino-pretty": "^13.0.0"
   },

--- a/src/__tests__/e2e-cli.test.ts
+++ b/src/__tests__/e2e-cli.test.ts
@@ -266,7 +266,9 @@ describe('End-to-End CLI Tests', () => {
       const result = await runCLI(['--provider', 'invalid']);
 
       expect(result.exitCode).toBe(1);
-      expect(result.stderr).toContain('--provider must be "anthropic", "lmstudio", or "ollama"');
+      expect(result.stderr).toContain(
+        '--provider must be "anthropic", "openai", "lmstudio", or "ollama"'
+      );
     });
 
     it('should validate log level values', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@
 
 import { Agent } from './agents/agent.js';
 import { AnthropicProvider } from './providers/anthropic-provider.js';
+import { OpenAIProvider } from './providers/openai-provider.js';
 import { LMStudioProvider } from './providers/lmstudio-provider.js';
 import { OllamaProvider } from './providers/ollama-provider.js';
 import { AIProvider } from './providers/types.js';
@@ -31,7 +32,7 @@ import { CLIInterface } from './cli/interface.js';
 
 // Create provider based on CLI option
 async function createProvider(
-  providerType: 'anthropic' | 'lmstudio' | 'ollama',
+  providerType: 'anthropic' | 'openai' | 'lmstudio' | 'ollama',
   model?: string
 ): Promise<AIProvider> {
   // Load configurable prompts from user's Lace directory
@@ -55,6 +56,16 @@ async function createProvider(
         process.exit(1);
       }
       return new AnthropicProvider({ apiKey, systemPrompt, model });
+    }
+    case 'openai': {
+      const apiKey = process.env.OPENAI_API_KEY || process.env.OPENAI_KEY;
+      if (!apiKey) {
+        console.error(
+          'Error: OPENAI_API_KEY or OPENAI_KEY environment variable required for OpenAI provider'
+        );
+        process.exit(1);
+      }
+      return new OpenAIProvider({ apiKey, systemPrompt, model });
     }
     case 'lmstudio': {
       return new LMStudioProvider({ systemPrompt, model });

--- a/src/cli/__tests__/args.test.ts
+++ b/src/cli/__tests__/args.test.ts
@@ -41,19 +41,21 @@ describe('CLI Arguments', () => {
       expect(parseArgs(['--provider', 'lmstudio']).provider).toBe('lmstudio');
       expect(parseArgs(['-p', 'ollama']).provider).toBe('ollama');
       expect(parseArgs(['--provider=anthropic']).provider).toBe('anthropic');
+      expect(parseArgs(['--provider', 'openai']).provider).toBe('openai');
+      expect(parseArgs(['-p', 'openai']).provider).toBe('openai');
     });
 
     it('should validate provider values', () => {
       expect(() => parseArgs(['--provider', 'invalid'])).toThrow('process.exit called');
       expect(consoleSpy).toHaveBeenCalledWith(
-        'Error: --provider must be "anthropic", "lmstudio", or "ollama"'
+        'Error: --provider must be "anthropic", "openai", "lmstudio", or "ollama"'
       );
     });
 
     it('should handle missing provider value', () => {
       expect(() => parseArgs(['--provider'])).toThrow('process.exit called');
       expect(consoleSpy).toHaveBeenCalledWith(
-        'Error: --provider must be "anthropic", "lmstudio", or "ollama"'
+        'Error: --provider must be "anthropic", "openai", "lmstudio", or "ollama"'
       );
     });
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Handles all CLI flags, validation, and help text generation
 
 export interface CLIOptions {
-  provider: 'anthropic' | 'lmstudio' | 'ollama';
+  provider: 'anthropic' | 'openai' | 'lmstudio' | 'ollama';
   model: string | undefined;
   help: boolean;
   logLevel: 'error' | 'warn' | 'info' | 'debug';
@@ -27,19 +27,22 @@ export function parseArgs(args: string[] = process.argv.slice(2)): CLIOptions {
       options.help = true;
     } else if (arg === '--provider' || arg === '-p') {
       const providerValue = args[i + 1];
-      if (!providerValue || !['anthropic', 'lmstudio', 'ollama'].includes(providerValue)) {
-        console.error('Error: --provider must be "anthropic", "lmstudio", or "ollama"');
+      if (
+        !providerValue ||
+        !['anthropic', 'openai', 'lmstudio', 'ollama'].includes(providerValue)
+      ) {
+        console.error('Error: --provider must be "anthropic", "openai", "lmstudio", or "ollama"');
         process.exit(1);
       }
-      options.provider = providerValue as 'anthropic' | 'lmstudio' | 'ollama';
+      options.provider = providerValue as 'anthropic' | 'openai' | 'lmstudio' | 'ollama';
       i++; // Skip next argument since we consumed it
     } else if (arg.startsWith('--provider=')) {
       const providerValue = arg.split('=')[1];
-      if (!['anthropic', 'lmstudio', 'ollama'].includes(providerValue)) {
-        console.error('Error: --provider must be "anthropic", "lmstudio", or "ollama"');
+      if (!['anthropic', 'openai', 'lmstudio', 'ollama'].includes(providerValue)) {
+        console.error('Error: --provider must be "anthropic", "openai", "lmstudio", or "ollama"');
         process.exit(1);
       }
-      options.provider = providerValue as 'anthropic' | 'lmstudio' | 'ollama';
+      options.provider = providerValue as 'anthropic' | 'openai' | 'lmstudio' | 'ollama';
     } else if (arg === '--model' || arg === '-m') {
       const modelValue = args[i + 1];
       if (!modelValue) {
@@ -121,7 +124,7 @@ Usage: lace [options]
 
 Options:
   -h, --help                Show this help message
-  -p, --provider <name>     Choose AI provider: "anthropic" (default), "lmstudio", or "ollama"
+  -p, --provider <name>     Choose AI provider: "anthropic" (default), "openai", "lmstudio", or "ollama"
   -m, --model <name>        Override the default model for the selected provider
   --log-level <level>       Set log level: "error", "warn", "info" (default), or "debug"
   --log-file <path>         Write logs to file (no file = no logging)
@@ -131,9 +134,11 @@ Options:
 Examples:
   lace                      # Use Anthropic Claude (default)
   lace --provider anthropic # Use Anthropic Claude explicitly
+  lace --provider openai    # Use OpenAI GPT models
   lace --provider lmstudio  # Use local LMStudio server
   lace --provider ollama    # Use local Ollama server
   lace --model claude-haiku-3-20241022  # Use specific Anthropic model
+  lace --provider openai --model gpt-4o  # Use specific OpenAI model
   lace --provider lmstudio --model mistralai/devstral-small-2505  # Use specific LMStudio model
   lace --log-level debug --log-file debug.log  # Debug logging to file
   lace --prompt "What files are in the current directory?"  # Single command
@@ -143,5 +148,6 @@ Examples:
 
 Environment Variables:
   ANTHROPIC_KEY            Required for Anthropic provider
+  OPENAI_API_KEY           Required for OpenAI provider (or OPENAI_KEY)
 `);
 }

--- a/src/providers/__tests__/openai-provider.test.ts
+++ b/src/providers/__tests__/openai-provider.test.ts
@@ -1,0 +1,558 @@
+// ABOUTME: Unit tests for OpenAIProvider class
+// ABOUTME: Tests streaming vs non-streaming responses, configuration, and error handling
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { OpenAIProvider } from '../openai-provider.js';
+import { Tool } from '../../tools/types.js';
+
+// Mock the OpenAI SDK
+const mockCreate = vi.fn();
+
+vi.mock('openai', () => {
+  return {
+    default: class MockOpenAI {
+      chat = {
+        completions: {
+          create: mockCreate,
+        },
+      };
+    },
+  };
+});
+
+// Mock logger
+vi.mock('../../utils/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('OpenAIProvider', () => {
+  let provider: OpenAIProvider;
+  let mockTool: Tool;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    provider = new OpenAIProvider({
+      apiKey: 'test-key',
+      systemPrompt: 'Test system prompt',
+    });
+
+    mockTool = {
+      name: 'test_tool',
+      description: 'A test tool',
+      input_schema: {
+        type: 'object',
+        properties: {
+          action: { type: 'string', description: 'Action to perform' },
+        },
+        required: ['action'],
+      },
+      executeTool: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    provider.removeAllListeners();
+  });
+
+  describe('basic properties', () => {
+    it('should have correct provider name', () => {
+      expect(provider.providerName).toBe('openai');
+    });
+
+    it('should have correct default model', () => {
+      expect(provider.defaultModel).toBe('gpt-4o-mini');
+    });
+
+    it('should support streaming', () => {
+      expect(provider.supportsStreaming).toBe(true);
+    });
+
+    it('should expose configuration', () => {
+      const config = provider.config;
+      expect(config.systemPrompt).toBe('Test system prompt');
+    });
+  });
+
+  describe('non-streaming responses', () => {
+    beforeEach(() => {
+      mockCreate.mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: 'Test response',
+              tool_calls: undefined,
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      });
+    });
+
+    it('should create non-streaming response correctly', async () => {
+      const messages = [{ role: 'user' as const, content: 'Hello' }];
+
+      const response = await provider.createResponse(messages, [mockTool]);
+
+      expect(response.content).toBe('Test response');
+      expect(response.toolCalls).toEqual([]);
+      expect(mockCreate).toHaveBeenCalled();
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.model).toBe('gpt-4o-mini');
+      expect(callArgs.max_tokens).toBe(4000);
+      expect(callArgs.messages[0]).toEqual({ role: 'system', content: 'Test system prompt' });
+      expect(callArgs.messages[1]).toEqual({ role: 'user', content: 'Hello' });
+      expect(callArgs.tools).toEqual([
+        {
+          type: 'function',
+          function: {
+            name: 'test_tool',
+            description: 'A test tool',
+            parameters: mockTool.input_schema,
+          },
+        },
+      ]);
+    });
+
+    it('should handle tool calls in response', async () => {
+      mockCreate.mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: 'Using tool',
+              tool_calls: [
+                {
+                  id: 'call_123',
+                  function: {
+                    name: 'test_tool',
+                    arguments: JSON.stringify({ action: 'test' }),
+                  },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      });
+
+      const messages = [{ role: 'user' as const, content: 'Use tool' }];
+      const response = await provider.createResponse(messages, [mockTool]);
+
+      expect(response.content).toBe('Using tool');
+      expect(response.toolCalls).toEqual([
+        {
+          id: 'call_123',
+          name: 'test_tool',
+          input: { action: 'test' },
+        },
+      ]);
+    });
+
+    it('should handle system messages correctly', async () => {
+      const messages = [
+        { role: 'system' as const, content: 'Override system message' },
+        { role: 'user' as const, content: 'User message' },
+        { role: 'assistant' as const, content: 'Assistant message' },
+      ];
+
+      await provider.createResponse(messages, []);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.messages[0]).toEqual({ role: 'system', content: 'Override system message' });
+      expect(callArgs.messages[1]).toEqual({ role: 'user', content: 'User message' });
+      expect(callArgs.messages[2]).toEqual({ role: 'assistant', content: 'Assistant message' });
+    });
+
+    it('should handle empty message content', async () => {
+      mockCreate.mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: null,
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {},
+      });
+
+      const messages = [{ role: 'user' as const, content: 'Test' }];
+      const response = await provider.createResponse(messages, []);
+
+      expect(response.content).toBe('');
+    });
+
+    it('should throw error if no message in response', async () => {
+      mockCreate.mockResolvedValue({
+        choices: [{}],
+        usage: {},
+      });
+
+      const messages = [{ role: 'user' as const, content: 'Test' }];
+
+      await expect(provider.createResponse(messages, [])).rejects.toThrow(
+        'No message in OpenAI response'
+      );
+    });
+  });
+
+  describe('streaming responses', () => {
+    let mockStream: any;
+
+    beforeEach(() => {
+      mockStream = {
+        [Symbol.asyncIterator]: vi.fn(),
+      };
+      mockCreate.mockReturnValue(mockStream);
+    });
+
+    it('should create streaming response correctly', async () => {
+      const chunks = [
+        {
+          choices: [
+            {
+              delta: { content: 'Hello ' },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          choices: [
+            {
+              delta: { content: 'world!' },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          choices: [
+            {
+              delta: {},
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 15, completion_tokens: 8, total_tokens: 23 },
+        },
+      ];
+
+      mockStream[Symbol.asyncIterator].mockReturnValue(
+        {
+          async *[Symbol.asyncIterator]() {
+            for (const chunk of chunks) {
+              yield chunk;
+            }
+          },
+        }[Symbol.asyncIterator]()
+      );
+
+      const messages = [{ role: 'user' as const, content: 'Stream this' }];
+      const response = await provider.createStreamingResponse(messages, [mockTool]);
+
+      expect(response.content).toBe('Hello world!');
+      expect(response.toolCalls).toEqual([]);
+      expect(response.stopReason).toBe('stop');
+      expect(response.usage).toEqual({
+        promptTokens: 15,
+        completionTokens: 8,
+        totalTokens: 23,
+      });
+    });
+
+    it('should emit token events during streaming', async () => {
+      const tokenEvents: string[] = [];
+      provider.on('token', ({ token }) => {
+        tokenEvents.push(token);
+      });
+
+      const chunks = [
+        {
+          choices: [
+            {
+              delta: { content: 'Token ' },
+            },
+          ],
+        },
+        {
+          choices: [
+            {
+              delta: { content: 'stream ' },
+            },
+          ],
+        },
+        {
+          choices: [
+            {
+              delta: { content: 'test' },
+              finish_reason: 'stop',
+            },
+          ],
+        },
+      ];
+
+      mockStream[Symbol.asyncIterator].mockReturnValue(
+        {
+          async *[Symbol.asyncIterator]() {
+            for (const chunk of chunks) {
+              yield chunk;
+            }
+          },
+        }[Symbol.asyncIterator]()
+      );
+
+      const messages = [{ role: 'user' as const, content: 'Stream tokens' }];
+      await provider.createStreamingResponse(messages, []);
+
+      expect(tokenEvents).toEqual(['Token ', 'stream ', 'test']);
+    });
+
+    it('should emit complete event when streaming finishes', async () => {
+      const completeEvents: any[] = [];
+      provider.on('complete', (data) => {
+        completeEvents.push(data);
+      });
+
+      const chunks = [
+        {
+          choices: [
+            {
+              delta: { content: 'Final content' },
+              finish_reason: 'stop',
+            },
+          ],
+        },
+      ];
+
+      mockStream[Symbol.asyncIterator].mockReturnValue(
+        {
+          async *[Symbol.asyncIterator]() {
+            for (const chunk of chunks) {
+              yield chunk;
+            }
+          },
+        }[Symbol.asyncIterator]()
+      );
+
+      const messages = [{ role: 'user' as const, content: 'Complete test' }];
+      await provider.createStreamingResponse(messages, []);
+
+      expect(completeEvents).toHaveLength(1);
+      expect(completeEvents[0].response.content).toBe('Final content');
+    });
+
+    it('should handle streaming errors', async () => {
+      const errorEvents: any[] = [];
+      provider.on('error', ({ error }) => {
+        errorEvents.push(error);
+      });
+
+      const streamError = new Error('Stream failed');
+      mockStream[Symbol.asyncIterator].mockReturnValue(
+        {
+          async *[Symbol.asyncIterator]() {
+            // Yield a valid chunk to satisfy ESLint, but immediately throw after
+            yield { choices: [{ delta: {} }] };
+            throw streamError;
+          },
+        }[Symbol.asyncIterator]()
+      );
+
+      const messages = [{ role: 'user' as const, content: 'Error test' }];
+
+      await expect(provider.createStreamingResponse(messages, [])).rejects.toThrow('Stream failed');
+
+      expect(errorEvents).toHaveLength(1);
+      expect(errorEvents[0].message).toBe('Stream failed');
+    });
+
+    it('should handle tool calls in streaming response', async () => {
+      const chunks = [
+        {
+          choices: [
+            {
+              delta: {
+                content: 'Using tool via stream',
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'stream_call_456',
+                    function: {
+                      name: 'test_tool',
+                      arguments: '{"action":',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    function: {
+                      arguments: '"stream_action"}',
+                    },
+                  },
+                ],
+              },
+              finish_reason: 'tool_calls',
+            },
+          ],
+        },
+      ];
+
+      mockStream[Symbol.asyncIterator].mockReturnValue(
+        {
+          async *[Symbol.asyncIterator]() {
+            for (const chunk of chunks) {
+              yield chunk;
+            }
+          },
+        }[Symbol.asyncIterator]()
+      );
+
+      const messages = [{ role: 'user' as const, content: 'Stream with tools' }];
+      const response = await provider.createStreamingResponse(messages, [mockTool]);
+
+      expect(response.content).toBe('Using tool via stream');
+      expect(response.toolCalls).toEqual([
+        {
+          id: 'stream_call_456',
+          name: 'test_tool',
+          input: { action: 'stream_action' },
+        },
+      ]);
+    });
+  });
+
+  describe('configuration handling', () => {
+    it('should use custom model when provided', async () => {
+      const customProvider = new OpenAIProvider({
+        apiKey: 'test-key',
+        model: 'gpt-4o',
+      });
+
+      mockCreate.mockResolvedValue({
+        choices: [
+          {
+            message: { content: 'Custom model response' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {},
+      });
+
+      await customProvider.createResponse([{ role: 'user', content: 'Test' }], []);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.model).toBe('gpt-4o');
+    });
+
+    it('should use custom max tokens when provided', async () => {
+      const customProvider = new OpenAIProvider({
+        apiKey: 'test-key',
+        maxTokens: 2000,
+      });
+
+      mockCreate.mockResolvedValue({
+        choices: [
+          {
+            message: { content: 'Custom tokens response' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {},
+      });
+
+      await customProvider.createResponse([{ role: 'user', content: 'Test' }], []);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.max_tokens).toBe(2000);
+    });
+
+    it('should use fallback system prompt when none provided', async () => {
+      const noSystemProvider = new OpenAIProvider({
+        apiKey: 'test-key',
+      });
+
+      mockCreate.mockResolvedValue({
+        choices: [
+          {
+            message: { content: 'Fallback response' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {},
+      });
+
+      await noSystemProvider.createResponse([{ role: 'user', content: 'Test' }], []);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.messages[0]).toEqual({
+        role: 'system',
+        content: 'You are a helpful assistant.',
+      });
+    });
+  });
+
+  describe('stop reason normalization', () => {
+    it('should normalize stop reasons correctly', async () => {
+      const testCases = [
+        { openai: 'length', expected: 'max_tokens' },
+        { openai: 'stop', expected: 'stop' },
+        { openai: 'tool_calls', expected: 'tool_use' },
+        { openai: 'content_filter', expected: 'stop' },
+        { openai: 'unknown_reason', expected: 'stop' },
+        { openai: null, expected: undefined },
+      ];
+
+      for (const { openai, expected } of testCases) {
+        mockCreate.mockResolvedValue({
+          choices: [
+            {
+              message: { content: 'Test' },
+              finish_reason: openai,
+            },
+          ],
+          usage: {},
+        });
+
+        const response = await provider.createResponse([{ role: 'user', content: 'Test' }], []);
+        expect(response.stopReason).toBe(expected);
+      }
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle non-streaming errors', async () => {
+      const providerError = new Error('API Error');
+      mockCreate.mockRejectedValue(providerError);
+
+      const messages = [{ role: 'user' as const, content: 'Error test' }];
+
+      await expect(provider.createResponse(messages, [])).rejects.toThrow('API Error');
+    });
+
+    it('should handle streaming setup errors', async () => {
+      const streamError = new Error('Stream setup failed');
+      mockCreate.mockImplementation(() => {
+        throw streamError;
+      });
+
+      const messages = [{ role: 'user' as const, content: 'Stream error test' }];
+
+      await expect(provider.createStreamingResponse(messages, [])).rejects.toThrow(
+        'Stream setup failed'
+      );
+    });
+  });
+});

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -3,6 +3,7 @@
 
 export * from './types.js';
 export * from './anthropic-provider.js';
+export * from './openai-provider.js';
 export * from './lmstudio-provider.js';
 export * from './ollama-provider.js';
 export * from './registry.js';

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -1,0 +1,306 @@
+// ABOUTME: OpenAI GPT provider implementation
+// ABOUTME: Wraps OpenAI SDK in the common provider interface
+
+import OpenAI from 'openai';
+import {
+  AIProvider,
+  ProviderMessage,
+  ProviderResponse,
+  ProviderConfig,
+  ProviderToolCall,
+} from './types.js';
+import { Tool } from '../tools/types.js';
+import { logger } from '../utils/logger.js';
+import { convertToOpenAIFormat } from './format-converters.js';
+
+export interface OpenAIProviderConfig extends ProviderConfig {
+  apiKey: string;
+}
+
+export class OpenAIProvider extends AIProvider {
+  private readonly _openai: OpenAI;
+
+  constructor(config: OpenAIProviderConfig) {
+    super(config);
+    this._openai = new OpenAI({ apiKey: config.apiKey });
+  }
+
+  get providerName(): string {
+    return 'openai';
+  }
+
+  get defaultModel(): string {
+    return 'gpt-4o-mini';
+  }
+
+  get supportsStreaming(): boolean {
+    return true;
+  }
+
+  async createResponse(messages: ProviderMessage[], tools: Tool[] = []): Promise<ProviderResponse> {
+    // Convert our enhanced generic messages to OpenAI format
+    const openaiMessages = convertToOpenAIFormat(
+      messages
+    ) as unknown as OpenAI.Chat.ChatCompletionMessageParam[];
+
+    // Extract system message if present
+    const systemMessage = messages.find((msg) => msg.role === 'system');
+    const systemPrompt =
+      systemMessage?.content || this._config.systemPrompt || 'You are a helpful assistant.';
+
+    // Add system message at the beginning if not already present
+    const messagesWithSystem = [
+      { role: 'system' as const, content: systemPrompt },
+      ...openaiMessages.filter((msg) => msg.role !== 'system'),
+    ];
+
+    // Convert tools to OpenAI format
+    const openaiTools: OpenAI.Chat.ChatCompletionTool[] = tools.map((tool) => ({
+      type: 'function' as const,
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.input_schema,
+      },
+    }));
+
+    const requestPayload: OpenAI.Chat.ChatCompletionCreateParams = {
+      model: this._config.model || this.defaultModel,
+      messages: messagesWithSystem,
+      max_tokens: this._config.maxTokens || 4000,
+      ...(tools.length > 0 && { tools: openaiTools }),
+    };
+
+    logger.debug('Sending request to OpenAI', {
+      provider: 'openai',
+      model: requestPayload.model,
+      messageCount: messagesWithSystem.length,
+      systemPromptLength: systemPrompt.length,
+      toolCount: openaiTools.length,
+      toolNames: openaiTools.map((t) => t.function.name),
+    });
+
+    // Log full request payload for debugging
+    logger.debug('OpenAI request payload', {
+      provider: 'openai',
+      payload: JSON.stringify(requestPayload, null, 2),
+    });
+
+    const response = (await this._openai.chat.completions.create(
+      requestPayload
+    )) as OpenAI.Chat.ChatCompletion;
+
+    // Log full response for debugging
+    logger.debug('OpenAI response payload', {
+      provider: 'openai',
+      response: JSON.stringify(response, null, 2),
+    });
+
+    const choice = response.choices[0];
+    if (!choice.message) {
+      throw new Error('No message in OpenAI response');
+    }
+
+    const textContent = choice.message.content || '';
+
+    const toolCalls: ProviderToolCall[] =
+      choice.message.tool_calls?.map((toolCall: OpenAI.Chat.ChatCompletionMessageToolCall) => ({
+        id: toolCall.id,
+        name: toolCall.function.name,
+        input: JSON.parse(toolCall.function.arguments) as Record<string, unknown>,
+      })) || [];
+
+    logger.debug('Received response from OpenAI', {
+      provider: 'openai',
+      contentLength: textContent.length,
+      toolCallCount: toolCalls.length,
+      toolCallNames: toolCalls.map((tc) => tc.name),
+      usage: response.usage,
+    });
+
+    return {
+      content: textContent,
+      toolCalls,
+      stopReason: this._normalizeStopReason(choice.finish_reason),
+      usage: response.usage
+        ? {
+            promptTokens: response.usage.prompt_tokens,
+            completionTokens: response.usage.completion_tokens,
+            totalTokens: response.usage.total_tokens,
+          }
+        : undefined,
+    };
+  }
+
+  async createStreamingResponse(
+    messages: ProviderMessage[],
+    tools: Tool[] = []
+  ): Promise<ProviderResponse> {
+    // Convert our enhanced generic messages to OpenAI format
+    const openaiMessages = convertToOpenAIFormat(
+      messages
+    ) as unknown as OpenAI.Chat.ChatCompletionMessageParam[];
+
+    // Extract system message if present
+    const systemMessage = messages.find((msg) => msg.role === 'system');
+    const systemPrompt =
+      systemMessage?.content || this._config.systemPrompt || 'You are a helpful assistant.';
+
+    // Add system message at the beginning if not already present
+    const messagesWithSystem = [
+      { role: 'system' as const, content: systemPrompt },
+      ...openaiMessages.filter((msg) => msg.role !== 'system'),
+    ];
+
+    // Convert tools to OpenAI format
+    const openaiTools: OpenAI.Chat.ChatCompletionTool[] = tools.map((tool) => ({
+      type: 'function' as const,
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.input_schema,
+      },
+    }));
+
+    const requestPayload: OpenAI.Chat.ChatCompletionCreateParams = {
+      model: this._config.model || this.defaultModel,
+      messages: messagesWithSystem,
+      max_tokens: this._config.maxTokens || 4000,
+      stream: true,
+      ...(tools.length > 0 && { tools: openaiTools }),
+    };
+
+    logger.debug('Sending streaming request to OpenAI', {
+      provider: 'openai',
+      model: requestPayload.model,
+      messageCount: messagesWithSystem.length,
+      systemPromptLength: systemPrompt.length,
+      toolCount: openaiTools.length,
+      toolNames: openaiTools.map((t) => t.function.name),
+    });
+
+    // Log full request payload for debugging
+    logger.debug('OpenAI streaming request payload', {
+      provider: 'openai',
+      payload: JSON.stringify(requestPayload, null, 2),
+    });
+
+    try {
+      // Use the streaming API
+      const stream = (await this._openai.chat.completions.create(
+        requestPayload
+      )) as AsyncIterable<OpenAI.Chat.ChatCompletionChunk>;
+
+      let content = '';
+      let toolCalls: ProviderToolCall[] = [];
+      let stopReason: string | undefined;
+      let usage: OpenAI.CompletionUsage | undefined;
+
+      // Accumulate tool calls during streaming
+      const partialToolCalls: Map<
+        number,
+        {
+          id: string;
+          name: string;
+          arguments: string;
+        }
+      > = new Map();
+
+      // Process stream chunks
+      for await (const chunk of stream) {
+        const delta = chunk.choices[0]?.delta;
+
+        if (delta?.content) {
+          content += delta.content;
+          // Emit token events for real-time display
+          this.emit('token', { token: delta.content });
+        }
+
+        // Handle tool calls
+        if (delta?.tool_calls) {
+          for (const toolCall of delta.tool_calls) {
+            const index = toolCall.index!;
+
+            if (!partialToolCalls.has(index)) {
+              partialToolCalls.set(index, {
+                id: toolCall.id!,
+                name: toolCall.function!.name!,
+                arguments: '',
+              });
+            }
+
+            const partial = partialToolCalls.get(index)!;
+            if (toolCall.function?.arguments) {
+              partial.arguments += toolCall.function.arguments;
+            }
+          }
+        }
+
+        // Get finish reason from the last chunk
+        if (chunk.choices[0]?.finish_reason) {
+          stopReason = chunk.choices[0].finish_reason;
+        }
+
+        // Some providers include usage in streaming responses
+        if (chunk.usage) {
+          usage = chunk.usage;
+        }
+      }
+
+      // Convert partial tool calls to final format
+      toolCalls = Array.from(partialToolCalls.values()).map((partial) => ({
+        id: partial.id,
+        name: partial.name,
+        input: JSON.parse(partial.arguments) as Record<string, unknown>,
+      }));
+
+      logger.debug('Received streaming response from OpenAI', {
+        provider: 'openai',
+        contentLength: content.length,
+        toolCallCount: toolCalls.length,
+        toolCallNames: toolCalls.map((tc) => tc.name),
+        usage,
+      });
+
+      const response = {
+        content,
+        toolCalls,
+        stopReason: this._normalizeStopReason(stopReason),
+        usage: usage
+          ? {
+              promptTokens: usage.prompt_tokens,
+              completionTokens: usage.completion_tokens,
+              totalTokens: usage.total_tokens,
+            }
+          : undefined,
+      };
+
+      // Emit completion event
+      this.emit('complete', { response });
+
+      return response;
+    } catch (error) {
+      const errorObj = error as Error;
+      logger.error('Streaming error from OpenAI', { error: errorObj.message });
+      this.emit('error', { error: errorObj });
+      throw error;
+    }
+  }
+
+  private _normalizeStopReason(stopReason: string | null | undefined): string | undefined {
+    if (!stopReason) return undefined;
+
+    switch (stopReason) {
+      case 'length':
+        return 'max_tokens';
+      case 'stop':
+        return 'stop';
+      case 'tool_calls':
+        return 'tool_use';
+      case 'content_filter':
+        return 'stop';
+      default:
+        return 'stop';
+    }
+  }
+}

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -1,7 +1,7 @@
 // ABOUTME: OpenAI GPT provider implementation
 // ABOUTME: Wraps OpenAI SDK in the common provider interface
 
-import OpenAI from 'openai';
+import OpenAI, { ClientOptions } from 'openai';
 import {
   AIProvider,
   ProviderMessage,
@@ -22,7 +22,19 @@ export class OpenAIProvider extends AIProvider {
 
   constructor(config: OpenAIProviderConfig) {
     super(config);
-    this._openai = new OpenAI({ apiKey: config.apiKey });
+
+    const openaiConfig: ClientOptions = {
+      apiKey: config.apiKey,
+    };
+
+    // Support custom base URL for OpenAI-compatible APIs
+    const baseURL = process.env.OPENAI_BASE_URL;
+    if (baseURL) {
+      openaiConfig.baseURL = baseURL;
+      logger.info('Using custom OpenAI base URL', { baseURL });
+    }
+
+    this._openai = new OpenAI(openaiConfig);
   }
 
   get providerName(): string {


### PR DESCRIPTION
  Add OpenAI Provider Support

  Summary

  - Implemented OpenAI provider with full support for GPT models (GPT-4, GPT-4o, etc.)
  - Added OPENAI_BASE_URL environment variable for custom endpoints
  - Includes both streaming and non-streaming response handling

  Changes

  - New OpenAI Provider: Complete implementation wrapping the OpenAI SDK with our common provider interface
  - Custom Base URL Support: OPENAI_BASE_URL environment variable enables using OpenAI-compatible APIs (Azure OpenAI, local servers, etc.)
  - Comprehensive Tests: Full test coverage for all provider functionality
  - CLI Integration: Added --provider openai option with proper argument parsing

  Usage

  # Standard OpenAI
  export OPENAI_API_KEY="your-key"
  npm start -- --provider openai

  # Custom endpoint (e.g., Azure OpenAI)
  export OPENAI_API_KEY="your-key"
  export OPENAI_BASE_URL="https://your-instance.openai.azure.com/v1"
  npm start -- --provider openai --model gpt-4

  Test plan

  - Unit tests passing for OpenAI provider
  - E2E tests updated to include OpenAI
  - Manual testing with OpenAI API
  - Manual testing with custom base URL (Azure OpenAI or compatible endpoint)