### PR TITLE
test: rename ephemeral-shell persona fixtures → ephemeral-box

### DIFF
--- a/packages/agent/src/containers/plane-runtime.test.ts
+++ b/packages/agent/src/containers/plane-runtime.test.ts
@@ -52,7 +52,7 @@ function makeFakeChild(): FakeChild {
 
 function spawnRequest(extra: Partial<PlaneSpawnRequest> = {}): PlaneSpawnRequest {
   return {
-    persona: 'ephemeral-shell',
+    persona: 'ephemeral-box',
     role: 'ephemeral-box-worker',
     parentSession: 'sess_parent',
     childSession: 'sess_child',
@@ -78,7 +78,7 @@ describe('PlaneRuntime', () => {
 
     expect(run).toHaveBeenCalledWith([
       'spawn',
-      'ephemeral-shell',
+      'ephemeral-box',
       'sess_parent',
       'sess_child',
       'job_1',
@@ -96,7 +96,7 @@ describe('PlaneRuntime', () => {
     const rt = new PlaneRuntime('/bin/sen-docker-client', { run });
 
     await rt.create({
-      persona: 'ephemeral-shell',
+      persona: 'ephemeral-box',
       role: 'ephemeral-box-worker',
       parentSessionId: 'sess_parent',
       childSessionId: 'sess_child',
@@ -108,7 +108,7 @@ describe('PlaneRuntime', () => {
 
     expect(run).toHaveBeenCalledWith([
       'spawn',
-      'ephemeral-shell',
+      'ephemeral-box',
       'sess_parent',
       'sess_child',
       'job_1',
@@ -146,7 +146,7 @@ describe('PlaneRuntime', () => {
 
     await expect(
       rt.create({
-        persona: 'ephemeral-shell',
+        persona: 'ephemeral-box',
         parentSession: 'sess_parent',
         childSession: 'sess_child',
         jobId: 'job_1',
@@ -163,7 +163,7 @@ describe('PlaneRuntime', () => {
     const rt = new PlaneRuntime('/bin/sen-docker-client', { run });
 
     await rt.create({
-      persona: 'ephemeral-shell',
+      persona: 'ephemeral-box',
       role: 'ephemeral-box-worker',
       parentSession: 'sess_parent',
       childSession: 'sess_child',
@@ -171,7 +171,7 @@ describe('PlaneRuntime', () => {
 
     expect(run).toHaveBeenCalledWith([
       'spawn',
-      'ephemeral-shell',
+      'ephemeral-box',
       'sess_parent',
       'sess_child',
       'job_child',
@@ -235,7 +235,7 @@ describe('PlaneRuntime', () => {
 
     expect(run).toHaveBeenCalledWith([
       'spawn',
-      'ephemeral-shell',
+      'ephemeral-box',
       'sess_parent',
       'sess_child',
       'job_1',

--- a/packages/agent/src/tools/runtime/__tests__/validation.test.ts
+++ b/packages/agent/src/tools/runtime/__tests__/validation.test.ts
@@ -222,7 +222,7 @@ describe('runtime binding validation', () => {
     expect(() =>
       parseRuntimeExecutionBinding(
         containerBinding({
-          persona: 'ephemeral-shell',
+          persona: 'ephemeral-box',
           parentSessionId: 'sess_parent00112233',
           childSessionId: 'sess_child00112233',
           ports: [{ host: 7777, container: 7777 }],

--- a/packages/agent/src/tools/runtime/validation.test.ts
+++ b/packages/agent/src/tools/runtime/validation.test.ts
@@ -27,14 +27,14 @@ describe('parseRuntimeExecutionBinding — selector-field completeness (bug-#7 g
   it('accepts a container binding carrying all four selector fields', () => {
     const b = parseRuntimeExecutionBinding(
       containerBinding({
-        persona: 'ephemeral-shell',
+        persona: 'ephemeral-box',
         parentSession: 'sess_p',
         childSession: 'sess_c',
         jobId: 'job_x',
       })
     );
     const spec = (b.toolRuntime as { type: 'container'; spec: Record<string, unknown> }).spec;
-    expect(spec.persona).toBe('ephemeral-shell');
+    expect(spec.persona).toBe('ephemeral-box');
     expect(spec.parentSession).toBe('sess_p');
     expect(spec.childSession).toBe('sess_c');
     expect(spec.jobId).toBe('job_x');


### PR DESCRIPTION
Test-only. Updates arbitrary persona-selector fixtures (lace is persona-agnostic) to match the renamed environment/image in sen-core. No runtime/source change — `spawn-broker-personas` source was already removed in the decoupling; only `.test.ts` fixtures carried the dead `ephemeral-shell` string.

Companion to prime-radiant-inc/sen-core-v2#9.

Tests: 59 changed-file tests pass.