### PR TITLE
fix: remove duplicate tool approval modal overlay

### DIFF
--- a/src/interfaces/terminal/terminal-interface.tsx
+++ b/src/interfaces/terminal/terminal-interface.tsx
@@ -721,16 +721,6 @@ export const TerminalInterfaceComponent: React.FC<TerminalInterfaceProps> = ({
             </TimelineExpansionProvider>
           </Box>
 
-          {/* Tool approval modal */}
-          {approvalRequest && (
-            <ToolApprovalModal
-              toolName={approvalRequest.toolName}
-              input={approvalRequest.input}
-              isReadOnly={approvalRequest.isReadOnly}
-              onDecision={handleApprovalDecision}
-              isVisible={true}
-            />
-          )}
 
           {/* Bottom section - debug panel, status bar, input anchored to bottom */}
           <Box flexDirection="column" flexShrink={0} ref={bottomSectionRef}>


### PR DESCRIPTION
## Summary
- Remove accidentally reintroduced overlay tool approval modal
- Fixes duplicate approval prompts and UI corruption in terminal interface
- Restore intended behavior: modal only appears as input area replacement

## Root Cause Analysis  
- Commit 1c852a7 correctly moved modal from overlay to input replacement
- Commit ec8a758 accidentally reintroduced overlay during "linting fixes"
- Both modals used same focus region causing keyboard input conflicts

## Test Plan
- [x] Verify tool approval modal appears only once when tool execution requires approval
- [x] Confirm modal replaces input area (not overlay)
- [x] Check keyboard shortcuts work without duplication
- [x] Ensure all debug panel features remain functional

🤖 Generated with [Claude Code](https://claude.ai/code)