### PR TITLE
feat: add zero-overhead SQLite profiling system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,21 @@ LACE_LOG_LEVEL=debug LACE_LOG_STDERR=true npm run dev
 - `LACE_LOG_STDERR`: Set to `true` to output logs to stderr
 - `LACE_LOG_FILE`: Optional file path for log output
 
+### SQL Profiling
+```bash
+# Enable SQL profiling to log all database queries with timing
+LACE_SQL_PROFILING=true LACE_LOG_LEVEL=debug npm run dev
+
+# Or with file output
+LACE_SQL_PROFILING=true LACE_LOG_LEVEL=debug LACE_LOG_FILE=sql-profile.log npm run dev
+```
+
+When `LACE_SQL_PROFILING=true`:
+- All SQL queries are logged at DEBUG level with execution time, parameters, and row counts
+- Slow queries (>100ms) are additionally logged at INFO level
+- Zero overhead when disabled - no performance impact on production
+- Logs include operation type (run/get/all/exec), duration, affected/returned rows
+
 ### Testing
 ```bash
 npm test            # Run tests in watch mode

--- a/src/persistence/database-profiling-integration.test.ts
+++ b/src/persistence/database-profiling-integration.test.ts
@@ -1,0 +1,132 @@
+// ABOUTME: Integration test for database profiling functionality
+// ABOUTME: Verifies that DatabasePersistence works with SQL profiling enabled
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DatabasePersistence } from '~/persistence/database';
+import { logger } from '~/utils/logger';
+import { setupCoreTest } from '~/test-utils/core-test-setup';
+import { getLaceDbPath } from '~/config/lace-dir';
+
+// Mock the logger
+vi.mock('~/utils/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('Database with SQL Profiling', () => {
+  const _tempLaceDir = setupCoreTest();
+  let db: DatabasePersistence;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Save original env
+    originalEnv = process.env.LACE_SQL_PROFILING;
+  });
+
+  afterEach(() => {
+    if (db) {
+      db.close();
+    }
+    // Restore original env
+    if (originalEnv !== undefined) {
+      process.env.LACE_SQL_PROFILING = originalEnv;
+    } else {
+      delete process.env.LACE_SQL_PROFILING;
+    }
+    vi.resetModules();
+  });
+
+  it('should work normally without profiling enabled', () => {
+    delete process.env.LACE_SQL_PROFILING;
+
+    db = new DatabasePersistence(getLaceDbPath());
+
+    // Create a simple thread
+    const thread = {
+      id: 'test-thread',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      events: [],
+    };
+
+    db.saveThread(thread);
+    const loadedThread = db.loadThread('test-thread');
+
+    expect(loadedThread).toBeTruthy();
+    expect(loadedThread!.id).toBe('test-thread');
+
+    // Should not have any profiling logs
+    expect(logger.debug).not.toHaveBeenCalledWith('SQL_PROFILE', expect.any(Object));
+  });
+
+  it('should profile queries when LACE_SQL_PROFILING=true', async () => {
+    process.env.LACE_SQL_PROFILING = 'true';
+
+    // Need to reload modules to pick up env change
+    vi.resetModules();
+    const { DatabasePersistence: ProfiledDB } = await import('./database');
+    const { getLaceDbPath: getDbPath } = await import('~/config/lace-dir');
+
+    db = new ProfiledDB(getDbPath());
+
+    // Create a simple thread
+    const thread = {
+      id: 'test-thread',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      events: [],
+    };
+
+    db.saveThread(thread);
+    const loadedThread = db.loadThread('test-thread');
+
+    expect(loadedThread).toBeTruthy();
+    expect(loadedThread!.id).toBe('test-thread');
+
+    // Should have profiling logs
+    expect(logger.debug).toHaveBeenCalledWith(
+      'SQL_PROFILE',
+      expect.objectContaining({
+        operation: expect.stringMatching(/^(run|get|all|exec)$/),
+        duration: expect.stringMatching(/\d+\.\d+ms/),
+        query: expect.any(String),
+        timestamp: expect.any(String),
+      }) as Record<string, unknown>
+    );
+
+    // Should have multiple calls due to schema initialization and operations
+    const mockLogger = vi.mocked(logger.debug);
+    const sqlProfileCalls = mockLogger.mock.calls.filter((call) => call[0] === 'SQL_PROFILE');
+    expect(sqlProfileCalls.length).toBeGreaterThan(0);
+  });
+
+  it('should profile both schema setup and regular operations', async () => {
+    process.env.LACE_SQL_PROFILING = 'true';
+
+    // Need to reload modules to pick up env change
+    vi.resetModules();
+    const { DatabasePersistence: ProfiledDB } = await import('./database');
+    const { getLaceDbPath: getDbPath } = await import('~/config/lace-dir');
+
+    db = new ProfiledDB(getDbPath());
+
+    // Should have profiled the schema creation
+    const mockLogger = vi.mocked(logger.debug);
+    const sqlProfileCalls = mockLogger.mock.calls.filter((call) => call[0] === 'SQL_PROFILE');
+
+    // Should have schema creation calls
+    const schemaQueries = sqlProfileCalls.filter((call) => {
+      const queryData = call[1] as { query: string };
+      return queryData.query.includes('CREATE TABLE') || queryData.query.includes('CREATE INDEX');
+    });
+
+    expect(schemaQueries.length).toBeGreaterThan(0);
+  });
+});

--- a/src/persistence/sql-profiler.test.ts
+++ b/src/persistence/sql-profiler.test.ts
@@ -1,0 +1,190 @@
+// ABOUTME: Tests for SQLite profiling functionality
+// ABOUTME: Verifies profiler captures timing data and logs correctly
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SQLProfiler } from '~/persistence/sql-profiler';
+import { logger } from '~/utils/logger';
+
+// Mock the logger
+vi.mock('~/utils/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+describe('SQLProfiler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset environment for each test
+    delete process.env.LACE_SQL_PROFILING;
+  });
+
+  it('should be disabled by default', () => {
+    expect(SQLProfiler.isEnabled()).toBe(false);
+  });
+
+  it('should be enabled when LACE_SQL_PROFILING=true', async () => {
+    process.env.LACE_SQL_PROFILING = 'true';
+    // Need to reload the module to pick up env change
+    vi.resetModules();
+    const { SQLProfiler: ReloadedProfiler } = await import('./sql-profiler');
+    expect(ReloadedProfiler.isEnabled()).toBe(true);
+  });
+
+  it('should not profile when disabled', () => {
+    const mockExecute = vi.fn().mockReturnValue('result');
+
+    const result = SQLProfiler.profile('get', 'SELECT * FROM table', [], mockExecute);
+
+    expect(result).toBe('result');
+    expect(mockExecute).toHaveBeenCalled();
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+
+  it('should profile when enabled', () => {
+    // Temporarily enable profiling
+    SQLProfiler.setEnabled(true);
+
+    const mockExecute = vi.fn().mockReturnValue({ changes: 1 });
+
+    const result = SQLProfiler.profile(
+      'run',
+      'INSERT INTO table VALUES (?)',
+      ['value'],
+      mockExecute
+    );
+
+    expect(result).toEqual({ changes: 1 });
+    expect(mockExecute).toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      'SQL_PROFILE',
+      expect.objectContaining({
+        operation: 'run',
+        duration: expect.stringMatching(/\d+\.\d+ms/),
+        query: 'INSERT INTO table VALUES (?)',
+        params: ['value'],
+        rowsAffected: 1,
+        timestamp: expect.any(String),
+      }) as Record<string, unknown>
+    );
+
+    // Reset
+    SQLProfiler.setEnabled(false);
+  });
+
+  it('should log slow queries at info level', () => {
+    // Temporarily enable profiling
+    SQLProfiler.setEnabled(true);
+
+    // Mock process.hrtime.bigint to simulate slow query
+    const originalHrtime = process.hrtime.bigint;
+    const startTime = BigInt(1000000000); // 1 second in nanoseconds
+    let callCount = 0;
+
+    process.hrtime.bigint = vi.fn(() => {
+      callCount++;
+      if (callCount === 1) return startTime;
+      // Return time that represents 150ms later (150 * 1_000_000 nanoseconds)
+      return startTime + BigInt(150 * 1_000_000);
+    });
+
+    const mockExecute = vi.fn().mockReturnValue('result');
+
+    SQLProfiler.profile('get', 'SELECT * FROM slow_table', [], mockExecute);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      'SLOW_SQL_QUERY',
+      expect.objectContaining({
+        operation: 'get',
+        duration: expect.stringMatching(/\d+\.\d+ms/),
+        query: 'SELECT * FROM slow_table',
+      }) as Record<string, unknown>
+    );
+
+    // Restore original hrtime and reset profiler
+    process.hrtime.bigint = originalHrtime;
+    SQLProfiler.setEnabled(false);
+  });
+
+  it('should normalize query whitespace', () => {
+    // Temporarily enable profiling
+    SQLProfiler.setEnabled(true);
+
+    const mockExecute = vi.fn().mockReturnValue('result');
+    const multilineQuery = `SELECT *
+                           FROM   table
+                           WHERE  id = ?`;
+
+    SQLProfiler.profile('get', multilineQuery, [1], mockExecute);
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      'SQL_PROFILE',
+      expect.objectContaining({
+        query: 'SELECT * FROM table WHERE id = ?',
+      }) as Record<string, unknown>
+    );
+
+    // Reset
+    SQLProfiler.setEnabled(false);
+  });
+
+  it('should track rows returned for get operations', () => {
+    // Temporarily enable profiling
+    SQLProfiler.setEnabled(true);
+
+    const mockExecute = vi.fn().mockReturnValue({ id: 1, name: 'test' });
+
+    SQLProfiler.profile('get', 'SELECT * FROM table WHERE id = ?', [1], mockExecute);
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      'SQL_PROFILE',
+      expect.objectContaining({
+        rowsReturned: 1,
+      }) as Record<string, unknown>
+    );
+
+    // Reset
+    SQLProfiler.setEnabled(false);
+  });
+
+  it('should track rows returned for all operations', () => {
+    // Temporarily enable profiling
+    SQLProfiler.setEnabled(true);
+
+    const mockExecute = vi.fn().mockReturnValue([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+    SQLProfiler.profile('all', 'SELECT * FROM table', [], mockExecute);
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      'SQL_PROFILE',
+      expect.objectContaining({
+        rowsReturned: 3,
+      }) as Record<string, unknown>
+    );
+
+    // Reset
+    SQLProfiler.setEnabled(false);
+  });
+
+  it('should track zero rows for empty get result', () => {
+    // Temporarily enable profiling
+    SQLProfiler.setEnabled(true);
+
+    const mockExecute = vi.fn().mockReturnValue(null);
+
+    SQLProfiler.profile('get', 'SELECT * FROM table WHERE id = ?', [999], mockExecute);
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      'SQL_PROFILE',
+      expect.objectContaining({
+        rowsReturned: 0,
+      }) as Record<string, unknown>
+    );
+
+    // Reset
+    SQLProfiler.setEnabled(false);
+  });
+});

--- a/src/persistence/sql-profiler.ts
+++ b/src/persistence/sql-profiler.ts
@@ -1,0 +1,111 @@
+// ABOUTME: Zero-overhead SQL query profiler for SQLite operations
+// ABOUTME: Logs query performance data only when LACE_SQL_PROFILING=true
+
+import { logger } from '~/utils/logger';
+
+interface QueryProfile {
+  query: string;
+  params?: unknown[];
+  duration: number;
+  timestamp: Date;
+  operation: 'run' | 'get' | 'all' | 'exec';
+  rowsAffected?: number;
+  rowsReturned?: number;
+}
+
+class SQLProfiler {
+  private static _enabled: boolean = process.env.LACE_SQL_PROFILING === 'true';
+
+  static isEnabled(): boolean {
+    return this._enabled;
+  }
+
+  // Test helper method to enable/disable profiling
+  static setEnabled(enabled: boolean): void {
+    this._enabled = enabled;
+  }
+
+  static profile<T>(
+    operation: 'run' | 'get' | 'all' | 'exec',
+    query: string,
+    params: unknown[] = [],
+    execute: () => T
+  ): T {
+    if (!this._enabled) {
+      return execute();
+    }
+
+    const startTime = process.hrtime.bigint();
+    const result = execute();
+    const endTime = process.hrtime.bigint();
+
+    const duration = Number(endTime - startTime) / 1_000_000; // Convert to milliseconds
+
+    let rowsAffected: number | undefined;
+    let rowsReturned: number | undefined;
+
+    // Extract metrics based on operation and result type
+    if (operation === 'run' && result && typeof result === 'object') {
+      const runResult = result as { changes?: number };
+      rowsAffected = runResult.changes;
+    } else if (operation === 'all' && Array.isArray(result)) {
+      rowsReturned = result.length;
+    } else if (operation === 'get' && result) {
+      rowsReturned = 1;
+    } else if (operation === 'get' && !result) {
+      rowsReturned = 0;
+    }
+
+    const profile: QueryProfile = {
+      query: query.trim().replace(/\s+/g, ' '), // Normalize whitespace
+      params: params.length > 0 ? params : undefined,
+      duration,
+      timestamp: new Date(),
+      operation,
+      rowsAffected,
+      rowsReturned,
+    };
+
+    // Log with structured data for easy parsing
+    logger.debug('SQL_PROFILE', {
+      operation: profile.operation,
+      duration: `${profile.duration.toFixed(2)}ms`,
+      query: profile.query,
+      params: profile.params,
+      rowsAffected: profile.rowsAffected,
+      rowsReturned: profile.rowsReturned,
+      timestamp: profile.timestamp.toISOString(),
+    });
+
+    // Also log slow queries at info level (>100ms)
+    if (profile.duration > 100) {
+      logger.info('SLOW_SQL_QUERY', {
+        operation: profile.operation,
+        duration: `${profile.duration.toFixed(2)}ms`,
+        query: profile.query,
+        params: profile.params,
+      });
+    }
+
+    return result;
+  }
+
+  // Convenience methods for each operation type
+  static profileRun<T>(query: string, params: unknown[], execute: () => T): T {
+    return this.profile('run', query, params, execute);
+  }
+
+  static profileGet<T>(query: string, params: unknown[], execute: () => T): T {
+    return this.profile('get', query, params, execute);
+  }
+
+  static profileAll<T>(query: string, params: unknown[], execute: () => T): T {
+    return this.profile('all', query, params, execute);
+  }
+
+  static profileExec<T>(query: string, execute: () => T): T {
+    return this.profile('exec', query, [], execute);
+  }
+}
+
+export { SQLProfiler, type QueryProfile };


### PR DESCRIPTION
## Summary
- Adds SQLProfiler class that logs SQL queries with timing when `LACE_SQL_PROFILING=true`
- Profiles all operations (run, get, all, exec) with execution time and row counts
- Logs slow queries (>100ms) at INFO level for visibility
- Zero performance impact when disabled - uses raw database directly

## Implementation Details
- Integrated with existing DatabasePersistence via transparent wrapper pattern
- When `LACE_SQL_PROFILING=false` (default), raw database is used with no overhead
- When enabled, wraps database with profiling layer that logs structured timing data
- Includes operation type, duration, query text, parameters, and affected/returned rows

## Usage
```bash
# Enable SQL profiling with debug logging
LACE_SQL_PROFILING=true LACE_LOG_LEVEL=debug npm run dev

# Save profiling data to file
LACE_SQL_PROFILING=true LACE_LOG_LEVEL=debug LACE_LOG_FILE=sql-profile.log npm run dev
```

## Test Coverage
- Comprehensive unit tests for SQLProfiler class
- Integration tests verifying database wrapper behavior
- Tests cover enabled/disabled states, timing accuracy, and log formatting

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional SQL profiling for database operations, enabled via LACE_SQL_PROFILING. Logs query, parameters, duration, and row metrics. Slow queries (>100ms) are highlighted. Zero overhead when disabled. Supports logging to a file (sql-profile.log).

- Documentation
  - Added a new SQL Profiling section with setup and usage examples, including file output instructions.

- Tests
  - Added integration and unit tests verifying profiling enable/disable behavior, structured logs, slow query detection, and coverage of setup and runtime queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->