### PR TITLE
feat(compact): rename wire strategy 'truncate' to 'trim-tool-results' (PRI-1825)

### DIFF
--- a/packages/agent/src/__tests__/agent-process.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.e2e.test.ts
@@ -872,7 +872,7 @@ describe('lace-agent process (E2E over stdio)', () => {
   );
 
   it(
-    'supports ent/session/compact truncate and trims tool results in provider context',
+    'supports ent/session/compact trim-tool-results and trims tool results in provider context',
     { timeout: 15_000 },
     async () => {
       ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
@@ -903,7 +903,10 @@ describe('lace-agent process (E2E over stdio)', () => {
       );
 
       const compact = (await withTimeout(
-        ctx.agent.peer.request('ent/session/compact', { strategy: 'truncate', preserveRecent: 0 }),
+        ctx.agent.peer.request('ent/session/compact', {
+          strategy: 'trim-tool-results',
+          preserveRecent: 0,
+        }),
         2_000,
         'ent/session/compact'
       )) as { messagesCompacted: number };

--- a/packages/agent/src/rpc/handlers/__tests__/session-operations.compact-budget.test.ts
+++ b/packages/agent/src/rpc/handlers/__tests__/session-operations.compact-budget.test.ts
@@ -114,7 +114,7 @@ describe('ent/session/compact — systemPrompt token inclusion (PRI-1799 Task 4)
       writeConversationWithLargeSystemPrompt(sessionDir, systemPromptText);
 
       const response = (await client.request('ent/session/compact', {
-        strategy: 'truncate',
+        strategy: 'trim-tool-results',
         // preserveRecent:0 to maximise dropped messages; avoids needing a real LLM.
         preserveRecent: 0,
       })) as { previousTokens: number; currentTokens: number; messagesCompacted: number };
@@ -161,7 +161,7 @@ describe('ent/session/compact — systemPrompt token inclusion (PRI-1799 Task 4)
       writeConversationWithLargeSystemPrompt(sessionDir, systemPromptText);
 
       const response = (await client.request('ent/session/compact', {
-        strategy: 'truncate',
+        strategy: 'trim-tool-results',
         preserveRecent: 0,
       })) as { previousTokens: number; currentTokens: number; messagesCompacted: number };
 

--- a/packages/agent/src/rpc/handlers/session-operations.ts
+++ b/packages/agent/src/rpc/handlers/session-operations.ts
@@ -426,7 +426,7 @@ export function registerSessionOperationHandlers(
 
     const parsed = params as
       | {
-          strategy?: 'summarize' | 'truncate' | 'selective';
+          strategy?: 'summarize' | 'trim-tool-results' | 'selective';
           targetTokens?: number;
           preserveRecent?: number;
         }
@@ -435,10 +435,10 @@ export function registerSessionOperationHandlers(
     if (
       parsed?.strategy &&
       parsed.strategy !== 'summarize' &&
-      parsed.strategy !== 'truncate' &&
+      parsed.strategy !== 'trim-tool-results' &&
       parsed.strategy !== 'selective'
     ) {
-      throwInvalidParams('strategy must be summarize|truncate|selective');
+      throwInvalidParams('strategy must be summarize|trim-tool-results|selective');
     }
 
     // Default to 'summarize' (PRI-1824). 'truncate' only crops TOOL_RESULT
@@ -446,7 +446,7 @@ export function registerSessionOperationHandlers(
     // the default was a near-no-op for callers that don't specify a strategy.
     const strategy =
       parsed?.strategy === 'summarize' ||
-      parsed?.strategy === 'truncate' ||
+      parsed?.strategy === 'trim-tool-results' ||
       parsed?.strategy === 'selective'
         ? parsed.strategy
         : 'summarize';
@@ -496,7 +496,7 @@ export function registerSessionOperationHandlers(
       let summary: string | undefined;
 
       if (dropped.length > 0) {
-        if (strategy === 'truncate') {
+        if (strategy === 'trim-tool-results') {
           const result = await compactDroppedMessagesWithCore({
             strategyId: 'trim-tool-results',
             dropped,

--- a/packages/ent-protocol/src/schemas/methods.ts
+++ b/packages/ent-protocol/src/schemas/methods.ts
@@ -750,7 +750,7 @@ export const EntAgentStatusResponseSchema = z
 
 const EntSessionCompactParamsSchema = z
   .object({
-    strategy: z.enum(['summarize', 'truncate', 'selective']).optional(),
+    strategy: z.enum(['summarize', 'trim-tool-results', 'selective']).optional(),
     targetTokens: z.number().optional(),
     preserveRecent: z.number().optional(),
   })


### PR DESCRIPTION
## Summary

The RPC strategy enum at `ent/session/compact` accepted `'truncate'` and dispatched it to the `trim-tool-results` registry strategy. The wire name actively misled callers — the strategy doesn't drop messages, it trims TOOL_RESULT text blocks to 3 lines. Rename the wire enum to match the internal strategy ID.

- Updates `EntSessionCompactParamsSchema` in `@lace/ent-protocol`
- Updates the dispatch + default in `session-operations.ts`
- Updates the two tests that hardcoded the wire name (`agent-process.e2e`, `session-operations.compact-budget`)
- Hard rename, no back-compat alias (pre-release v1, internal protocol)

[Linear: PRI-1825](https://linear.app/prime-radiant/issue/PRI-1825)

## Coordination

Paired sen-core-v2 PR: https://github.com/prime-radiant-inc/sen-core-v2/pull/1

**Deploy order: merge this lace PR first, deploy lace, then merge the sen-core PR.** The sen-core caller currently passes `strategy: 'truncate'`; that call returns `InvalidParams` from the moment this PR lands until the sen-core PR is deployed. For Ada, this is a brief window during the rolling upgrade only.

## Test plan

- [x] `npm run typecheck --workspace=packages/ent-protocol`
- [x] `npm run typecheck --workspace=packages/agent`
- [x] `npm run build --workspace=packages/agent`
- [x] `npx vitest run src/rpc src/compaction` (59 passed)
- [x] `npx vitest run src/__tests__/agent-process.e2e.test.ts -t "compact"` (2 passed)
- [ ] Verify after deploy: `ent/session/compact { strategy: 'trim-tool-results' }` succeeds on Ada