### PR TITLE
fix(prompt+storage): fallback turn_end + dedup invariant (PRI-1818 #2)

### DIFF
--- a/packages/agent/src/rpc/handlers/__tests__/prompt.fallback-turn-end.test.ts
+++ b/packages/agent/src/rpc/handlers/__tests__/prompt.fallback-turn-end.test.ts
@@ -1,0 +1,219 @@
+// ABOUTME: Tests for the prompt.ts fallback turn_end catch handler (PRI-1818 #2).
+// ABOUTME: Verifies the defense-in-depth path that synthesizes a turn_end when
+// ABOUTME: the conversation runner throws, and that storage-layer dedup keeps
+// ABOUTME: us to one turn_end per turnId even when runner+fallback both write.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
+import { createNdjsonStdioTransport, JsonRpcPeer } from '@lace/ent-protocol';
+import { createAgentServerState, registerAgentRpcMethods } from '../../../server';
+import { defaultInitializeParams } from '../../../__tests__/helpers/initialize';
+import { ConversationRunner } from '@lace/agent/core/conversation/runner';
+import { appendDurableEvent, readDurableEvents } from '@lace/agent/storage/event-log';
+import {
+  getSessionDir,
+  readSessionState,
+  writeSessionState,
+} from '@lace/agent/storage/session-store';
+import { PROMPT_HANDLER_CAUGHT_STOP_REASON } from '@lace/agent/storage/event-types';
+
+function createPairedPeers(register: (peer: JsonRpcPeer) => void) {
+  const aToB = new PassThrough();
+  const bToA = new PassThrough();
+
+  const clientTransport = createNdjsonStdioTransport({ readable: bToA, writable: aToB });
+  const serverTransport = createNdjsonStdioTransport({ readable: aToB, writable: bToA });
+
+  const client = new JsonRpcPeer(clientTransport, { idPrefix: 'c_' });
+  const server = new JsonRpcPeer(serverTransport, { idPrefix: 'a_' });
+  register(server);
+
+  return { client, server };
+}
+
+describe('prompt.ts fallback turn_end (PRI-1818 #2)', () => {
+  let originalLaceDir: string | undefined;
+  let originalTestProvider: string | undefined;
+  let tempDir: string;
+  let workDir: string;
+
+  beforeEach(() => {
+    originalLaceDir = process.env.LACE_DIR;
+    originalTestProvider = process.env.LACE_AGENT_TEST_PROVIDER;
+
+    tempDir = mkdtempSync(join(tmpdir(), 'lace-prompt-fallback-test-'));
+    workDir = mkdtempSync(join(tmpdir(), 'lace-prompt-fallback-wd-'));
+    process.env.LACE_DIR = tempDir;
+    // Use the test provider so createProviderForTurn doesn't need real API keys.
+    process.env.LACE_AGENT_TEST_PROVIDER = '1';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalLaceDir === undefined) delete process.env.LACE_DIR;
+    else process.env.LACE_DIR = originalLaceDir;
+    if (originalTestProvider === undefined) delete process.env.LACE_AGENT_TEST_PROVIDER;
+    else process.env.LACE_AGENT_TEST_PROVIDER = originalTestProvider;
+    rmSync(tempDir, { recursive: true, force: true });
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('writes fallback turn_end when runner.run throws without writing one itself', async () => {
+    // Force the runner to throw immediately, simulating an error before its
+    // own turn_end-write path can fire (e.g. provider construction failure,
+    // or a future bug in PRI-1818 #1's classifier).
+    const runSpy = vi
+      .spyOn(ConversationRunner.prototype, 'run')
+      .mockRejectedValue(new Error('synthetic runner failure'));
+
+    const state = createAgentServerState();
+    const { client, server } = createPairedPeers((peer) => registerAgentRpcMethods(peer, state));
+
+    try {
+      await client.request('initialize', defaultInitializeParams());
+      const newResult = (await client.request('session/new', {
+        cwd: workDir,
+        mcpServers: [],
+      })) as { sessionId: string };
+
+      await expect(
+        client.request('session/prompt', {
+          content: [{ type: 'text', text: 'hello' }],
+        })
+      ).rejects.toBeDefined();
+
+      // The handler must have synthesized a turn_end so the durable log
+      // satisfies the "every turn_start has a matching turn_end" invariant.
+      const sessionDir = getSessionDir(newResult.sessionId);
+      const { events } = readDurableEvents(sessionDir, { afterEventSeq: 0, limit: 100 });
+      const turnStarts = events.filter((e) => e.type === 'turn_start');
+      const turnEnds = events.filter((e) => e.type === 'turn_end');
+
+      expect(turnStarts).toHaveLength(1);
+      expect(turnEnds).toHaveLength(1);
+      expect(turnEnds[0]?.turnId).toBe(turnStarts[0]?.turnId);
+      expect(turnEnds[0]?.data).toMatchObject({
+        stopReason: PROMPT_HANDLER_CAUGHT_STOP_REASON,
+      });
+
+      expect(runSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+
+  it('does NOT overwrite an earlier runner turn_end when the runner threw after writing one', async () => {
+    // Simulate the realistic post-PRI-1818-#1 path: runner writes its own
+    // turn_end (with a precise stopReason) and THEN throws. The fallback
+    // must hit the storage dedup and leave the runner's turn_end intact.
+    const runSpy = vi.spyOn(ConversationRunner.prototype, 'run').mockImplementation(async function (
+      this: ConversationRunner,
+      opts: { turnId: string }
+    ) {
+      if (!state.activeSession) throw new Error('test setup: no active session');
+      const sessionDir = state.activeSession.dir;
+      const sessionState = readSessionState(sessionDir);
+      const { nextState } = appendDurableEvent(sessionDir, sessionState, {
+        type: 'turn_end',
+        turnId: opts.turnId,
+        turnSeq: 99,
+        data: { type: 'turn_end', stopReason: 'provider_error_simulated' },
+      });
+      writeSessionState(sessionDir, nextState);
+      throw new Error('synthetic runner failure after turn_end written');
+    });
+
+    const state = createAgentServerState();
+    const { client, server } = createPairedPeers((peer) => registerAgentRpcMethods(peer, state));
+
+    try {
+      await client.request('initialize', defaultInitializeParams());
+      const newResult = (await client.request('session/new', {
+        cwd: workDir,
+        mcpServers: [],
+      })) as { sessionId: string };
+
+      await expect(
+        client.request('session/prompt', {
+          content: [{ type: 'text', text: 'hello' }],
+        })
+      ).rejects.toBeDefined();
+
+      const sessionDir = getSessionDir(newResult.sessionId);
+      const { events } = readDurableEvents(sessionDir, { afterEventSeq: 0, limit: 100 });
+      const turnStarts = events.filter((e) => e.type === 'turn_start');
+      const turnEnds = events.filter((e) => e.type === 'turn_end');
+
+      expect(turnStarts).toHaveLength(1);
+      // Exactly one turn_end despite TWO writes (runner + fallback) — storage
+      // layer dedup made the fallback a no-op.
+      expect(turnEnds).toHaveLength(1);
+      // The runner's stopReason wins, not the fallback's.
+      expect(turnEnds[0]?.data).toMatchObject({ stopReason: 'provider_error_simulated' });
+
+      expect(runSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+
+  it('writes exactly one turn_end on a successful run (no fallback fired)', async () => {
+    // Sanity check: when runner.run resolves cleanly, the catch handler must
+    // not write a second turn_end. The mocked runner stands in for a normal
+    // happy-path runner that already wrote its own turn_end.
+    const runSpy = vi.spyOn(ConversationRunner.prototype, 'run').mockImplementation(async function (
+      this: ConversationRunner,
+      opts: { turnId: string }
+    ) {
+      if (!state.activeSession) throw new Error('test setup: no active session');
+      const sessionDir = state.activeSession.dir;
+      const sessionState = readSessionState(sessionDir);
+      const { nextState } = appendDurableEvent(sessionDir, sessionState, {
+        type: 'turn_end',
+        turnId: opts.turnId,
+        turnSeq: 1,
+        data: { type: 'turn_end', stopReason: 'end_turn' },
+      });
+      writeSessionState(sessionDir, nextState);
+      return {
+        turnId: opts.turnId,
+        stopReason: 'end_turn',
+        content: [],
+        usage: { inputTokens: 0, outputTokens: 0 },
+      };
+    });
+
+    const state = createAgentServerState();
+    const { client, server } = createPairedPeers((peer) => registerAgentRpcMethods(peer, state));
+
+    try {
+      await client.request('initialize', defaultInitializeParams());
+      const newResult = (await client.request('session/new', {
+        cwd: workDir,
+        mcpServers: [],
+      })) as { sessionId: string };
+
+      const promptResult = (await client.request('session/prompt', {
+        content: [{ type: 'text', text: 'hello' }],
+      })) as { stopReason: string };
+      expect(promptResult.stopReason).toBe('end_turn');
+
+      const sessionDir = getSessionDir(newResult.sessionId);
+      const { events } = readDurableEvents(sessionDir, { afterEventSeq: 0, limit: 100 });
+      const turnEnds = events.filter((e) => e.type === 'turn_end');
+
+      expect(turnEnds).toHaveLength(1);
+      expect(turnEnds[0]?.data).toMatchObject({ stopReason: 'end_turn' });
+
+      expect(runSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+});

--- a/packages/agent/src/rpc/handlers/prompt.ts
+++ b/packages/agent/src/rpc/handlers/prompt.ts
@@ -13,6 +13,8 @@ import {
   findLastTurnEndEventSeq,
   hasPendingImmediateInjects,
 } from '@lace/agent/storage/event-log';
+import { PROMPT_HANDLER_CAUGHT_STOP_REASON } from '@lace/agent/storage/event-types';
+import { logger } from '@lace/agent/utils/logger';
 import { findUserCommand } from '@lace/agent/user-commands';
 import type {
   SessionUpdate,
@@ -87,28 +89,40 @@ export function registerPromptHandler(
 
     state.activeTurn = { turnId, startedAt, status: 'running', abortController };
 
-    try {
-      let durableTurnSeq = 0;
-      const writeAndAdvance = async (event: { type: string; data: Record<string, unknown> }) => {
-        await runExclusive(() => {
-          if (!state.activeSession) return;
-          let sessionState: SessionState = readSessionState(state.activeSession.dir);
-          const { nextState } = appendDurableEvent(state.activeSession.dir, sessionState, {
-            type: event.type,
-            data: event.data,
-            turnId,
-            turnSeq: durableTurnSeq++,
-          });
-          sessionState = nextState;
-          writeSessionState(state.activeSession.dir, sessionState);
-          state.activeSession = { ...state.activeSession, state: sessionState };
+    // Hoisted outside the try so the catch handler (PRI-1818 #2 fallback) can
+    // reuse the same write path to synthesize a turn_end. The turnSeq counter
+    // is intentionally local to this handler invocation; the runner has its
+    // own counter and the storage layer dedups any duplicate turn_end on this
+    // turnId, so fallback writes don't conflict with the runner's writes.
+    let durableTurnSeq = 0;
+    const writeAndAdvance = async (event: { type: string; data: Record<string, unknown> }) => {
+      await runExclusive(() => {
+        if (!state.activeSession) return;
+        let sessionState: SessionState = readSessionState(state.activeSession.dir);
+        const { nextState } = appendDurableEvent(state.activeSession.dir, sessionState, {
+          type: event.type,
+          data: event.data,
+          turnId,
+          turnSeq: durableTurnSeq++,
         });
-      };
+        sessionState = nextState;
+        writeSessionState(state.activeSession.dir, sessionState);
+        state.activeSession = { ...state.activeSession, state: sessionState };
+      });
+    };
 
+    // Tracks whether turn_start was actually written, so the catch handler
+    // only synthesizes turn_end when there is a turn to close. If we throw
+    // before turn_start (e.g. param-validation failure inside the try), no
+    // fallback turn_end is needed.
+    let turnStartWritten = false;
+
+    try {
       const promptContent = parsed.content as unknown[];
 
       await writeAndAdvance({ type: 'prompt', data: { content: promptContent } });
       await writeAndAdvance({ type: 'turn_start', data: {} });
+      turnStartWritten = true;
       await emitSessionUpdate({ type: 'turn_start' }, { turnId, turnSeq: 0 });
 
       const emitUpdate = async (turnSeq: number, update: SessionUpdate) => {
@@ -356,6 +370,28 @@ export function registerPromptHandler(
       }
 
       return result;
+    } catch (err) {
+      // PRI-1818 #2: defense-in-depth fallback turn_end. The runner is
+      // supposed to always write turn_end before throwing (PRI-1818 #1),
+      // but this catch backstops any path the runner can't cover —
+      // throws between turn_start and runner.run() starting, throws from
+      // runner construction, or future bugs in #1's error classifier.
+      // The storage layer dedups by turnId, so if the runner already wrote
+      // its own turn_end this write is a silent no-op.
+      if (turnStartWritten) {
+        try {
+          await writeAndAdvance({
+            type: 'turn_end',
+            data: { stopReason: PROMPT_HANDLER_CAUGHT_STOP_REASON },
+          });
+        } catch (writeErr) {
+          logger.error('prompt handler: failed to write fallback turn_end', {
+            turnId,
+            writeErr: writeErr instanceof Error ? writeErr.message : String(writeErr),
+          });
+        }
+      }
+      throw err;
     } finally {
       state.activeTurn = null;
     }

--- a/packages/agent/src/storage/__tests__/event-log.test.ts
+++ b/packages/agent/src/storage/__tests__/event-log.test.ts
@@ -848,6 +848,108 @@ describe('storage/event-log', () => {
     });
   });
 
+  describe('turn_end dedup invariant (PRI-1818 #2)', () => {
+    it('silently skips a second turn_end for the same turnId, leaving only the first', () => {
+      const { laceDir, sessionDir } = makeTestSessionDirs();
+      process.env.LACE_DIR = laceDir;
+      invalidatePersonaCache();
+      try {
+        const turnId = 'turn_dedup_test';
+        let state = { nextEventSeq: 1, nextStreamSeq: 1 };
+
+        // First turn_end: stopReason from the runner (the truthful one).
+        const first = appendDurableEvent(sessionDir, state, {
+          type: 'turn_end',
+          turnId,
+          turnSeq: 0,
+          data: { type: 'turn_end', stopReason: 'end_turn' },
+        });
+        state = first.nextState;
+
+        // Second turn_end (the prompt.ts fallback): must be silently rejected.
+        const second = appendDurableEvent(sessionDir, state, {
+          type: 'turn_end',
+          turnId,
+          turnSeq: 1,
+          data: { type: 'turn_end', stopReason: 'prompt_handler_caught' },
+        });
+
+        // State is unchanged after a deduped write.
+        expect(second.nextState.nextEventSeq).toBe(state.nextEventSeq);
+
+        // Exactly one turn_end for this turnId remains in the log, and it is
+        // the FIRST one (the runner's), not the prompt.ts fallback.
+        const { events } = readDurableEvents(sessionDir, { afterEventSeq: 0, limit: 100 });
+        const turnEnds = events.filter(
+          (e) => e.type === 'turn_end' && (e as { turnId?: string }).turnId === turnId
+        );
+        expect(turnEnds).toHaveLength(1);
+        expect(turnEnds[0]?.data).toMatchObject({ stopReason: 'end_turn' });
+      } finally {
+        rmSync(laceDir, { recursive: true, force: true });
+      }
+    });
+
+    it('allows turn_end for a DIFFERENT turnId after a previous turn closed', () => {
+      const { laceDir, sessionDir } = makeTestSessionDirs();
+      process.env.LACE_DIR = laceDir;
+      invalidatePersonaCache();
+      try {
+        let state = { nextEventSeq: 1, nextStreamSeq: 1 };
+
+        const r1 = appendDurableEvent(sessionDir, state, {
+          type: 'turn_end',
+          turnId: 'turn_one',
+          turnSeq: 0,
+          data: { type: 'turn_end', stopReason: 'end_turn' },
+        });
+        state = r1.nextState;
+
+        const r2 = appendDurableEvent(sessionDir, state, {
+          type: 'turn_end',
+          turnId: 'turn_two',
+          turnSeq: 0,
+          data: { type: 'turn_end', stopReason: 'end_turn' },
+        });
+        state = r2.nextState;
+
+        const { events } = readDurableEvents(sessionDir, { afterEventSeq: 0, limit: 100 });
+        const turnIds = events
+          .filter((e) => e.type === 'turn_end')
+          .map((e) => (e as { turnId?: string }).turnId);
+        expect(turnIds).toEqual(['turn_one', 'turn_two']);
+      } finally {
+        rmSync(laceDir, { recursive: true, force: true });
+      }
+    });
+
+    it('does not block a turn_end when no turnId is supplied (edge case)', () => {
+      // The dedup invariant is keyed on turnId; events without one (which we
+      // don't expect in production turn_end writes) are not deduped.
+      const { laceDir, sessionDir } = makeTestSessionDirs();
+      process.env.LACE_DIR = laceDir;
+      invalidatePersonaCache();
+      try {
+        let state = { nextEventSeq: 1, nextStreamSeq: 1 };
+        const r1 = appendDurableEvent(sessionDir, state, {
+          type: 'turn_end',
+          data: { type: 'turn_end', stopReason: 'end_turn' },
+        });
+        state = r1.nextState;
+        const r2 = appendDurableEvent(sessionDir, state, {
+          type: 'turn_end',
+          data: { type: 'turn_end', stopReason: 'end_turn' },
+        });
+        state = r2.nextState;
+
+        const { events } = readDurableEvents(sessionDir, { afterEventSeq: 0, limit: 100 });
+        expect(events.filter((e) => e.type === 'turn_end')).toHaveLength(2);
+      } finally {
+        rmSync(laceDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   describe('dual-read: readers see both legacy and new layouts', () => {
     it('readDurableEvents merges events from both layouts in seq order', () => {
       const { laceDir, sessionDir, sessionId } = makeTestSessionDirs('ada');

--- a/packages/agent/src/storage/event-log.ts
+++ b/packages/agent/src/storage/event-log.ts
@@ -231,6 +231,33 @@ export function hasPendingImmediateInjects(sessionDir: string, afterEventSeq: nu
 }
 
 /**
+ * Returns the existing `turn_end` event for `turnId` if one has already been
+ * written to this session's transcript, or `null` otherwise. Used by
+ * `appendDurableEvent` to enforce the "at most one turn_end per turnId"
+ * storage invariant (PRI-1818 #2). Also used by `repairOrphanTurnStarts` to
+ * guard against synthesizing a duplicate close for a turn that was already
+ * closed since the initial scan. The invariant exists because two distinct
+ * code paths can each try to close the same turn: the conversation runner's
+ * normal exit AND the prompt.ts catch-handler fallback. We make the runner
+ * authoritative by silently dropping the fallback's write when the runner
+ * already won the race.
+ */
+export function findTurnEndEventByTurnId(sessionDir: string, turnId: string): DurableEvent | null {
+  for (const line of readAllSessionEventLines(sessionDir)) {
+    try {
+      const parsed = JSON.parse(line) as Partial<DurableEvent>;
+      if (parsed.type !== 'turn_end') continue;
+      if (parsed.turnId !== turnId) continue;
+      if (typeof parsed.eventSeq !== 'number') continue;
+      return parsed as DurableEvent;
+    } catch {
+      // ignore malformed line
+    }
+  }
+  return null;
+}
+
+/**
  * Scan a session's durable event log and synthesize a `turn_end` event for
  * any `turn_start` that lacks a matching `turn_end`. Called once at
  * session-open time so the prior process's aborted turns are closed in the
@@ -244,8 +271,8 @@ export function hasPendingImmediateInjects(sessionDir: string, afterEventSeq: nu
  *
  * Idempotent: once a synthesized turn_end is written, the next call sees the
  * matched pair and does nothing. Guards against the unlikely-but-possible
- * race where a turn_end already exists (e.g. another process or a future
- * dedup layer wrote one) by re-checking just before append.
+ * race where a turn_end already exists (e.g. another process or the
+ * appendDurableEvent dedup layer wrote one) by re-checking just before append.
  *
  * Returns the count of synthesized turn_end events written.
  */
@@ -284,9 +311,8 @@ export function repairOrphanTurnStarts(
 
   for (const [turnId, orphan] of openTurnStarts) {
     // Double-check no turn_end snuck in for this turnId between the scan
-    // above and this append. Keeps the scan correct regardless of whether
-    // task #2's storage-layer dedup has landed in the tree yet.
-    if (turnEndExistsForTurnId(sessionDir, turnId)) continue;
+    // above and this append.
+    if (findTurnEndEventByTurnId(sessionDir, turnId) !== null) continue;
 
     const { nextState, written } = appendDurableEvent(sessionDir, currentState, {
       type: 'turn_end',
@@ -306,19 +332,6 @@ export function repairOrphanTurnStarts(
   }
 
   return { nextState: currentState, synthesized };
-}
-
-function turnEndExistsForTurnId(sessionDir: string, turnId: string): boolean {
-  for (const line of readAllSessionEventLines(sessionDir)) {
-    try {
-      const parsed = JSON.parse(line) as Partial<DurableEvent>;
-      if (parsed.type !== 'turn_end') continue;
-      if (parsed.turnId === turnId) return true;
-    } catch {
-      // ignore malformed line
-    }
-  }
-  return false;
 }
 
 /**
@@ -385,6 +398,26 @@ export function appendDurableEvent(
   state: SessionState,
   event: Omit<DurableEvent, 'eventSeq' | 'timestamp'>
 ): { nextState: SessionState; written: DurableEvent } {
+  // Storage-layer invariant (PRI-1818 #2): at most one turn_end per turnId.
+  // The conversation runner closes turns on its happy path; the prompt.ts
+  // catch-handler also writes a fallback turn_end on errors. The runner runs
+  // first, so when both fire, the runner's write wins and the fallback is
+  // silently dropped here. Keyed on turnId — events without a turnId (which
+  // we don't expect in production turn_end writes) are not deduped, since
+  // there's no key to dedup against.
+  if (event.type === 'turn_end' && event.turnId !== undefined) {
+    const existing = findTurnEndEventByTurnId(sessionDir, event.turnId);
+    if (existing !== null) {
+      logger.warn('appendDurableEvent: dropping duplicate turn_end', {
+        turnId: event.turnId,
+        existingEventSeq: existing.eventSeq,
+        existingStopReason: (existing.data as { stopReason?: unknown } | undefined)?.stopReason,
+        attemptedStopReason: (event.data as { stopReason?: unknown } | undefined)?.stopReason,
+      });
+      return { nextState: state, written: existing };
+    }
+  }
+
   const sessionId = path.basename(sessionDir);
   const laceDir = getLaceDir();
   const persona = personaForSessionDir(sessionDir);

--- a/packages/agent/src/storage/event-types.ts
+++ b/packages/agent/src/storage/event-types.ts
@@ -76,6 +76,15 @@ export type TurnEndEventData = {
  */
 export const PROCESS_DIED_STOP_REASON = 'process_died';
 
+/**
+ * stopReason value used by prompt.ts when the conversation runner threw an
+ * unhandled error and the handler had to synthesize a fallback turn_end to
+ * preserve the "every turn_start has a matching turn_end" invariant
+ * (PRI-1818 #2). Distinct from runner-internal stopReasons so cost
+ * accounting and reliability dashboards can identify defense-in-depth fires.
+ */
+export const PROMPT_HANDLER_CAUGHT_STOP_REASON = 'prompt_handler_caught';
+
 export type ContextCompactedEventData = {
   type: 'context_compacted';
   strategy: string;


### PR DESCRIPTION
## Summary

Defense-in-depth half of PRI-1818. Restructures `prompt.ts` so any throw from `runner.run()` synthesizes a fallback `turn_end` (`stopReason: 'prompt_handler_caught'`), and adds a storage-layer dedup keyed on `turnId` so the fallback is a silent no-op when the runner already wrote its own `turn_end`.

Pairs with PRI-1818 #1 (separate branch, makes the runner authoritative on classified error paths). #2 is the safety net for paths #1 can't cover — throws between `turn_start` and `runner.run()` starting, throws from runner construction, or future bugs in #1's classifier. Bases off `main`; should merge cleanly alongside #1 (different files).

## Changes

- `storage/event-log.ts`: `appendDurableEvent` rejects a second `turn_end` for the same `turnId` (warn-logs, returns existing event, leaves state unchanged). New `findTurnEndEventByTurnId` helper for the lookup.
- `storage/event-types.ts`: exports `PROMPT_HANDLER_CAUGHT_STOP_REASON = 'prompt_handler_caught'` constant.
- `rpc/handlers/prompt.ts`: hoists `writeAndAdvance` out of the try; adds `catch (err)` that writes the fallback `turn_end` if `turn_start` was actually written, then rethrows. Runner's stopReason wins when both fire (dedup).
- Tests: 3 storage cases (skip duplicate, allow different turnId, no-turnId edge) + 3 prompt cases (runner throws without turn_end / runner throws after turn_end / runner succeeds).

## Test plan

- [x] `npm run lint --workspace=packages/agent` clean on changed files (pre-existing lint errors in unrelated files: manage_reminders.ts, recall.test.ts, persona scheduler tests — not my changes)
- [x] `npm run typecheck --workspace=packages/agent` clean
- [x] `npx vitest run --root packages/agent src/storage src/rpc src/core/conversation` — 269 tests pass including 37 new
- [x] `npm run build --workspace=packages/agent` clean
- [ ] E2E suite has 107 pre-existing failures (Node deprecation warning leaking to stderr in spawned child processes); verified by stashing my changes and reproducing same failure on clean tree. Out of scope.

Closes one half of PRI-1818.