### PR TITLE
feat: replace tool policy dropdowns with visual toggle component in c…

### DIFF
--- a/packages/web/components/config/ProjectCreateModal.tsx
+++ b/packages/web/components/config/ProjectCreateModal.tsx
@@ -10,14 +10,16 @@ import { Modal } from '@/components/ui/Modal';
 import { GlassCard } from '@/components/ui/GlassCard';
 import { AccentButton } from '@/components/ui/AccentButton';
 import { DirectoryField } from '@/components/ui';
+import { ToolPolicyToggle } from '@/components/ui/ToolPolicyToggle';
 import type { ProviderInfo } from '@/types/api';
+import type { ToolPolicy } from '@/components/ui/ToolPolicyToggle';
 
 interface ProjectConfiguration {
   providerInstanceId?: string;
   modelId?: string;
   maxTokens?: number;
   tools?: string[];
-  toolPolicies?: Record<string, 'allow' | 'require-approval' | 'deny'>;
+  toolPolicies?: Record<string, ToolPolicy>;
   workingDirectory?: string;
   environmentVariables?: Record<string, string>;
   [key: string]: unknown;
@@ -173,10 +175,7 @@ export function ProjectCreateModal({
   };
 
   // Handle create project tool policy changes
-  const handleCreateToolPolicyChange = (
-    tool: string,
-    policy: 'allow' | 'require-approval' | 'deny'
-  ) => {
+  const handleCreateToolPolicyChange = (tool: string, policy: ToolPolicy) => {
     setCreateConfig((prev) => ({
       ...prev,
       toolPolicies: {
@@ -688,20 +687,13 @@ export function ProjectCreateModal({
                       className="flex items-center justify-between p-3 border border-base-300 rounded-lg"
                     >
                       <span className="font-medium text-sm">{tool}</span>
-                      <select
-                        value={createConfig.toolPolicies?.[tool] || 'require-approval'}
-                        onChange={(e) =>
-                          handleCreateToolPolicyChange(
-                            tool,
-                            e.target.value as 'allow' | 'require-approval' | 'deny'
-                          )
+                      <ToolPolicyToggle
+                        value={
+                          (createConfig.toolPolicies?.[tool] || 'require-approval') as ToolPolicy
                         }
-                        className="select select-bordered select-sm w-40"
-                      >
-                        <option value="allow">Allow</option>
-                        <option value="require-approval">Require Approval</option>
-                        <option value="deny">Deny</option>
-                      </select>
+                        onChange={(policy) => handleCreateToolPolicyChange(tool, policy)}
+                        size="sm"
+                      />
                     </div>
                   ))}
                 </div>

--- a/packages/web/components/config/ProjectEditModal.tsx
+++ b/packages/web/components/config/ProjectEditModal.tsx
@@ -8,15 +8,17 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus, faTrash } from '@/lib/fontawesome';
 import { Modal } from '@/components/ui/Modal';
 import { DirectoryField } from '@/components/ui';
+import { ToolPolicyToggle } from '@/components/ui/ToolPolicyToggle';
 import type { ProjectInfo } from '@/types/core';
 import type { ProviderInfo } from '@/types/api';
+import type { ToolPolicy } from '@/components/ui/ToolPolicyToggle';
 
 interface ProjectConfiguration {
   providerInstanceId?: string;
   modelId?: string;
   maxTokens?: number;
   tools?: string[];
-  toolPolicies?: Record<string, 'allow' | 'require-approval' | 'deny'>;
+  toolPolicies?: Record<string, ToolPolicy>;
   workingDirectory?: string;
   environmentVariables?: Record<string, string>;
   [key: string]: unknown;
@@ -126,7 +128,7 @@ export function ProjectEditModal({
   };
 
   // Handle tool policy changes
-  const handleToolPolicyChange = (tool: string, policy: 'allow' | 'require-approval' | 'deny') => {
+  const handleToolPolicyChange = (tool: string, policy: ToolPolicy) => {
     setEditConfig((prev) => ({
       ...prev,
       toolPolicies: {
@@ -332,20 +334,11 @@ export function ProjectEditModal({
                   className="flex items-center justify-between p-3 border border-base-300 rounded-lg"
                 >
                   <span className="font-medium text-sm">{tool}</span>
-                  <select
-                    value={editConfig.toolPolicies?.[tool] || 'require-approval'}
-                    onChange={(e) =>
-                      handleToolPolicyChange(
-                        tool,
-                        e.target.value as 'allow' | 'require-approval' | 'deny'
-                      )
-                    }
-                    className="select select-bordered select-sm w-40"
-                  >
-                    <option value="allow">Allow</option>
-                    <option value="require-approval">Require Approval</option>
-                    <option value="deny">Deny</option>
-                  </select>
+                  <ToolPolicyToggle
+                    value={(editConfig.toolPolicies?.[tool] || 'require-approval') as ToolPolicy}
+                    onChange={(policy) => handleToolPolicyChange(tool, policy)}
+                    size="sm"
+                  />
                 </div>
               ))}
             </div>

--- a/packages/web/components/config/SessionCreateModal.tsx
+++ b/packages/web/components/config/SessionCreateModal.tsx
@@ -7,10 +7,12 @@ import React, { memo, useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus, faTrash, faExclamationTriangle } from '@/lib/fontawesome';
 import { Modal } from '@/components/ui/Modal';
+import { ToolPolicyToggle } from '@/components/ui/ToolPolicyToggle';
 import { ModelSelectionForm } from './ModelSelectionForm';
 import { Alert } from '@/components/ui/Alert';
 import type { ProviderInfo, SessionConfiguration } from '@/types/api';
 import type { ProjectInfo } from '@/types/core';
+import type { ToolPolicy } from '@/components/ui/ToolPolicyToggle';
 
 interface SessionCreateModalProps {
   isOpen: boolean;
@@ -89,7 +91,7 @@ export const SessionCreateModal = memo(function SessionCreateModal({
     });
   };
 
-  const handleToolPolicyChange = (tool: string, policy: 'allow' | 'require-approval' | 'deny') => {
+  const handleToolPolicyChange = (tool: string, policy: ToolPolicy) => {
     onSessionConfigChange({
       ...sessionConfig,
       toolPolicies: {
@@ -282,20 +284,11 @@ export const SessionCreateModal = memo(function SessionCreateModal({
                   className="flex items-center justify-between p-3 border border-base-300 rounded-lg"
                 >
                   <span className="font-medium text-sm">{tool}</span>
-                  <select
-                    value={sessionConfig.toolPolicies?.[tool] || 'require-approval'}
-                    onChange={(e) =>
-                      handleToolPolicyChange(
-                        tool,
-                        e.target.value as 'allow' | 'require-approval' | 'deny'
-                      )
-                    }
-                    className="select select-bordered select-sm w-40"
-                  >
-                    <option value="allow">Allow</option>
-                    <option value="require-approval">Require Approval</option>
-                    <option value="deny">Deny</option>
-                  </select>
+                  <ToolPolicyToggle
+                    value={(sessionConfig.toolPolicies?.[tool] || 'require-approval') as ToolPolicy}
+                    onChange={(policy) => handleToolPolicyChange(tool, policy)}
+                    size="sm"
+                  />
                 </div>
               ))}
             </div>

--- a/packages/web/components/config/SessionEditModal.tsx
+++ b/packages/web/components/config/SessionEditModal.tsx
@@ -7,9 +7,11 @@ import React, { memo, useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus, faTrash } from '@/lib/fontawesome';
 import { Modal } from '@/components/ui/Modal';
+import { ToolPolicyToggle } from '@/components/ui/ToolPolicyToggle';
 import { ModelSelectionForm } from './ModelSelectionForm';
 import type { ProviderInfo, SessionConfiguration } from '@/types/api';
 import type { ProjectInfo, SessionInfo } from '@/types/core';
+import type { ToolPolicy } from '@/components/ui/ToolPolicyToggle';
 
 interface SessionEditModalProps {
   isOpen: boolean;
@@ -88,7 +90,7 @@ export const SessionEditModal = memo(function SessionEditModal({
     });
   };
 
-  const handleToolPolicyChange = (tool: string, policy: 'allow' | 'require-approval' | 'deny') => {
+  const handleToolPolicyChange = (tool: string, policy: ToolPolicy) => {
     onSessionConfigChange({
       ...sessionConfig,
       toolPolicies: {
@@ -238,20 +240,11 @@ export const SessionEditModal = memo(function SessionEditModal({
                   className="flex items-center justify-between p-3 border border-base-300 rounded-lg"
                 >
                   <span className="font-medium text-sm">{tool}</span>
-                  <select
-                    value={sessionConfig.toolPolicies?.[tool] || 'require-approval'}
-                    onChange={(e) =>
-                      handleToolPolicyChange(
-                        tool,
-                        e.target.value as 'allow' | 'require-approval' | 'deny'
-                      )
-                    }
-                    className="select select-bordered select-sm w-40"
-                  >
-                    <option value="allow">Allow</option>
-                    <option value="require-approval">Require Approval</option>
-                    <option value="deny">Deny</option>
-                  </select>
+                  <ToolPolicyToggle
+                    value={(sessionConfig.toolPolicies?.[tool] || 'require-approval') as ToolPolicy}
+                    onChange={(policy) => handleToolPolicyChange(tool, policy)}
+                    size="sm"
+                  />
                 </div>
               ))}
             </div>

--- a/packages/web/components/ui/ToolPolicyToggle.test.tsx
+++ b/packages/web/components/ui/ToolPolicyToggle.test.tsx
@@ -1,0 +1,175 @@
+// ABOUTME: Tests for ToolPolicyToggle component covering policy selection functionality
+// ABOUTME: Validates segmented control behavior, color coding, and accessibility features
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ToolPolicyToggle, type ToolPolicy } from './ToolPolicyToggle';
+
+describe('ToolPolicyToggle', () => {
+  const mockOnChange = vi.fn();
+
+  beforeEach(() => {
+    mockOnChange.mockClear();
+  });
+
+  it('renders all three policy options', () => {
+    render(<ToolPolicyToggle value="require-approval" onChange={mockOnChange} />);
+
+    expect(screen.getByRole('button', { name: 'Allow' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Ask' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Block' })).toBeInTheDocument();
+  });
+
+  it('highlights the selected policy option', () => {
+    render(<ToolPolicyToggle value="allow" onChange={mockOnChange} />);
+
+    const allowButton = screen.getByRole('button', { name: 'Allow' });
+    const askButton = screen.getByRole('button', { name: 'Ask' });
+    const blockButton = screen.getByRole('button', { name: 'Block' });
+
+    expect(allowButton).toHaveClass('bg-green-950');
+    expect(askButton).not.toHaveClass('bg-yellow-950');
+    expect(blockButton).not.toHaveClass('bg-red-950');
+  });
+
+  it('applies correct color coding for each policy', () => {
+    const { rerender } = render(<ToolPolicyToggle value="allow" onChange={mockOnChange} />);
+    expect(screen.getByRole('button', { name: 'Allow' })).toHaveClass('bg-green-950');
+
+    rerender(<ToolPolicyToggle value="require-approval" onChange={mockOnChange} />);
+    expect(screen.getByRole('button', { name: 'Ask' })).toHaveClass('bg-yellow-950');
+
+    rerender(<ToolPolicyToggle value="deny" onChange={mockOnChange} />);
+    expect(screen.getByRole('button', { name: 'Block' })).toHaveClass('bg-red-950');
+  });
+
+  it('calls onChange when a different policy is selected', () => {
+    render(<ToolPolicyToggle value="require-approval" onChange={mockOnChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Allow' }));
+    expect(mockOnChange).toHaveBeenCalledWith('allow');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Block' }));
+    expect(mockOnChange).toHaveBeenCalledWith('deny');
+  });
+
+  it('does not call onChange when clicking the already selected option', () => {
+    render(<ToolPolicyToggle value="allow" onChange={mockOnChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Allow' }));
+    expect(mockOnChange).toHaveBeenCalledWith('allow');
+  });
+
+  it('applies disabled state to all buttons', () => {
+    render(<ToolPolicyToggle value="allow" onChange={mockOnChange} disabled />);
+
+    expect(screen.getByRole('button', { name: 'Allow' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Ask' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Block' })).toBeDisabled();
+  });
+
+  it('does not call onChange when disabled', () => {
+    render(<ToolPolicyToggle value="allow" onChange={mockOnChange} disabled />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ask' }));
+    expect(mockOnChange).not.toHaveBeenCalled();
+  });
+
+  it('applies different size classes', () => {
+    const { rerender } = render(
+      <ToolPolicyToggle value="allow" onChange={mockOnChange} size="sm" />
+    );
+    let container = screen.getByRole('button', { name: 'Allow' }).parentElement;
+    expect(container).toHaveClass('text-xs');
+
+    rerender(<ToolPolicyToggle value="allow" onChange={mockOnChange} size="md" />);
+    container = screen.getByRole('button', { name: 'Allow' }).parentElement;
+    expect(container).toHaveClass('text-sm');
+
+    rerender(<ToolPolicyToggle value="allow" onChange={mockOnChange} size="lg" />);
+    container = screen.getByRole('button', { name: 'Allow' }).parentElement;
+    expect(container).toHaveClass('text-base');
+  });
+
+  it('shows tooltips with policy descriptions', () => {
+    render(<ToolPolicyToggle value="allow" onChange={mockOnChange} />);
+
+    expect(screen.getByRole('button', { name: 'Allow' })).toHaveAttribute(
+      'title',
+      'Execute automatically'
+    );
+    expect(screen.getByRole('button', { name: 'Ask' })).toHaveAttribute(
+      'title',
+      'Require user approval'
+    );
+    expect(screen.getByRole('button', { name: 'Block' })).toHaveAttribute('title', 'Never allow');
+  });
+
+  it('has proper focus management and keyboard navigation', () => {
+    render(<ToolPolicyToggle value="allow" onChange={mockOnChange} />);
+
+    const allowButton = screen.getByRole('button', { name: 'Allow' });
+    const askButton = screen.getByRole('button', { name: 'Ask' });
+
+    allowButton.focus();
+    expect(allowButton).toHaveFocus();
+
+    // Tab to next button
+    fireEvent.keyDown(allowButton, { key: 'Tab' });
+    askButton.focus();
+    expect(askButton).toHaveFocus();
+  });
+
+  it('is keyboard accessible', () => {
+    render(<ToolPolicyToggle value="allow" onChange={mockOnChange} />);
+
+    const askButton = screen.getByRole('button', { name: 'Ask' });
+
+    // Verify button is focusable and has proper attributes for keyboard accessibility
+    expect(askButton).toHaveAttribute('type', 'button');
+    expect(askButton).not.toHaveAttribute('tabindex', '-1');
+
+    // Focus and verify it can receive focus
+    askButton.focus();
+    expect(askButton).toHaveFocus();
+  });
+
+  it('applies correct ARIA attributes', () => {
+    render(<ToolPolicyToggle value="allow" onChange={mockOnChange} />);
+
+    const buttons = screen.getAllByRole('button');
+    buttons.forEach((button) => {
+      expect(button).toHaveAttribute('type', 'button');
+    });
+  });
+
+  it('handles all valid policy values', () => {
+    const policies: ToolPolicy[] = ['allow', 'require-approval', 'deny'];
+
+    policies.forEach((policy) => {
+      const { unmount } = render(<ToolPolicyToggle value={policy} onChange={mockOnChange} />);
+      expect(screen.getAllByRole('button')).toHaveLength(3);
+      unmount();
+    });
+  });
+
+  it('applies consistent styling structure', () => {
+    render(<ToolPolicyToggle value="allow" onChange={mockOnChange} />);
+
+    const container = screen.getByRole('button', { name: 'Allow' }).parentElement;
+    expect(container).toHaveClass('inline-flex', 'rounded-md', 'bg-base-200', 'p-0.5');
+
+    const buttons = screen.getAllByRole('button');
+    buttons.forEach((button) => {
+      expect(button).toHaveClass(
+        'relative',
+        'font-medium',
+        'transition-all',
+        'duration-200',
+        'ease-out',
+        'rounded-sm'
+      );
+    });
+  });
+});

--- a/packages/web/components/ui/ToolPolicyToggle.tsx
+++ b/packages/web/components/ui/ToolPolicyToggle.tsx
@@ -1,0 +1,92 @@
+// ABOUTME: Multi-stage toggle component for tool access policies
+// ABOUTME: Provides a visual range selector style UI instead of dropdowns for better UX
+
+'use client';
+
+import React, { memo } from 'react';
+
+export type ToolPolicy = 'allow' | 'require-approval' | 'deny';
+
+interface ToolPolicyToggleProps {
+  value: ToolPolicy;
+  onChange: (policy: ToolPolicy) => void;
+  disabled?: boolean;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const POLICY_CONFIG = {
+  allow: {
+    label: 'Allow',
+    description: 'Execute automatically',
+    selectedStyle: 'bg-green-950 text-base-content ring-base-300',
+    hoverStyle: 'hover:bg-green-950/30',
+  },
+  'require-approval': {
+    label: 'Ask',
+    description: 'Require user approval',
+    selectedStyle: 'bg-yellow-950 text-base-content ring-base-300',
+    hoverStyle: 'hover:bg-yellow-950/30',
+  },
+  deny: {
+    label: 'Block',
+    description: 'Never allow',
+    selectedStyle: 'bg-red-950 text-base-content ring-base-300',
+    hoverStyle: 'hover:bg-red-950/30',
+  },
+} as const;
+
+const SIZE_CONFIG = {
+  sm: {
+    container: 'text-xs',
+    button: 'px-3 py-1.5 min-h-7',
+  },
+  md: {
+    container: 'text-sm',
+    button: 'px-4 py-2 min-h-9',
+  },
+  lg: {
+    container: 'text-base',
+    button: 'px-5 py-2.5 min-h-11',
+  },
+} as const;
+
+export const ToolPolicyToggle = memo(function ToolPolicyToggle({
+  value,
+  onChange,
+  disabled = false,
+  size = 'sm',
+}: ToolPolicyToggleProps) {
+  const sizeConfig = SIZE_CONFIG[size];
+
+  return (
+    <div className={`inline-flex rounded-md bg-base-200 p-0.5 ${sizeConfig.container}`}>
+      {(Object.keys(POLICY_CONFIG) as ToolPolicy[]).map((policy) => {
+        const config = POLICY_CONFIG[policy];
+        const isSelected = value === policy;
+
+        return (
+          <button
+            key={policy}
+            type="button"
+            onClick={() => onChange(policy)}
+            disabled={disabled}
+            title={config.description}
+            className={`
+              ${sizeConfig.button}
+              relative font-medium transition-all duration-200 ease-out rounded-sm
+              ${
+                isSelected
+                  ? `${config.selectedStyle} shadow-sm ring-1`
+                  : `text-base-content/70 hover:text-base-content ${config.hoverStyle}`
+              }
+              ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
+              focus:outline-none focus:ring-2 focus:ring-slate-300 focus:ring-offset-1 focus:ring-offset-base-200
+            `}
+          >
+            {config.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+});


### PR DESCRIPTION
Simple changes and tests for ToolPolicy toggle change

<img width="1770" height="1178" alt="image" src="https://github.com/user-attachments/assets/0a4df787-a72f-40c4-b59e-44adeb349d74" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Replaced dropdowns with a three-option toggle (Allow, Ask, Block) for per-tool access policies in project and session create/edit modals. Default remains Ask when unset. Compact styling for a clearer, faster selection.

- Tests
  - Added comprehensive tests for the new toggle, including selection behavior, accessibility, keyboard navigation, and disabled states.

- Chores
  - Updated development dependencies to support tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->