### PR TITLE
Update OpenAI and Anthropic providers with 2025 model listings

### DIFF
--- a/src/providers/__tests__/openai-provider.test.ts
+++ b/src/providers/__tests__/openai-provider.test.ts
@@ -71,7 +71,7 @@ describe('OpenAIProvider', () => {
     });
 
     it('should have correct default model', () => {
-      expect(provider.defaultModel).toBe('gpt-4o-mini');
+      expect(provider.defaultModel).toBe('gpt-4o');
     });
 
     it('should support streaming', () => {
@@ -114,7 +114,7 @@ describe('OpenAIProvider', () => {
         messages: Array<{ role: string; content: string }>;
         tools?: Array<{ type: string; function: { name: string } }>;
       };
-      expect(callArgs.model).toBe('gpt-4o-mini');
+      expect(callArgs.model).toBe('gpt-4o');
       expect(callArgs.max_tokens).toBe(4000);
       expect(callArgs.messages[0]).toEqual({ role: 'system', content: 'Test system prompt' });
       expect(callArgs.messages[1]).toEqual({ role: 'user', content: 'Hello' });

--- a/src/providers/anthropic-provider.ts
+++ b/src/providers/anthropic-provider.ts
@@ -87,13 +87,18 @@ export class AnthropicProvider extends AIProvider {
   get maxCompletionTokens(): number {
     const model = this.modelName.toLowerCase();
 
-    // Claude 3.5 and Claude 4 models support 8192 output tokens
+    // Claude 4 and Claude 3.7 models support 8192 output tokens
     if (
-      model.includes('claude-3-5') ||
       model.includes('claude-4') ||
       model.includes('claude-sonnet-4') ||
-      model.includes('claude-opus-4')
+      model.includes('claude-opus-4') ||
+      model.includes('claude-3-7')
     ) {
+      return 8192;
+    }
+
+    // Claude 3.5 models support 8192 output tokens
+    if (model.includes('claude-3-5')) {
       return 8192;
     }
 
@@ -394,23 +399,51 @@ export class AnthropicProvider extends AIProvider {
 
   getAvailableModels(): ModelInfo[] {
     return [
+      // Claude 4 Series (Latest - May 2025)
+      {
+        id: 'claude-sonnet-4-20250514',
+        displayName: 'Claude Sonnet 4',
+        description: 'Latest Sonnet model with hybrid reasoning capabilities',
+        contextWindow: 200000,
+        maxOutputTokens: 8192,
+        capabilities: ['vision', 'function-calling', 'reasoning'],
+        isDefault: true,
+      },
+      {
+        id: 'claude-opus-4-20250514',
+        displayName: 'Claude Opus 4',
+        description: 'World\'s best coding model with sustained performance',
+        contextWindow: 200000,
+        maxOutputTokens: 8192,
+        capabilities: ['vision', 'function-calling', 'coding', 'reasoning'],
+      },
+      // Claude 3.7 Series (February 2025)
+      {
+        id: 'claude-3-7-sonnet-20250224',
+        displayName: 'Claude 3.7 Sonnet',
+        description: 'Pioneering hybrid AI reasoning model',
+        contextWindow: 200000,
+        maxOutputTokens: 8192,
+        capabilities: ['vision', 'function-calling', 'reasoning'],
+      },
+      // Claude 3.5 Series (Current Generation)
       {
         id: 'claude-3-5-sonnet-20241022',
         displayName: 'Claude 3.5 Sonnet',
-        description: 'Most intelligent model, best for complex tasks',
+        description: 'High-performance model with enhanced capabilities',
         contextWindow: 200000,
         maxOutputTokens: 8192,
         capabilities: ['vision', 'function-calling'],
-        isDefault: true,
       },
       {
         id: 'claude-3-5-haiku-20241022',
         displayName: 'Claude 3.5 Haiku',
-        description: 'Fast and efficient for simple tasks',
+        description: 'Fast model matching Claude 3 Opus performance',
         contextWindow: 200000,
         maxOutputTokens: 8192,
         capabilities: ['function-calling'],
       },
+      // Claude 3 Series (Legacy)
       {
         id: 'claude-3-opus-20240229',
         displayName: 'Claude 3 Opus',

--- a/src/providers/anthropic-provider.ts
+++ b/src/providers/anthropic-provider.ts
@@ -412,7 +412,7 @@ export class AnthropicProvider extends AIProvider {
       {
         id: 'claude-opus-4-20250514',
         displayName: 'Claude Opus 4',
-        description: 'World\'s best coding model with sustained performance',
+        description: "World's best coding model with sustained performance",
         contextWindow: 200000,
         maxOutputTokens: 8192,
         capabilities: ['vision', 'function-calling', 'coding', 'reasoning'],

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -46,7 +46,7 @@ export class OpenAIProvider extends AIProvider {
   }
 
   get defaultModel(): string {
-    return 'gpt-4o-mini';
+    return 'gpt-4o';
   }
 
   get supportsStreaming(): boolean {
@@ -56,12 +56,23 @@ export class OpenAIProvider extends AIProvider {
   get contextWindow(): number {
     const model = this.modelName.toLowerCase();
 
+    // GPT-4.1 series with 1M token context
+    if (model.includes('gpt-4.1')) {
+      return 1000000;
+    }
+
     // GPT-4o and GPT-4-turbo models
     if (model.includes('gpt-4o') || model.includes('gpt-4-turbo')) {
       return 128000;
     }
 
-    // O1 models
+    // O-series models
+    if (model === 'o3' || model === 'o3-pro') {
+      return 200000;
+    }
+    if (model === 'o4-mini' || model.includes('o4-mini')) {
+      return 128000;
+    }
     if (model === 'o1' || model === 'o1-preview') {
       return 200000;
     }
@@ -89,7 +100,13 @@ export class OpenAIProvider extends AIProvider {
   get maxCompletionTokens(): number {
     const model = this.modelName.toLowerCase();
 
-    // O1 models have larger output limits
+    // O-series models have larger output limits
+    if (model === 'o3' || model === 'o3-pro') {
+      return 100000;
+    }
+    if (model === 'o4-mini' || model.includes('o4-mini')) {
+      return 65536;
+    }
     if (model === 'o1' || model === 'o1-preview') {
       return 100000;
     }
@@ -413,14 +430,80 @@ export class OpenAIProvider extends AIProvider {
 
   getAvailableModels(): ModelInfo[] {
     return [
+      // O-Series Reasoning Models (2025)
+      {
+        id: 'o3',
+        displayName: 'OpenAI o3',
+        description: 'Most capable reasoning model for complex tasks',
+        contextWindow: 200000,
+        maxOutputTokens: 100000,
+        capabilities: ['reasoning', 'math', 'coding'],
+      },
+      {
+        id: 'o3-pro',
+        displayName: 'OpenAI o3 Pro',
+        description: 'Enhanced o3 with superior performance',
+        contextWindow: 200000,
+        maxOutputTokens: 100000,
+        capabilities: ['reasoning', 'math', 'coding'],
+      },
+      {
+        id: 'o4-mini',
+        displayName: 'OpenAI o4 Mini',
+        description: 'Efficient reasoning model optimized for speed and cost',
+        contextWindow: 128000,
+        maxOutputTokens: 65536,
+        capabilities: ['reasoning', 'math', 'coding', 'vision'],
+      },
+      {
+        id: 'o4-mini-high',
+        displayName: 'OpenAI o4 Mini High',
+        description: 'Premium o4-mini with enhanced accuracy and speed (paid users)',
+        contextWindow: 128000,
+        maxOutputTokens: 65536,
+        capabilities: ['reasoning', 'math', 'coding', 'vision'],
+      },
+      // GPT Models (2025)
       {
         id: 'gpt-4o',
         displayName: 'GPT-4o',
-        description: 'Most capable GPT-4 model with vision',
+        description: 'Default flagship model for chat and complex tasks',
         contextWindow: 128000,
         maxOutputTokens: 16384,
         capabilities: ['vision', 'function-calling'],
         isDefault: true,
+      },
+      {
+        id: 'gpt-4.5',
+        displayName: 'GPT-4.5',
+        description: 'Largest and best model for chat (Pro users)',
+        contextWindow: 128000,
+        maxOutputTokens: 16384,
+        capabilities: ['vision', 'function-calling'],
+      },
+      {
+        id: 'gpt-4.1',
+        displayName: 'GPT-4.1',
+        description: 'Flagship multimodal model with 1M token context and coding improvements',
+        contextWindow: 1000000,
+        maxOutputTokens: 16384,
+        capabilities: ['vision', 'function-calling', 'coding'],
+      },
+      {
+        id: 'gpt-4.1-mini',
+        displayName: 'GPT-4.1 Mini',
+        description: 'High performance small model with 1M token context, beats GPT-4o',
+        contextWindow: 1000000,
+        maxOutputTokens: 16384,
+        capabilities: ['vision', 'function-calling'],
+      },
+      {
+        id: 'gpt-4.1-nano',
+        displayName: 'GPT-4.1 Nano',
+        description: 'Fastest and cheapest model with 1M token context',
+        contextWindow: 1000000,
+        maxOutputTokens: 4096,
+        capabilities: ['function-calling'],
       },
       {
         id: 'gpt-4o-mini',
@@ -430,6 +513,7 @@ export class OpenAIProvider extends AIProvider {
         maxOutputTokens: 16384,
         capabilities: ['vision', 'function-calling'],
       },
+      // Legacy Models (still available)
       {
         id: 'gpt-4-turbo',
         displayName: 'GPT-4 Turbo',
@@ -453,6 +537,23 @@ export class OpenAIProvider extends AIProvider {
         contextWindow: 16384,
         maxOutputTokens: 4096,
         capabilities: ['function-calling'],
+      },
+      // Legacy O1 models
+      {
+        id: 'o1',
+        displayName: 'OpenAI o1',
+        description: 'Previous generation reasoning model',
+        contextWindow: 200000,
+        maxOutputTokens: 100000,
+        capabilities: ['reasoning', 'math', 'coding'],
+      },
+      {
+        id: 'o1-mini',
+        displayName: 'OpenAI o1 Mini',
+        description: 'Smaller reasoning model',
+        contextWindow: 128000,
+        maxOutputTokens: 65536,
+        capabilities: ['reasoning', 'math', 'coding'],
       },
     ];
   }


### PR DESCRIPTION
## Summary
- Updated OpenAI provider with latest 2025 models including o3, o3-pro, o4-mini series, and GPT-4.1 family
- Updated Anthropic provider with Claude 4 series and Claude 3.7 models
- Added support for GPT-4.1's 1 million token context window

## Changes Made
### OpenAI Provider
- Added O-series reasoning models: o3, o3-pro, o4-mini, o4-mini-high
- Added GPT-4.1 series with 1M token context: gpt-4.1, gpt-4.1-mini, gpt-4.1-nano
- Added GPT-4.5 model for Pro users
- Updated context window logic to handle 1M token capability
- Changed default model from gpt-4o-mini to gpt-4o
- Added new capabilities: reasoning, math, coding

### Anthropic Provider
- Added Claude 4 series: claude-sonnet-4-20250514, claude-opus-4-20250514
- Added Claude 3.7 series: claude-3-7-sonnet-20250224
- Updated model descriptions and capabilities
- Added reasoning and coding capabilities for newer models

### Test Updates
- Updated test expectations to reflect new default model (gpt-4o)
- All provider tests pass successfully

## Test plan
- [x] OpenAI provider tests pass
- [x] Anthropic provider tests pass
- [x] TypeScript compilation succeeds
- [x] Context window logic correctly handles new models

🤖 Generated with [Claude Code](https://claude.ai/code)