### PR TITLE
tools: document read-before-edit + sync bash timeout (agent self-doc)

### DIFF
--- a/packages/agent/src/tools/implementations/bash.ts
+++ b/packages/agent/src/tools/implementations/bash.ts
@@ -50,7 +50,8 @@ Parameters:
 When background=true, returns { jobId, status: "started" }. Use job_output(jobId) to check status/output.
 Background jobs send completion notifications automatically. Progress notifications are opt-in (see progressIntervalMs / job_notify).
 
-Default (sync): Blocks until complete. Output truncated to 100+50 lines. Chain with && or ;.`;
+Default (sync): Blocks until complete. Output truncated to 100+50 lines. Chain with && or ;.
+A sync command is subject to a runtime timeout (tens of seconds) and is killed if it exceeds it — for anything long-running (installs, builds, long fetches) use background=true and poll job_output(jobId).`;
   schema = bashSchema;
   annotations: ToolAnnotations = {
     title: 'Run commands with bash',

--- a/packages/agent/src/tools/implementations/file_edit.ts
+++ b/packages/agent/src/tools/implementations/file_edit.ts
@@ -45,7 +45,7 @@ export class FileEditTool extends Tool {
 
 * All edits are applied atomically - if any edit fails validation, no changes are made
 * Each edit replaces old_text with new_text exactly once by default
-* Use file_read first to see exact content, then copy text precisely
+* You MUST file_read a path before editing it — read-before-edit is enforced; an edit to an unread path fails. Read first to see exact content, then copy text precisely
 
 Notes for the edits parameter:
 * The old_text must match EXACTLY one or more consecutive lines from the file. Be mindful of whitespaces!


### PR DESCRIPTION
Two tool-description papercuts from Ada's dump: `file_edit` now states read-before-edit is *enforced* (was only advised); `bash` notes the sync runtime timeout and to use `background=true` for long-running work. Description-only; 46 tool tests green, typecheck clean.