### PR TITLE
feat(compact): default ent/session/compact strategy to summarize (PRI-1824)

### DIFF
--- a/packages/agent/src/rpc/handlers/__tests__/session-operations.compact-default.test.ts
+++ b/packages/agent/src/rpc/handlers/__tests__/session-operations.compact-default.test.ts
@@ -1,0 +1,170 @@
+// ABOUTME: Regression test that ent/session/compact defaults to the 'summarize'
+// ABOUTME: strategy when the caller omits `strategy` (PRI-1824). Truncate is a
+// ABOUTME: near-no-op on prose-heavy sessions, so the default must be summarize.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, appendFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
+import { createNdjsonStdioTransport, JsonRpcPeer } from '@lace/ent-protocol';
+import { createAgentServerState, registerAgentRpcMethods } from '../../../server';
+import { defaultInitializeParams } from '../../../__tests__/helpers/initialize';
+import { AIProvider } from '@lace/agent/providers/base-provider';
+import { SUMMARIZER_SYSTEM_PROMPT } from '@lace/agent/compaction/summarize-strategy';
+import { getSessionDir } from '@lace/agent/storage/session-store';
+
+function createPairedPeers(register: (peer: JsonRpcPeer) => void) {
+  const aToB = new PassThrough();
+  const bToA = new PassThrough();
+
+  const clientTransport = createNdjsonStdioTransport({ readable: bToA, writable: aToB });
+  const serverTransport = createNdjsonStdioTransport({ readable: aToB, writable: bToA });
+
+  const client = new JsonRpcPeer(clientTransport, { idPrefix: 'c_' });
+  const server = new JsonRpcPeer(serverTransport, { idPrefix: 'a_' });
+  register(server);
+
+  return { client, server };
+}
+
+function writeMinimalConversation(sessionDir: string): void {
+  const eventsPath = join(sessionDir, 'events.jsonl');
+
+  const events = [
+    {
+      eventSeq: 0,
+      timestamp: new Date().toISOString(),
+      type: 'system_prompt_set',
+      data: { text: 'You are a test assistant.' },
+    },
+    ...Array.from({ length: 12 }, (_, i) => [
+      {
+        eventSeq: 1 + i * 2,
+        timestamp: new Date().toISOString(),
+        type: 'message',
+        data: { role: 'user', content: `User message ${i}` },
+      },
+      {
+        eventSeq: 2 + i * 2,
+        timestamp: new Date().toISOString(),
+        type: 'message',
+        data: { role: 'assistant', content: `Assistant reply ${i}` },
+      },
+    ]).flat(),
+  ];
+
+  for (const event of events) {
+    appendFileSync(eventsPath, JSON.stringify(event) + '\n', { encoding: 'utf8' });
+  }
+}
+
+describe('ent/session/compact — default strategy (PRI-1824)', () => {
+  let originalLaceDir: string | undefined;
+  let originalTestProvider: string | undefined;
+  let tempDir: string;
+  let workDir: string;
+
+  beforeEach(() => {
+    originalLaceDir = process.env.LACE_DIR;
+    originalTestProvider = process.env.LACE_AGENT_TEST_PROVIDER;
+
+    tempDir = mkdtempSync(join(tmpdir(), 'lace-compact-default-test-'));
+    workDir = mkdtempSync(join(tmpdir(), 'lace-compact-default-wd-'));
+    process.env.LACE_DIR = tempDir;
+    process.env.LACE_AGENT_TEST_PROVIDER = '1';
+  });
+
+  afterEach(() => {
+    if (originalLaceDir === undefined) delete process.env.LACE_DIR;
+    else process.env.LACE_DIR = originalLaceDir;
+
+    if (originalTestProvider === undefined) delete process.env.LACE_AGENT_TEST_PROVIDER;
+    else process.env.LACE_AGENT_TEST_PROVIDER = originalTestProvider;
+
+    rmSync(tempDir, { recursive: true, force: true });
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('defaults to summarize when strategy is omitted', async () => {
+    // setSystemPrompt(SUMMARIZER_SYSTEM_PROMPT) is only invoked on the summarize
+    // path. Spying on it lets us prove the default reaches summarize without
+    // depending on any particular wire enum string.
+    const setSystemPromptSpy = vi.spyOn(AIProvider.prototype, 'setSystemPrompt');
+
+    const state = createAgentServerState();
+    const { client, server } = createPairedPeers((peer) => registerAgentRpcMethods(peer, state));
+
+    try {
+      await client.request('initialize', defaultInitializeParams());
+      const newResult = (await client.request('session/new', { cwd: workDir, mcpServers: [] })) as {
+        sessionId: string;
+      };
+
+      const sessionDir = getSessionDir(newResult.sessionId);
+      writeMinimalConversation(sessionDir);
+
+      setSystemPromptSpy.mockClear();
+
+      // No `strategy` field — exercise the default path.
+      await client.request('ent/session/compact', {
+        preserveRecent: 0,
+      });
+
+      expect(setSystemPromptSpy).toHaveBeenCalledWith(SUMMARIZER_SYSTEM_PROMPT);
+    } finally {
+      setSystemPromptSpy.mockRestore();
+      client.close();
+      server.close();
+    }
+  });
+
+  it('defaults to summarize when params is omitted entirely', async () => {
+    const setSystemPromptSpy = vi.spyOn(AIProvider.prototype, 'setSystemPrompt');
+
+    const state = createAgentServerState();
+    const { client, server } = createPairedPeers((peer) => registerAgentRpcMethods(peer, state));
+
+    try {
+      await client.request('initialize', defaultInitializeParams());
+      const newResult = (await client.request('session/new', { cwd: workDir, mcpServers: [] })) as {
+        sessionId: string;
+      };
+
+      const sessionDir = getSessionDir(newResult.sessionId);
+      // Write more events so preserveRecent's default (10) still leaves dropped > 0.
+      writeMinimalConversation(sessionDir);
+      // Add 8 more user/assistant pairs (24 events total here + 1 system prompt)
+      // to comfortably exceed preserveRecent=10.
+      const eventsPath = join(sessionDir, 'events.jsonl');
+      for (let i = 12; i < 20; i++) {
+        for (const ev of [
+          {
+            eventSeq: 1 + i * 2,
+            timestamp: new Date().toISOString(),
+            type: 'message',
+            data: { role: 'user', content: `User message ${i}` },
+          },
+          {
+            eventSeq: 2 + i * 2,
+            timestamp: new Date().toISOString(),
+            type: 'message',
+            data: { role: 'assistant', content: `Assistant reply ${i}` },
+          },
+        ]) {
+          appendFileSync(eventsPath, JSON.stringify(ev) + '\n', { encoding: 'utf8' });
+        }
+      }
+
+      setSystemPromptSpy.mockClear();
+
+      await client.request('ent/session/compact');
+
+      expect(setSystemPromptSpy).toHaveBeenCalledWith(SUMMARIZER_SYSTEM_PROMPT);
+    } finally {
+      setSystemPromptSpy.mockRestore();
+      client.close();
+      server.close();
+    }
+  });
+});

--- a/packages/agent/src/rpc/handlers/session-operations.ts
+++ b/packages/agent/src/rpc/handlers/session-operations.ts
@@ -441,12 +441,15 @@ export function registerSessionOperationHandlers(
       throwInvalidParams('strategy must be summarize|truncate|selective');
     }
 
+    // Default to 'summarize' (PRI-1824). 'truncate' only crops TOOL_RESULT
+    // text and reclaims ~10% of context on prose-heavy sessions, so making it
+    // the default was a near-no-op for callers that don't specify a strategy.
     const strategy =
       parsed?.strategy === 'summarize' ||
       parsed?.strategy === 'truncate' ||
       parsed?.strategy === 'selective'
         ? parsed.strategy
-        : 'truncate';
+        : 'summarize';
 
     const targetTokens =
       typeof parsed?.targetTokens === 'number' &&


### PR DESCRIPTION
## Summary

- Default `ent/session/compact` strategy from `'truncate'` to `'summarize'` in `packages/agent/src/rpc/handlers/session-operations.ts`. Truncate only crops TOOL_RESULT text blocks and reclaims ~10% of context on prose-heavy sessions, so the previous default was effectively a no-op for any caller that didn't pass `strategy` explicitly.
- Adds regression tests at `packages/agent/src/rpc/handlers/__tests__/session-operations.compact-default.test.ts` covering both `{ }` and entirely-omitted params shapes; assertion spies on `setSystemPrompt(SUMMARIZER_SYSTEM_PROMPT)` which is only invoked on the summarize path.

## Rationale

Evidence on Ada's main session (eventSeq 1581): a default-strategy call with `messagesCompacted:1166` left `preserved.length:1110` — essentially the same conversation with cropped tool outputs — and bounced back to 600K tokens within 12 turns. See [PRI-1824](https://linear.app/prime-radiant/issue/PRI-1824) and the strategy audit at `sen2/compaction/scratch/strategy-audit/` (and PRI-1819 comments) for full trajectory data.

## Callers audited

All in-tree callers already pass `strategy` explicitly, so this only affects callers that were depending on the default — and they were depending on a no-op:

- `sen-core-v2/src/turn-hooks/compaction-trigger.ts` — passes `'truncate'` or `'summarize'`
- `sen-core-v2/src/rotation/runner.ts` — passes `'summarize'`
- `lace/packages/agent/src/conversation/slash-commands.ts` — passes strategy via slash command
- All test callers (`agent-process.e2e.test.ts`, `ent-protocol.spec.ts`, `session-operations.compact-budget.test.ts`, `session-operations.compact-prompt.test.ts`) pass strategy explicitly

## Coordination

Independent of PRI-1825 (rename `truncate` → `trim-tool-results`). This change touches only the default value, not the wire enum names. If both land, the new default becomes `'summarize'` and the old `'truncate'` enum slot is renamed/removed by PRI-1825.

## Test plan

- [x] `npm run typecheck --workspace=packages/agent` — clean
- [x] `npm run build --workspace=packages/agent` — clean
- [x] New tests fail RED on origin/main (verified before implementing fix)
- [x] New tests pass GREEN with the change
- [x] Compaction-related tests pass (40/40):
      `session-operations.compact-default.test.ts`,
      `session-operations.compact-prompt.test.ts`,
      `session-operations.compact-budget.test.ts`,
      `agent-process.e2e.test.ts` (compact truncate + compact summarize),
      `ent-protocol.spec.ts` (invalid strategy validation)
- [x] Full agent suite: 2851 passed, 6 pre-existing failures (Apple container integration + session-fork.durable-history) confirmed present on origin/main — unrelated
- [ ] `npm run lint --workspace=packages/agent` — 58 pre-existing errors on origin/main, none introduced by this change (verified by re-running lint on origin/main and on the two files touched by this PR)