### PR TITLE
Support .env.local with proper priority order

### DIFF
--- a/src/config/env-loader.ts
+++ b/src/config/env-loader.ts
@@ -6,7 +6,7 @@ import { logger } from '~/utils/logger.js';
 function loadAndLogEnvFile(path: string, description: string): void {
   const result = dotenv.config({ path });
   if (result.error) {
-    if (result.error.code === 'ENOENT') {
+    if ('code' in result.error && result.error.code === 'ENOENT') {
       logger.debug(`No ${description} file found`);
     } else {
       logger.debug(`${description} failed to parse`, { error: result.error.message });

--- a/src/config/env-loader.ts
+++ b/src/config/env-loader.ts
@@ -1,26 +1,27 @@
 // ABOUTME: Loads environment variables from .env files using dotenv
 
 import dotenv from 'dotenv';
-import path from 'path';
-import fs from 'fs';
 import { logger } from '~/utils/logger.js';
 
 export function loadEnvFile(): void {
-  const envPath = path.resolve(process.cwd(), '.env');
+  // Load .env.local first (highest priority - won't be overridden)
+  const localResult = dotenv.config({ path: '.env.local' });
+  if (localResult.error) {
+    logger.debug('No .env.local file found or failed to parse', { error: localResult.error.message });
+  } else if (localResult.parsed) {
+    logger.debug('.env.local loaded successfully', {
+      variableCount: Object.keys(localResult.parsed).length,
+    });
+  }
 
-  if (fs.existsSync(envPath)) {
-    const result = dotenv.config({ path: envPath });
-
-    if (result.error) {
-      logger.warn('Failed to parse .env file', { error: result.error.message });
-    } else {
-      logger.debug('.env file loaded successfully', {
-        path: envPath,
-        variableCount: Object.keys(result.parsed || {}).length,
-      });
-    }
-  } else {
-    logger.debug('No .env file found', { searchPath: envPath });
+  // Load .env second (lower priority - won't override existing variables)
+  const result = dotenv.config({ path: '.env' });
+  if (result.error) {
+    logger.debug('No .env file found or failed to parse', { error: result.error.message });
+  } else if (result.parsed) {
+    logger.debug('.env loaded successfully', {
+      variableCount: Object.keys(result.parsed).length,
+    });
   }
 }
 

--- a/src/config/env-loader.ts
+++ b/src/config/env-loader.ts
@@ -3,26 +3,27 @@
 import dotenv from 'dotenv';
 import { logger } from '~/utils/logger.js';
 
-export function loadEnvFile(): void {
-  // Load .env.local first (highest priority - won't be overridden)
-  const localResult = dotenv.config({ path: '.env.local' });
-  if (localResult.error) {
-    logger.debug('No .env.local file found or failed to parse', { error: localResult.error.message });
-  } else if (localResult.parsed) {
-    logger.debug('.env.local loaded successfully', {
-      variableCount: Object.keys(localResult.parsed).length,
-    });
-  }
-
-  // Load .env second (lower priority - won't override existing variables)
-  const result = dotenv.config({ path: '.env' });
+function loadAndLogEnvFile(path: string, description: string): void {
+  const result = dotenv.config({ path });
   if (result.error) {
-    logger.debug('No .env file found or failed to parse', { error: result.error.message });
+    if (result.error.code === 'ENOENT') {
+      logger.debug(`No ${description} file found`);
+    } else {
+      logger.debug(`${description} failed to parse`, { error: result.error.message });
+    }
   } else if (result.parsed) {
-    logger.debug('.env loaded successfully', {
+    logger.debug(`${description} loaded successfully`, {
       variableCount: Object.keys(result.parsed).length,
     });
   }
+}
+
+export function loadEnvFile(): void {
+  // Load .env.local first (highest priority - won't be overridden)
+  loadAndLogEnvFile('.env.local', '.env.local');
+
+  // Load .env second (lower priority - won't override existing variables)
+  loadAndLogEnvFile('.env', '.env');
 }
 
 export function getEnvVar(key: string, defaultValue?: string): string | undefined {


### PR DESCRIPTION
## Summary
- Add support for `.env.local` files with proper priority handling
- Load `.env.local` first (highest priority) then `.env` (lower priority)
- Simplify implementation using standard dotenv multiple calls pattern
- Remove manual file existence checks and path resolution

## Test plan
- [ ] Verify `.env.local` variables override `.env` variables
- [ ] Confirm graceful handling when files are missing
- [ ] Check debug logging shows correct load order and counts

🤖 Generated with [Claude Code](https://claude.ai/code)