### PR TITLE
feat: add Bun runtime compatibility for SQLite persistence

### DIFF
--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -32,7 +32,18 @@ const nextConfig: NextConfig = {
         fallback?: Record<string, string | boolean>;
         extensionAlias?: Record<string, string[]>;
       };
+      externals?: any;
     };
+
+    // Ignore all bun:* imports - they're only used in Bun runtime
+    if (isServer) {
+      webpackConfig.externals = [
+        ...(Array.isArray(webpackConfig.externals)
+          ? webpackConfig.externals
+          : [webpackConfig.externals].filter(Boolean)),
+        /^bun:/,
+      ];
+    }
 
     webpackConfig.resolve.alias = {
       ...webpackConfig.resolve.alias,

--- a/src/persistence/database.ts
+++ b/src/persistence/database.ts
@@ -22,7 +22,6 @@ let Database: DatabaseConstructor;
 if (process?.versions?.bun) {
   // Running in Bun - use built-in SQLite
   // Use string concatenation to prevent webpack from analyzing this import
-  // @ts-expect-error - bun:sqlite is only available in Bun runtime
   const bunSqlite = (await import('bun' + ':sqlite')) as { Database: DatabaseConstructor };
   Database = bunSqlite.Database;
 } else {


### PR DESCRIPTION
## Summary
- Add runtime detection to conditionally load bun:sqlite or better-sqlite3
- Configure webpack to ignore bun:* imports during build
- Enable lace to run with Bun's built-in SQLite module (3-6x faster)

## Changes
This PR adds Bun runtime compatibility for the SQLite persistence layer while maintaining full backward compatibility with Node.js and better-sqlite3.

### Implementation
1. **Runtime Detection**: Checks `process.versions.bun` to determine runtime
2. **Dynamic Import**: Conditionally loads either `bun:sqlite` (for Bun) or `better-sqlite3` (for Node.js)
3. **Common Interface**: Defines `SQLiteDatabase` interface that both implementations satisfy
4. **Webpack Config**: Adds externals pattern to ignore `bun:*` imports during build

### Performance
When running with Bun, the native SQLite module provides 3-6x faster read performance compared to better-sqlite3.

## Test Plan
- [x] All existing tests pass with `npm test`
- [x] All tests pass with `bun run vitest`
- [x] Build succeeds with `npm run build`
- [x] No breaking changes for Node.js users

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds server runtime compatibility so deployments can run on Bun or Node without affecting the client.

* **Bug Fixes**
  * Prevents duplicate tool-approval events from causing errors.
  * Reduces intermittent write failures under load for more reliable saves.

* **Refactor**
  * More resilient database operations with retries, improved concurrency handling, schema migrations and safer initialization for data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->