### PR TITLE
Fix: Use configured superjson instance for console forwarding

### DIFF
--- a/packages/web/app/api/debug/console/route.ts
+++ b/packages/web/app/api/debug/console/route.ts
@@ -70,7 +70,7 @@ export async function POST(request: NextRequest) {
         } else {
           formattedArgs = stringify(deserializedArgs);
         }
-      } catch (error) {
+      } catch (_error) {
         // Fallback: handle raw args data gracefully
         // This can happen with branded types or other custom values
         // Just extract the json part and stringify it normally


### PR DESCRIPTION
## Summary
Fixed WebUI console deserialization errors that occurred when logging branded types like `ThreadId`.

## Problem
The console forwarding route was importing `superjson` directly instead of using the configured instance from `lib/serialization`. This caused "Trying to deserialize unknown custom value" errors when `console.log` was used with branded types (ThreadId, NewAgentSpec, etc).

## Solution
- Import `deserialize`/`stringify` from `@/lib/serialization` instead of raw superjson
- This uses the pre-configured instance that has custom type transformers registered for branded types
- No longer need to convert branded types to strings before logging

## Testing
- TypeScript compilation passes
- Console logs with ThreadId and other branded types now work correctly
- No more deserialization errors in the console forwarding system

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - More reliable debug console output with consistent formatting for arrays and objects.
  - Prevents crashes on unstringifiable or malformed entries; displays clear “[Serialization Error: type]” messages when needed.
  - Improved handling of mixed and raw argument types for more readable logs.
- Refactor
  - Switched to internal serialization utilities for formatting and deserialization, reducing dependency issues.
- Tests
  - None.
- Chores
  - None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->