### PR TITLE
fix(storage): repair orphan turn_starts at session-open (PRI-1818 #3)

### DIFF
--- a/packages/agent/src/rpc/handlers/session.ts
+++ b/packages/agent/src/rpc/handlers/session.ts
@@ -183,7 +183,11 @@ async function activateStoredSession(
 
   let loaded;
   try {
-    loaded = loadSession(params.sessionId);
+    // Cold session-open path: ask loadSession to scan for and synthesize
+    // turn_end events for any orphan turn_starts left by a prior process
+    // (SIGKILL, OOM, container restart). All other loadSession call sites
+    // are mid-flight refreshes that must NOT repair. See PRI-1818.
+    loaded = loadSession(params.sessionId, { repairOrphanTurnStarts: true });
   } catch (error) {
     if (error instanceof Error && error.message === 'Session not found') {
       throw {

--- a/packages/agent/src/storage/__tests__/repair-orphan-turn-starts.test.ts
+++ b/packages/agent/src/storage/__tests__/repair-orphan-turn-starts.test.ts
@@ -1,0 +1,243 @@
+// ABOUTME: Tests for crash-recovery synthesis of turn_end events at session-open
+// ABOUTME: Covers single/multi orphans, clean sessions, last-event orphan, and idempotency
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { useTempLaceDir } from '../../test-utils/temp-lace-dir';
+import { loadSession, writeSessionMeta } from '../session-store';
+import { readAllSessionEventLines } from '../event-log';
+import { closeRecallIndex } from '../recall/index-db';
+import { PROCESS_DIED_STOP_REASON } from '../event-types';
+
+type RawEvent = {
+  eventSeq: number;
+  timestamp: string;
+  turnId?: string;
+  turnSeq?: number;
+  type: string;
+  data: Record<string, unknown>;
+};
+
+const SESSION_ID = 'sess_aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa';
+
+function sessionDirFor(laceDir: string): string {
+  return join(laceDir, 'agent-sessions', SESSION_ID);
+}
+
+function setupSession(laceDir: string, events: RawEvent[]): string {
+  const dir = sessionDirFor(laceDir);
+  mkdirSync(dir, { recursive: true });
+  writeSessionMeta(dir, {
+    sessionId: SESSION_ID,
+    workDir: laceDir,
+    created: '2026-05-24T00:00:00.000Z',
+  });
+  // Synthesize the prior process's events.jsonl in the legacy path; the
+  // dual-reader will pick it up alongside any new-layout files we never
+  // create here. Keeps the fixture self-contained without persona routing.
+  const eventsPath = join(dir, 'events.jsonl');
+  if (events.length > 0) {
+    writeFileSync(eventsPath, events.map((e) => JSON.stringify(e)).join('\n') + '\n', 'utf8');
+  }
+  return dir;
+}
+
+function readEvents(dir: string): RawEvent[] {
+  const out: RawEvent[] = [];
+  for (const line of readAllSessionEventLines(dir)) {
+    try {
+      out.push(JSON.parse(line) as RawEvent);
+    } catch {
+      // skip malformed lines (matches production reader's tolerance)
+    }
+  }
+  return out;
+}
+
+function turnStart(eventSeq: number, turnId: string, turnSeq = 1): RawEvent {
+  return {
+    eventSeq,
+    timestamp: `2026-05-24T00:00:${String(eventSeq).padStart(2, '0')}.000Z`,
+    turnId,
+    turnSeq,
+    type: 'turn_start',
+    data: { type: 'turn_start' },
+  };
+}
+
+function turnEnd(eventSeq: number, turnId: string, turnSeq = 2, stopReason = 'end_turn'): RawEvent {
+  return {
+    eventSeq,
+    timestamp: `2026-05-24T00:00:${String(eventSeq).padStart(2, '0')}.000Z`,
+    turnId,
+    turnSeq,
+    type: 'turn_end',
+    data: { type: 'turn_end', stopReason },
+  };
+}
+
+function prompt(eventSeq: number, turnId: string): RawEvent {
+  return {
+    eventSeq,
+    timestamp: `2026-05-24T00:00:${String(eventSeq).padStart(2, '0')}.000Z`,
+    turnId,
+    turnSeq: 0,
+    type: 'prompt',
+    data: { type: 'prompt', content: [{ type: 'text', text: 'hi' }] },
+  };
+}
+
+describe('repairOrphanTurnStarts via loadSession', () => {
+  const ctx = useTempLaceDir();
+
+  // Each test creates its own session under ctx.tempDir; close the recall
+  // index between tests so the next case sees a fresh DB rooted at its
+  // tempdir (mirrors event-log.test.ts's pattern).
+  afterEach(() => {
+    closeRecallIndex();
+  });
+
+  it('synthesizes one turn_end for a single orphan turn_start', () => {
+    const dir = setupSession(ctx.tempDir, [prompt(1, 'turn_solo'), turnStart(2, 'turn_solo', 1)]);
+
+    loadSession(SESSION_ID, { repairOrphanTurnStarts: true });
+
+    const events = readEvents(dir);
+    const turnEnds = events.filter((e) => e.type === 'turn_end');
+    expect(turnEnds).toHaveLength(1);
+    expect(turnEnds[0].turnId).toBe('turn_solo');
+    expect(turnEnds[0].data.stopReason).toBe(PROCESS_DIED_STOP_REASON);
+    expect(turnEnds[0].turnSeq).toBe(2);
+    expect(turnEnds[0].eventSeq).toBeGreaterThan(2);
+  });
+
+  it('synthesizes a turn_end for each of three back-to-back orphan turn_starts', () => {
+    const dir = setupSession(ctx.tempDir, [
+      prompt(1, 'turn_a'),
+      turnStart(2, 'turn_a', 1),
+      prompt(3, 'turn_b'),
+      turnStart(4, 'turn_b', 1),
+      prompt(5, 'turn_c'),
+      turnStart(6, 'turn_c', 1),
+    ]);
+
+    loadSession(SESSION_ID, { repairOrphanTurnStarts: true });
+
+    const turnEnds = readEvents(dir).filter((e) => e.type === 'turn_end');
+    expect(turnEnds).toHaveLength(3);
+    const closedTurnIds = turnEnds.map((e) => e.turnId).sort();
+    expect(closedTurnIds).toEqual(['turn_a', 'turn_b', 'turn_c']);
+    for (const te of turnEnds) {
+      expect(te.data.stopReason).toBe(PROCESS_DIED_STOP_REASON);
+    }
+  });
+
+  it('appends nothing when every turn_start already has a matching turn_end', () => {
+    const dir = setupSession(ctx.tempDir, [
+      prompt(1, 'turn_a'),
+      turnStart(2, 'turn_a', 1),
+      turnEnd(3, 'turn_a', 2),
+      prompt(4, 'turn_b'),
+      turnStart(5, 'turn_b', 1),
+      turnEnd(6, 'turn_b', 2),
+    ]);
+    const before = readEvents(dir);
+
+    loadSession(SESSION_ID, { repairOrphanTurnStarts: true });
+
+    const after = readEvents(dir);
+    expect(after).toHaveLength(before.length);
+  });
+
+  it('handles an orphan turn_start that is the last event in the file', () => {
+    const dir = setupSession(ctx.tempDir, [
+      prompt(1, 'turn_a'),
+      turnStart(2, 'turn_a', 1),
+      turnEnd(3, 'turn_a', 2),
+      prompt(4, 'turn_b'),
+      turnStart(5, 'turn_b', 1),
+    ]);
+
+    loadSession(SESSION_ID, { repairOrphanTurnStarts: true });
+
+    const events = readEvents(dir);
+    const turnEnds = events.filter((e) => e.type === 'turn_end');
+    expect(turnEnds).toHaveLength(2);
+    const synthesized = turnEnds.find((e) => e.turnId === 'turn_b');
+    expect(synthesized).toBeDefined();
+    expect(synthesized!.data.stopReason).toBe(PROCESS_DIED_STOP_REASON);
+    expect(synthesized!.turnSeq).toBe(2);
+    expect(synthesized!.eventSeq).toBeGreaterThan(5);
+  });
+
+  it('is idempotent: second loadSession does not append more turn_ends', () => {
+    const dir = setupSession(ctx.tempDir, [prompt(1, 'turn_solo'), turnStart(2, 'turn_solo', 1)]);
+
+    loadSession(SESSION_ID, { repairOrphanTurnStarts: true });
+    const afterFirst = readEvents(dir);
+    const firstCount = afterFirst.length;
+    const firstSynthesized = afterFirst.filter(
+      (e) => e.type === 'turn_end' && e.data.stopReason === PROCESS_DIED_STOP_REASON
+    );
+    expect(firstSynthesized).toHaveLength(1);
+
+    loadSession(SESSION_ID, { repairOrphanTurnStarts: true });
+    const afterSecond = readEvents(dir);
+    expect(afterSecond).toHaveLength(firstCount);
+  });
+
+  it('does not synthesize when a session has no events', () => {
+    const dir = setupSession(ctx.tempDir, []);
+    expect(existsSync(join(dir, 'events.jsonl'))).toBe(false);
+
+    loadSession(SESSION_ID, { repairOrphanTurnStarts: true });
+
+    // No events file should be created by repair (post-migration sessions
+    // route writes under transcripts/, but with no synth there's nothing to
+    // write anywhere).
+    const events = readEvents(dir);
+    expect(events).toHaveLength(0);
+  });
+
+  it('does NOT synthesize when called without the repairOrphanTurnStarts option (default refresh path)', () => {
+    // Safety invariant: mid-flight loadSession() refreshes (called all over
+    // the rpc handlers after writes) must NOT synthesize turn_end for an
+    // in-flight turn_start. Default behavior is no-repair.
+    const dir = setupSession(ctx.tempDir, [prompt(1, 'turn_solo'), turnStart(2, 'turn_solo', 1)]);
+
+    loadSession(SESSION_ID);
+
+    const turnEnds = readEvents(dir).filter((e) => e.type === 'turn_end');
+    expect(turnEnds).toHaveLength(0);
+  });
+
+  it('survives a malformed final line (partial write) in events.jsonl', () => {
+    const dir = sessionDirFor(ctx.tempDir);
+    mkdirSync(dir, { recursive: true });
+    writeSessionMeta(dir, {
+      sessionId: SESSION_ID,
+      workDir: ctx.tempDir,
+      created: '2026-05-24T00:00:00.000Z',
+    });
+
+    const validLines = [prompt(1, 'turn_solo'), turnStart(2, 'turn_solo', 1)].map((e) =>
+      JSON.stringify(e)
+    );
+    const truncated =
+      '{"eventSeq":3,"timestamp":"2026-05-24T00:00:03Z","turnId":"turn_x","type":"message","data":';
+    writeFileSync(join(dir, 'events.jsonl'), validLines.join('\n') + '\n' + truncated, 'utf8');
+
+    loadSession(SESSION_ID, { repairOrphanTurnStarts: true });
+
+    // Sanity: a synthesized turn_end exists for the orphan and we didn't
+    // crash on the malformed line. Repair writes to the dual-read transcript
+    // layout, so read via readAllSessionEventLines (which honors both
+    // legacy events.jsonl and the new transcripts/<persona>/<date>/ path).
+    const synthesized = readEvents(dir).filter(
+      (e) => e.type === 'turn_end' && e.data.stopReason === PROCESS_DIED_STOP_REASON
+    );
+    expect(synthesized).toHaveLength(1);
+    expect(synthesized[0].turnId).toBe('turn_solo');
+  });
+});

--- a/packages/agent/src/storage/event-log.ts
+++ b/packages/agent/src/storage/event-log.ts
@@ -15,7 +15,8 @@ import {
 import { eventToRow } from './recall/event-to-row';
 import { getRecallIndex } from './recall/index-db';
 import { insertRow } from './recall/index-writer';
-import type { TypedDurableEvent } from './event-types';
+import { PROCESS_DIED_STOP_REASON, type TypedDurableEvent } from './event-types';
+import { logger } from '@lace/agent/utils/logger';
 
 /**
  * Cache: sessionDir → persona, populated on first lookup. Persona is immutable
@@ -222,6 +223,97 @@ export function hasPendingImmediateInjects(sessionDir: string, afterEventSeq: nu
       const data = parsed.data as { priority?: unknown } | undefined;
       if (data?.priority !== 'immediate') continue;
       return true;
+    } catch {
+      // ignore malformed line
+    }
+  }
+  return false;
+}
+
+/**
+ * Scan a session's durable event log and synthesize a `turn_end` event for
+ * any `turn_start` that lacks a matching `turn_end`. Called once at
+ * session-open time so the prior process's aborted turns are closed in the
+ * log before a new process can append events.
+ *
+ * Pairing is done by `turnId`. An orphan turn_start is one whose turnId never
+ * appears on a turn_end in the same transcript. For each orphan we append a
+ * `turn_end` event with `stopReason: 'process_died'` and `turnSeq` set to
+ * `orphan.turnSeq + 1`. `timestamp` is the current time (recovery time, not
+ * death time) because the death time is unknowable.
+ *
+ * Idempotent: once a synthesized turn_end is written, the next call sees the
+ * matched pair and does nothing. Guards against the unlikely-but-possible
+ * race where a turn_end already exists (e.g. another process or a future
+ * dedup layer wrote one) by re-checking just before append.
+ *
+ * Returns the count of synthesized turn_end events written.
+ */
+export function repairOrphanTurnStarts(
+  sessionDir: string,
+  state: SessionState
+): { nextState: SessionState; synthesized: number } {
+  type TurnStartFingerprint = { eventSeq: number; turnSeq: number };
+  const openTurnStarts = new Map<string, TurnStartFingerprint>();
+
+  for (const line of readAllSessionEventLines(sessionDir)) {
+    let parsed: Partial<DurableEvent>;
+    try {
+      parsed = JSON.parse(line) as Partial<DurableEvent>;
+    } catch {
+      continue;
+    }
+    const turnId = parsed.turnId;
+    if (typeof turnId !== 'string' || turnId.length === 0) continue;
+    if (parsed.type === 'turn_start') {
+      openTurnStarts.set(turnId, {
+        eventSeq: typeof parsed.eventSeq === 'number' ? parsed.eventSeq : 0,
+        turnSeq: typeof parsed.turnSeq === 'number' ? parsed.turnSeq : 0,
+      });
+    } else if (parsed.type === 'turn_end') {
+      openTurnStarts.delete(turnId);
+    }
+  }
+
+  if (openTurnStarts.size === 0) {
+    return { nextState: state, synthesized: 0 };
+  }
+
+  let currentState = state;
+  let synthesized = 0;
+
+  for (const [turnId, orphan] of openTurnStarts) {
+    // Double-check no turn_end snuck in for this turnId between the scan
+    // above and this append. Keeps the scan correct regardless of whether
+    // task #2's storage-layer dedup has landed in the tree yet.
+    if (turnEndExistsForTurnId(sessionDir, turnId)) continue;
+
+    const { nextState, written } = appendDurableEvent(sessionDir, currentState, {
+      type: 'turn_end',
+      turnId,
+      turnSeq: orphan.turnSeq + 1,
+      data: {
+        type: 'turn_end',
+        stopReason: PROCESS_DIED_STOP_REASON,
+      },
+    });
+    currentState = nextState;
+    synthesized++;
+    logger.info(
+      `crash recovery: synthesized turn_end for orphan turn_start eventSeq=${orphan.eventSeq} turnId=${turnId}`,
+      { sessionDir, orphanEventSeq: orphan.eventSeq, turnId, writtenEventSeq: written.eventSeq }
+    );
+  }
+
+  return { nextState: currentState, synthesized };
+}
+
+function turnEndExistsForTurnId(sessionDir: string, turnId: string): boolean {
+  for (const line of readAllSessionEventLines(sessionDir)) {
+    try {
+      const parsed = JSON.parse(line) as Partial<DurableEvent>;
+      if (parsed.type !== 'turn_end') continue;
+      if (parsed.turnId === turnId) return true;
     } catch {
       // ignore malformed line
     }

--- a/packages/agent/src/storage/event-types.ts
+++ b/packages/agent/src/storage/event-types.ts
@@ -43,6 +43,16 @@ export type TurnEndEventData = {
   };
 };
 
+/**
+ * Stop reason written to a synthesized `turn_end` event by
+ * `repairOrphanTurnStarts` when the prior process died (SIGKILL, OOM,
+ * container restart) between `turn_start` and the matching `turn_end`.
+ * Surfaces crash-driven turn aborts in the durable log so downstream
+ * consumers (cost accounting, compaction, UI) can distinguish them from
+ * clean terminations. See PRI-1818.
+ */
+export const PROCESS_DIED_STOP_REASON = 'process_died';
+
 export type ContextCompactedEventData = {
   type: 'context_compacted';
   strategy: string;

--- a/packages/agent/src/storage/session-store.ts
+++ b/packages/agent/src/storage/session-store.ts
@@ -6,6 +6,7 @@ import { asSessionId } from '@lace/ent-protocol';
 import {
   deriveNextEventSeqFromEventLog,
   invalidatePersonaCache,
+  repairOrphanTurnStarts,
   summarizeDurableEvents,
 } from './event-log';
 import { atomicWriteJson } from './atomic-write';
@@ -213,13 +214,33 @@ export function listSessions(cwd?: string): Array<{
     .filter((s) => (cwd ? s.cwd === cwd : true));
 }
 
-export function loadSession(sessionId: string): LoadedSession {
+/**
+ * Options for `loadSession`.
+ *
+ * `repairOrphanTurnStarts` is opt-in because `loadSession` is called both
+ * for actual session-open (cold start from disk) AND for mid-flight
+ * in-memory refreshes after a write. The crash-recovery scan must only run
+ * on a true open — synthesizing a turn_end for the active in-flight turn
+ * would corrupt the durable log. See PRI-1818.
+ */
+export type LoadSessionOptions = {
+  /**
+   * When true, scan events.jsonl for orphan turn_starts left by a prior
+   * process and synthesize a `turn_end` event with stopReason='process_died'
+   * for each. Use only at cold session-open (e.g. session/load,
+   * session/resume) before any new event is appended for this session in
+   * the current process. Default: false.
+   */
+  repairOrphanTurnStarts?: boolean;
+};
+
+export function loadSession(sessionId: string, options?: LoadSessionOptions): LoadedSession {
   const sessionDir = getSessionDir(sessionId);
   const metaPath = path.join(sessionDir, 'meta.json');
   if (!fs.existsSync(metaPath)) throw new Error('Session not found');
 
   const meta = readSessionMeta(sessionDir);
-  const state = readSessionState(sessionDir);
+  let state = readSessionState(sessionDir);
   ensureSessionFiles(sessionDir);
 
   // events.jsonl is the durable source of truth; repair state.nextEventSeq on load.
@@ -227,6 +248,20 @@ export function loadSession(sessionId: string): LoadedSession {
   if (state.nextEventSeq !== repairedNextEventSeq) {
     state.nextEventSeq = repairedNextEventSeq;
     writeSessionState(sessionDir, state);
+  }
+
+  if (options?.repairOrphanTurnStarts) {
+    // Crash recovery: if the prior process died between turn_start and turn_end
+    // (SIGKILL, OOM, container restart), synthesize a turn_end with
+    // stopReason='process_died' so the durable log honors the invariant that
+    // every turn_start has a matching turn_end. Must run BEFORE any new event
+    // is appended by the opener so the new turn's eventSeq sits after the
+    // synthesized one. See PRI-1818.
+    const repair = repairOrphanTurnStarts(sessionDir, state);
+    if (repair.synthesized > 0) {
+      state = repair.nextState;
+      writeSessionState(sessionDir, state);
+    }
   }
 
   return { meta, dir: sessionDir, state };


### PR DESCRIPTION
## Summary

When the prior process dies between `turn_start` and `turn_end` (SIGKILL, OOM, container restart), the durable log accumulates orphan `turn_start` events that violate the invariant *every turn_start has a matching turn_end*. On Ada this accounted for ~15 of the 78 unmatched turn_starts surfaced by PRI-1818.

This change scans `events.jsonl` on cold session-open and synthesizes a `turn_end` event with `stopReason: 'process_died'` for each orphan, making crash-driven aborts visible to cost accounting, compaction, and UI consumers.

## Scope

- New `repairOrphanTurnStarts(sessionDir, state)` in `storage/event-log.ts` — walks events in eventSeq order, tracks open turn_starts by `turnId`, appends a synthesized `turn_end` (`turnSeq = orphan.turnSeq + 1`, `timestamp = now`) for each leftover.
- New `PROCESS_DIED_STOP_REASON = 'process_died'` constant in `storage/event-types.ts`.
- New `LoadSessionOptions.repairOrphanTurnStarts` opt-in flag on `loadSession`. Repair runs only when set.
- `activateStoredSession` (in `rpc/handlers/session.ts`) passes `repairOrphanTurnStarts: true` — this is the only cold-open path. All other `loadSession` callers are mid-flight refreshes after writes; they must NOT repair because doing so would close the in-flight turn before it emits its real `turn_end`.

## Coordination

Companion to two sibling PRs for PRI-1818 (won't touch this code):
- #1 — `runner.ts` writes turn_end in `finally` + adds `provider_error`/`tool_error`/`internal_error` stopReasons
- #2 — `prompt.ts` catch wrapper + storage-layer dedup by turnId

This change guards against the dedup invariant landing later (or never) by re-checking that no `turn_end` exists for the turnId immediately before appending. Idempotent: re-running on a session with already-synthesized turn_ends does nothing.

## Algorithm correctness

- Multiple back-to-back orphans (process restart loop): each gets its own synthesized `turn_end`.
- Orphan that is the very last event in the file: handled by the post-walk pass.
- Timestamp is the moment of recovery, NOT the unknowable moment of death — be honest about what we know.

## Note on `loadSession` signature

The task brief said "wire into `loadSession` so it runs ONCE before any new event gets appended." Implementing that literally broke `durable-events.test.ts` and 3 `agent-process.e2e.test.ts` cases because `loadSession` is called both for cold opens AND as a mid-flight in-memory state refresh after writes (24 call sites). The repair must NOT run for the latter — synthesizing a `turn_end` for the active in-flight turn would corrupt the log. Opt-in flag + explicit wiring at the actual session-open path is the smallest correct fix.

## Test plan

- [x] New test file: `packages/agent/src/storage/__tests__/repair-orphan-turn-starts.test.ts` — 8 cases covering single orphan, three back-to-back orphans, clean session no-op, orphan-as-last-event, idempotency, no-events sessions, malformed-line tolerance, AND the safety-invariant test that default `loadSession()` does NOT repair.
- [x] Full storage suite passes (10 files, 182 tests).
- [x] `durable-events.test.ts` + `agent-process.e2e.test.ts` (15 cases) pass cleanly under the change — confirms the in-flight gate works.
- [x] `npm run lint --workspace=packages/agent` clean on changed files.
- [x] `npm run typecheck --workspace=packages/agent` clean.
- [x] `npm run build --workspace=packages/agent` clean.

Linear: PRI-1818