### PR TITLE
Fix web server auto-reload and add port fallback

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -7,12 +7,12 @@
     "node": ">=20.18.3"
   },
   "scripts": {
-    "dev": "tsx watch server.ts",
+    "dev": "tsx server.ts",
     "build": "next build",
     "start": "NODE_ENV=production tsx server.ts",
     "lint": "next lint",
-    "dev:debug": "LACE_LOG_LEVEL=debug LACE_LOG_STDERR=true tsx watch server.ts",
-    "dev:debug-file": "LACE_LOG_LEVEL=debug LACE_LOG_FILE=/tmp/lace-web.log tsx watch server.ts",
+    "dev:debug": "LACE_LOG_LEVEL=debug LACE_LOG_STDERR=true tsx server.ts",
+    "dev:debug-file": "LACE_LOG_LEVEL=debug LACE_LOG_FILE=/tmp/lace-web.log tsx server.ts",
     "lint:fix": "next lint --fix",
     "format": "prettier --write",
     "test": "vitest",


### PR DESCRIPTION
## Summary
- Prevents web server from auto-reloading when user hits Enter in shell
- Adds intelligent port fallback behavior for better development experience
- Fixes deprecated url.parse() security warning

## Changes Made
- **Auto-reload fix**: Removed `tsx watch` from development scripts to prevent restart on Enter key
- **Port fallback**: Try up to 100 ports starting from default (3000) if unavailable
- **Manual port handling**: Only try specified port when user provides `--port` flag, fail fast if unavailable
- **Security fix**: Replaced deprecated `url.parse()` with Next.js built-in request handling
- **Code cleanup**: Simplified server request handling

## Test Plan
- [x] Server starts without auto-reload on Enter key press
- [x] Port fallback works when default port 3000 is unavailable
- [x] Manual port specification (`--port 8080`) only tries that specific port
- [x] No deprecation warnings from url.parse()
- [x] All existing functionality preserved (help, host binding, graceful shutdown)

🤖 Generated with [Claude Code](https://claude.ai/code)