### PR TITLE
Add file_edit tool renderer with diff visualization

### DIFF
--- a/packages/web/components/timeline/tool/file-edit.test.ts
+++ b/packages/web/components/timeline/tool/file-edit.test.ts
@@ -1,0 +1,163 @@
+// ABOUTME: Tests for the file-edit tool renderer with diff visualization
+// ABOUTME: Verifies proper rendering of file edits with context and diffs
+
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { fileEditRenderer } from './file-edit';
+import type { ToolResult } from './types';
+
+describe('fileEditRenderer', () => {
+  describe('getSummary', () => {
+    it('should return path-specific summary when path is provided', () => {
+      const summary = fileEditRenderer.getSummary({ path: '/src/app.ts' });
+      expect(summary).toBe('Edit /src/app.ts');
+    });
+
+    it('should return generic summary when no path', () => {
+      const summary = fileEditRenderer.getSummary({});
+      expect(summary).toBe('Edit file');
+    });
+
+    it('should handle invalid arguments gracefully', () => {
+      expect(fileEditRenderer.getSummary(null)).toBe('Edit file');
+      expect(fileEditRenderer.getSummary(undefined)).toBe('Edit file');
+      expect(fileEditRenderer.getSummary('string')).toBe('Edit file');
+    });
+  });
+
+  describe('isError', () => {
+    it('should return true for error results', () => {
+      const result: ToolResult = {
+        content: [{ type: 'text', text: 'Error message' }],
+        isError: true,
+      };
+      expect(fileEditRenderer.isError!(result)).toBe(true);
+    });
+
+    it('should return false for success results', () => {
+      const result: ToolResult = {
+        content: [{ type: 'text', text: 'Success' }],
+        isError: false,
+      };
+      expect(fileEditRenderer.isError!(result)).toBe(false);
+    });
+  });
+
+  describe('renderResult', () => {
+    it('should render error state properly', () => {
+      const result: ToolResult = {
+        content: [{ type: 'text', text: 'File not found' }],
+        isError: true,
+      };
+
+      const rendered = fileEditRenderer.renderResult!(result);
+      const { container } = render(React.createElement('div', null, rendered));
+
+      expect(container.textContent).toContain('Edit Failed');
+      expect(container.textContent).toContain('File not found');
+      expect(container.querySelector('.text-error')).toBeTruthy();
+    });
+
+    it('should render diff when enhanced metadata is available', () => {
+      const result: ToolResult = {
+        content: [{ type: 'text', text: 'Successfully replaced text' }],
+        isError: false,
+        metadata: {
+          diff: {
+            beforeContext: 'line 1\nline 2',
+            afterContext: 'line 5\nline 6',
+            oldContent: 'line 1\nline 2\nold line 3\nold line 4\nline 5\nline 6',
+            newContent: 'line 1\nline 2\nnew line 3\nnew line 4\nline 5\nline 6',
+            startLine: 1,
+          },
+          path: '/test/file.ts',
+          oldText: 'old line 3\nold line 4',
+          newText: 'new line 3\nnew line 4',
+        },
+      };
+
+      const rendered = fileEditRenderer.renderResult!(result);
+      const { container } = render(React.createElement('div', null, rendered));
+
+      // Should render FileDiffViewer component
+      expect(container.querySelector('.border-base-300')).toBeTruthy();
+    });
+
+    it('should show fallback diff when only arguments are available', () => {
+      const result: ToolResult = {
+        content: [{ type: 'text', text: 'Successfully replaced text' }],
+        isError: false,
+      };
+
+      const metadata = {
+        arguments: {
+          path: '/test/file.js',
+          old_text: 'const x = 1;',
+          new_text: 'const x = 2;',
+        },
+      };
+
+      const rendered = fileEditRenderer.renderResult!(result, metadata as any);
+      const { container } = render(React.createElement('div', null, rendered));
+
+      // Should show warning about no context
+      expect(container.textContent).toContain('without context');
+    });
+
+    it('should show simple success when no diff data available', () => {
+      const result: ToolResult = {
+        content: [{ type: 'text', text: 'File edited successfully' }],
+        isError: false,
+      };
+
+      const rendered = fileEditRenderer.renderResult!(result);
+      const { container } = render(React.createElement('div', null, rendered));
+
+      expect(container.textContent).toContain('File edited successfully');
+      expect(container.querySelector('.text-success')).toBeTruthy();
+    });
+
+    it('should handle empty content gracefully', () => {
+      const result: ToolResult = {
+        content: [],
+        isError: false,
+      };
+
+      const rendered = fileEditRenderer.renderResult!(result);
+      const { container } = render(React.createElement('div', null, rendered));
+
+      expect(container.textContent).toContain('No output');
+    });
+
+    it('should correctly adjust line numbers when startLine > 1', () => {
+      const result: ToolResult = {
+        content: [{ type: 'text', text: 'Success' }],
+        isError: false,
+        metadata: {
+          diff: {
+            beforeContext: 'line 10',
+            afterContext: 'line 14',
+            oldContent: 'line 10\nold line\nline 14',
+            newContent: 'line 10\nnew line\nline 14',
+            startLine: 10,
+          },
+          path: '/test.py',
+        },
+      };
+
+      const rendered = fileEditRenderer.renderResult!(result);
+      expect(rendered).toBeTruthy();
+      // The FileDiffViewer should receive adjusted line numbers
+      // This would be better tested with actual FileDiffViewer rendering
+    });
+  });
+
+  describe('getIcon', () => {
+    it('should return the file edit icon', () => {
+      const icon = fileEditRenderer.getIcon!();
+      expect(icon).toBeDefined();
+      expect(icon.iconName).toBe('file-edit');
+    });
+  });
+});

--- a/packages/web/components/timeline/tool/file-edit.tsx
+++ b/packages/web/components/timeline/tool/file-edit.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+// ABOUTME: File edit tool renderer with diff visualization
+// ABOUTME: Displays file modifications using the FileDiffViewer component for clear before/after comparison
+
+import React from 'react';
+import { faFileEdit, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import FileDiffViewer from '@/components/files/FileDiffViewer';
+import { createFileDiffFromText, detectLanguageFromPath } from '@/components/files/FileDiffViewer.utils';
+import type { ToolRenderer, ToolResult } from './types';
+import type { ToolAggregatedEventData } from '@/types/web-events';
+import type { FileEditDiffContext } from '@/types/core';
+
+/**
+ * File edit-specific tool renderer providing diff visualization
+ * for file modification operations
+ */
+export const fileEditRenderer: ToolRenderer = {
+  getSummary: (args: unknown): string => {
+    if (typeof args === 'object' && args !== null && 'path' in args) {
+      const path = (args as { path?: unknown }).path;
+      if (typeof path === 'string' && path.trim()) {
+        return `Edit ${path}`;
+      }
+    }
+    return 'Edit file';
+  },
+
+  isError: (result: ToolResult): boolean => {
+    // Trust the tool's own error flag
+    return result.isError;
+  },
+
+  renderResult: (result: ToolResult, metadata?: ToolAggregatedEventData): React.ReactNode => {
+    if (!result.content || result.content.length === 0) {
+      return (
+        <div className="font-mono text-sm text-base-content/60">
+          <em>No output</em>
+        </div>
+      );
+    }
+
+    const content = result.content
+      .map(block => block.text || '')
+      .join('');
+
+    const isError = fileEditRenderer.isError!(result);
+
+    if (isError) {
+      return (
+        <div className="bg-error/5 border border-error/20 rounded-lg">
+          <div className="px-3 py-2 border-b border-error/20 bg-error/10">
+            <div className="flex items-center gap-2">
+              <FontAwesomeIcon icon={faExclamationTriangle} className="w-4 h-4 text-error flex-shrink-0" />
+              <span className="text-error font-medium text-sm">Edit Failed</span>
+            </div>
+          </div>
+          <div className="p-3">
+            <div className="text-error/80 text-sm font-mono whitespace-pre-wrap break-words">
+              {content}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // Check if we have the enhanced metadata from the tool
+    const resultMetadata = result.metadata as {
+      diff?: FileEditDiffContext;
+      path?: string;
+      oldText?: string;
+      newText?: string;
+    } | undefined;
+
+    // If we have the enhanced diff context, use it
+    if (resultMetadata?.diff) {
+      const { diff, path } = resultMetadata;
+      const language = path ? detectLanguageFromPath(path) : undefined;
+      
+      // Create a FileDiff with the context-aware content
+      const fileDiff = createFileDiffFromText(
+        diff.oldContent,
+        diff.newContent,
+        path || 'file',
+        language
+      );
+      
+      // Adjust line numbers based on the start line from context
+      if (diff.startLine > 1 && fileDiff.chunks[0]) {
+        const chunk = fileDiff.chunks[0];
+        chunk.oldStart = diff.startLine;
+        chunk.newStart = diff.startLine;
+        
+        // Update line numbers for all lines
+        let oldLineNum = diff.startLine;
+        let newLineNum = diff.startLine;
+        
+        chunk.lines.forEach(line => {
+          if (line.type === 'removed') {
+            line.oldLineNumber = oldLineNum++;
+          } else if (line.type === 'added') {
+            line.newLineNumber = newLineNum++;
+          } else {
+            line.oldLineNumber = oldLineNum++;
+            line.newLineNumber = newLineNum++;
+          }
+        });
+      }
+      
+      return (
+        <div className="bg-base-100/50">
+          <FileDiffViewer
+            diff={fileDiff}
+            viewMode="unified"
+            showLineNumbers={true}
+            showFullFile={false}
+            maxLines={20}
+            className="shadow-sm"
+          />
+        </div>
+      );
+    }
+
+    // Fallback: Try to use arguments if no enhanced metadata
+    const args = metadata?.arguments as { 
+      path?: string; 
+      old_text?: string; 
+      new_text?: string;
+    } | undefined;
+    
+    const filePath = args?.path;
+    const oldText = args?.old_text || '';
+    const newText = args?.new_text || '';
+    
+    // Only show diff if we have both old and new text
+    if (filePath && (oldText || newText)) {
+      const language = detectLanguageFromPath(filePath);
+      const diff = createFileDiffFromText(oldText, newText, filePath, language);
+      
+      return (
+        <div className="bg-base-100/50">
+          <div className="text-xs text-base-content/60 px-3 py-1 bg-warning/10 border-b border-warning/20">
+            <FontAwesomeIcon icon={faExclamationTriangle} className="w-3 h-3 mr-1" />
+            Showing diff without context (upgrade file_edit tool for better diffs)
+          </div>
+          <FileDiffViewer
+            diff={diff}
+            viewMode="unified"
+            showLineNumbers={true}
+            showFullFile={false}
+            maxLines={20}
+            className="shadow-sm"
+          />
+        </div>
+      );
+    }
+    
+    // Final fallback: Simple success message
+    return (
+      <div className="bg-success/5 border border-success/20 rounded-lg">
+        <div className="px-3 py-2">
+          <div className="flex items-center gap-2">
+            <FontAwesomeIcon icon={faFileEdit} className="w-4 h-4 text-success flex-shrink-0" />
+            <span className="text-success font-medium text-sm">{content}</span>
+          </div>
+        </div>
+      </div>
+    );
+  },
+
+  getIcon: () => {
+    return faFileEdit;
+  },
+};

--- a/packages/web/components/timeline/tool/index.ts
+++ b/packages/web/components/timeline/tool/index.ts
@@ -7,6 +7,7 @@ import { taskRenderers } from './task';
 import { delegateRenderer } from './delegate';
 import { fileWriteRenderer } from './file-write';
 import { fileReadRenderer } from './file-read';
+import { fileEditRenderer } from './file-edit';
 
 // Registry of tool renderers - add new tools here
 const toolRenderers: Record<string, ToolRenderer> = {
@@ -28,6 +29,7 @@ const toolRenderers: Record<string, ToolRenderer> = {
   // File operation tools
   file_write: fileWriteRenderer,
   file_read: fileReadRenderer,
+  file_edit: fileEditRenderer,
 };
 
 /**

--- a/packages/web/types/core.ts
+++ b/packages/web/types/core.ts
@@ -6,6 +6,8 @@ export type { ThreadId, AssigneeId, ThreadEventType, ThreadEvent, Thread } from 
 
 export type { ToolCall, ToolResult, ToolContext, ToolAnnotations } from '~/tools/types';
 
+export type { FileEditDiffContext } from '~/tools/implementations/file-edit';
+
 export type {
   Task,
   TaskNote,

--- a/src/tools/file-edit-context.test.ts
+++ b/src/tools/file-edit-context.test.ts
@@ -1,0 +1,159 @@
+// ABOUTME: Tests for the enhanced file_edit tool with context extraction
+// ABOUTME: Verifies that diff context is properly extracted and included in metadata
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { FileEditTool } from '~/tools/implementations/file-edit';
+import type { FileEditDiffContext } from '~/tools/implementations/file-edit';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+describe('FileEditTool context extraction', () => {
+  let tool: FileEditTool;
+  let testDir: string;
+  let testFile: string;
+
+  beforeEach(async () => {
+    tool = new FileEditTool();
+    testDir = await fs.mkdtemp(join(tmpdir(), 'file-edit-test-'));
+    testFile = join(testDir, 'test.txt');
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('should include diff context in metadata for successful edits', async () => {
+    const content = `line 1
+line 2
+line 3
+line 4
+line 5
+line 6
+line 7
+line 8
+line 9
+line 10`;
+
+    await fs.writeFile(testFile, content, 'utf-8');
+
+    const result = await tool.execute({
+      path: testFile,
+      old_text: 'line 5\nline 6',
+      new_text: 'modified line 5\nmodified line 6',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.metadata).toBeDefined();
+    expect(result.metadata?.diff).toBeDefined();
+
+    const diff = result.metadata?.diff as FileEditDiffContext;
+    expect(diff.beforeContext).toContain('line 2');
+    expect(diff.beforeContext).toContain('line 3');
+    expect(diff.beforeContext).toContain('line 4');
+    expect(diff.afterContext).toContain('line 7');
+    expect(diff.afterContext).toContain('line 8');
+    expect(diff.afterContext).toContain('line 9');
+    expect(diff.oldContent).toContain('line 5\nline 6');
+    expect(diff.newContent).toContain('modified line 5\nmodified line 6');
+    expect(diff.startLine).toBe(2); // line 2 is where context starts (3 lines before line 5)
+  });
+
+  it('should handle edits at the beginning of file', async () => {
+    const content = `first line
+second line
+third line
+fourth line
+fifth line`;
+
+    await fs.writeFile(testFile, content, 'utf-8');
+
+    const result = await tool.execute({
+      path: testFile,
+      old_text: 'first line',
+      new_text: 'modified first line',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.metadata?.diff).toBeDefined();
+
+    const diff = result.metadata?.diff as FileEditDiffContext;
+    expect(diff.beforeContext).toBe(''); // No context before first line
+    expect(diff.afterContext).toContain('second line');
+    expect(diff.afterContext).toContain('third line');
+    expect(diff.startLine).toBe(1);
+  });
+
+  it('should handle edits at the end of file', async () => {
+    const content = `line 1
+line 2
+line 3
+line 4
+last line`;
+
+    await fs.writeFile(testFile, content, 'utf-8');
+
+    const result = await tool.execute({
+      path: testFile,
+      old_text: 'last line',
+      new_text: 'modified last line',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.metadata?.diff).toBeDefined();
+
+    const diff = result.metadata?.diff as FileEditDiffContext;
+    expect(diff.beforeContext).toContain('line 2');
+    expect(diff.beforeContext).toContain('line 3');
+    expect(diff.beforeContext).toContain('line 4');
+    expect(diff.afterContext).toBe(''); // No context after last line
+  });
+
+  it('should handle multi-line replacements with context', async () => {
+    const content = `function foo() {
+  console.log('hello');
+  console.log('world');
+  return true;
+}
+
+function bar() {
+  console.log('test');
+}`;
+
+    await fs.writeFile(testFile, content, 'utf-8');
+
+    const result = await tool.execute({
+      path: testFile,
+      old_text: `  console.log('hello');
+  console.log('world');
+  return true;`,
+      new_text: `  console.log('hello world');
+  return false;`,
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.metadata?.diff).toBeDefined();
+
+    const diff = result.metadata?.diff as FileEditDiffContext;
+    expect(diff.beforeContext).toContain('function foo() {');
+    expect(diff.afterContext).toContain('}');
+    expect(diff.oldContent).toContain("console.log('hello')");
+    expect(diff.newContent).toContain("console.log('hello world')");
+  });
+
+  it('should preserve path and text information in metadata', async () => {
+    const content = 'original content';
+    await fs.writeFile(testFile, content, 'utf-8');
+
+    const result = await tool.execute({
+      path: testFile,
+      old_text: 'original',
+      new_text: 'modified',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.metadata?.path).toBe(testFile);
+    expect(result.metadata?.oldText).toBe('original');
+    expect(result.metadata?.newText).toBe('modified');
+  });
+});


### PR DESCRIPTION
## Summary
- Enhanced file_edit tool to include context lines in results for better diff display
- Added professional diff visualization using FileDiffViewer component
- Shows unified diff view with syntax highlighting and proper line numbers

## Changes
- **Enhanced core tool**: Modified `file_edit` tool to extract and return 3 lines of context before/after changes in metadata
- **Added FileEditDiffContext type**: Created structured type for diff context data
- **New renderer**: Built `file-edit.tsx` renderer that displays diffs using the existing FileDiffViewer component
- **Tests**: Added comprehensive tests for both the tool enhancement and the renderer
- **Type exports**: Added FileEditDiffContext to web package's core types

## Visual Features
- Unified diff view with syntax highlighting based on file extension
- Accurate line numbers matching actual file positions
- Shows context lines for better understanding of changes
- Graceful fallback when context isn't available
- Error state handling with clear visual feedback

## Test Plan
✅ All tests passing
✅ TypeScript compilation successful
✅ Lint checks passing
✅ Tested file_edit tool with context extraction
✅ Tested renderer with various scenarios (with/without context, errors, empty content)

This implementation provides a professional diff display that matches or exceeds Claude's quality, showing actual file context rather than just raw text snippets.

🤖 Generated with [Claude Code](https://claude.ai/code)