### PR TITLE
fix: terminal job notification Slack hint + success-path inject-drain watermark

### DIFF
--- a/packages/agent/src/core/conversation/__tests__/runner.drain-on-exit.test.ts
+++ b/packages/agent/src/core/conversation/__tests__/runner.drain-on-exit.test.ts
@@ -228,6 +228,105 @@ describe('prompt handler — drain pending immediate injects on non-success exit
     }
   });
 
+  it("fires a follow-up turn when an immediate inject lands after the runner's last readNew() on the SUCCESS path", async () => {
+    // Regression test for the success-path drain gap: an inject that arrives
+    // after the runner's last readNew() call (during the final LLM round-trip)
+    // but before turn_end is written gets an eventSeq LESS than turn_end. The
+    // old drain used findLastTurnEndEventSeq (turn_end.seq) as the watermark,
+    // so inject.seq <= watermark → hasPendingImmediateInjects returned false →
+    // the inject was not delivered until the next externally-triggered turn.
+    // The fix: the runner returns lastSeenEventSeq and the prompt handler uses
+    // it as the watermark so only genuinely unprocessed injects trigger a
+    // follow-up turn.
+    const state = createAgentServerState();
+    const { client, server } = createPairedPeers((peer) => registerAgentRpcMethods(peer, state));
+
+    let followUpRuns = 0;
+    const runSpy = vi.spyOn(ConversationRunner.prototype, 'run').mockImplementation(async function (
+      this: ConversationRunner,
+      opts: { turnId: string }
+    ) {
+      if (!state.activeSession) throw new Error('test setup: no active session');
+      const sessionDir = state.activeSession.dir;
+
+      if (followUpRuns === 0) {
+        // First (original) turn: simulate the gap by writing an immediate inject
+        // BEFORE turn_end (so inject.seq < turn_end.seq), but return a
+        // lastSeenEventSeq that predates the inject (the runner never saw it).
+        const stateBeforeInject = readSessionState(sessionDir);
+        // Capture the watermark as if readNew() ran before the inject arrived.
+        const lastSeenEventSeq = stateBeforeInject.nextEventSeq - 1;
+
+        // Inject arrives mid-turn (after readNew, before turn_end).
+        injectImmediate(state, 'JOB-DONE-SUCCESS-GAP');
+
+        // Runner writes turn_end after the inject.
+        const stateAfterInject = readSessionState(sessionDir);
+        const { nextState } = realAppendDurableEvent(sessionDir, stateAfterInject, {
+          type: 'turn_end',
+          turnId: opts.turnId,
+          turnSeq: 1,
+          data: { type: 'turn_end', stopReason: 'end_turn' },
+        });
+        writeSessionState(sessionDir, nextState);
+
+        followUpRuns++;
+        return {
+          turnId: opts.turnId,
+          stopReason: 'end_turn' as const,
+          stopDetails: null,
+          content: [],
+          usage: { inputTokens: 0, outputTokens: 0 },
+          // Return the pre-inject watermark so the drain can detect the gap.
+          lastSeenEventSeq,
+        };
+      }
+
+      // Follow-up turn: write turn_end and return cleanly.
+      const sessionState = readSessionState(sessionDir);
+      const { nextState } = realAppendDurableEvent(sessionDir, sessionState, {
+        type: 'turn_end',
+        turnId: opts.turnId,
+        turnSeq: 1,
+        data: { type: 'turn_end', stopReason: 'end_turn' },
+      });
+      writeSessionState(sessionDir, nextState);
+      return {
+        turnId: opts.turnId,
+        stopReason: 'end_turn' as const,
+        stopDetails: null,
+        content: [],
+        usage: { inputTokens: 0, outputTokens: 0 },
+      };
+    });
+
+    try {
+      await client.request('initialize', defaultInitializeParams());
+      const newResult = (await client.request('session/new', {
+        cwd: workDir,
+        mcpServers: [],
+      })) as { sessionId: string };
+
+      const promptResult = (await client.request('session/prompt', {
+        content: [{ type: 'text', text: 'hello' }],
+      })) as { stopReason: string };
+      expect(promptResult.stopReason).toBe('end_turn');
+
+      // The drain must have scheduled a follow-up internal turn for the
+      // unprocessed inject that landed after the runner's last readNew().
+      await waitFor(() => runSpy.mock.calls.length >= 2);
+      expect(runSpy).toHaveBeenCalledTimes(2);
+
+      const sessionDir = getSessionDir(newResult.sessionId);
+      const { events } = readDurableEvents(sessionDir, { afterEventSeq: 0, limit: 200 });
+      const turnStarts = events.filter((e) => e.type === 'turn_start');
+      expect(turnStarts.length).toBe(2);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+
   it('does NOT fire a follow-up turn on a clean success with no pending inject', async () => {
     const state = createAgentServerState();
     const { client, server } = createPairedPeers((peer) => registerAgentRpcMethods(peer, state));

--- a/packages/agent/src/core/conversation/runner.ts
+++ b/packages/agent/src/core/conversation/runner.ts
@@ -1377,6 +1377,7 @@ export class ConversationRunner {
         costUsd: turnCostUsd,
       },
       ...(lastStructuredOutput !== undefined ? { structuredOutput: lastStructuredOutput } : {}),
+      lastSeenEventSeq,
     };
   }
 

--- a/packages/agent/src/core/conversation/types.ts
+++ b/packages/agent/src/core/conversation/types.ts
@@ -313,4 +313,13 @@ export interface RunResult {
    * requested or the response text could not be parsed.
    */
   structuredOutput?: unknown;
+  /**
+   * The highest `eventSeq` seen by the runner's inject tailer at the end of
+   * the turn. The prompt handler uses this as the watermark for the
+   * success-path inject drain: any inject with `eventSeq > lastSeenEventSeq`
+   * arrived after the runner's last `readNew()` call (during the final LLM
+   * round-trip) and was not incorporated into this turn's messages. Absent
+   * on synthesised mock RunResults in tests.
+   */
+  lastSeenEventSeq?: number;
 }

--- a/packages/agent/src/notifications/__tests__/composers.test.ts
+++ b/packages/agent/src/notifications/__tests__/composers.test.ts
@@ -21,7 +21,7 @@ describe('composers', () => {
         lastLines: ['build finished in 5.2s'],
       })
     ).toBe(
-      'Your background job completed successfully (exit code 0) after 12.3 seconds, writing 15,234 bytes of output. The last line was: "build finished in 5.2s". Call job_output(jobId="job_xyz") to read the full output.'
+      'Your background job completed successfully (exit code 0) after 12.3 seconds, writing 15,234 bytes of output. The last line was: "build finished in 5.2s". Call job_output(jobId="job_xyz") to read the full output. If this result is relevant to an active Slack thread, post an update before ending this turn.'
     );
   });
 
@@ -103,6 +103,47 @@ describe('composers', () => {
     });
     expect(body).not.toContain('Last line');
     expect(body).toContain('Call job_output');
+  });
+
+  it('job-completed: includes Slack follow-up hint', () => {
+    const body = composeJobCompletedBody({
+      jobId: 'job_xyz',
+      jobType: 'bash',
+      exitCode: 0,
+      durationMs: 1000,
+      outputBytes: 100,
+      lastLines: [],
+    });
+    expect(body).toContain(
+      'If this result is relevant to an active Slack thread, post an update before ending this turn.'
+    );
+  });
+
+  it('job-failed: includes Slack follow-up hint', () => {
+    const body = composeJobFailedBody({
+      jobId: 'job_q',
+      jobType: 'bash',
+      exitCode: 1,
+      durationMs: 1000,
+      outputBytes: 100,
+      lastLines: [],
+    });
+    expect(body).toContain(
+      'If this result is relevant to an active Slack thread, post an update before ending this turn.'
+    );
+  });
+
+  it('job-cancelled: includes Slack follow-up hint', () => {
+    const body = composeJobCancelledBody({
+      jobId: 'job_q',
+      jobType: 'bash',
+      durationMs: 1000,
+      outputBytes: 50,
+      lastLines: [],
+    });
+    expect(body).toContain(
+      'If this result is relevant to an active Slack thread, post an update before ending this turn.'
+    );
   });
 
   it('job-progress: omits "Recent output:" block when lastLines is empty', () => {

--- a/packages/agent/src/notifications/composers.ts
+++ b/packages/agent/src/notifications/composers.ts
@@ -1,6 +1,12 @@
 // ABOUTME: Pure body-composer functions for each notification kind. No side effects.
 // ABOUTME: Output strings are wrapped by buildNotification in inject-notification.ts.
 
+// Reminder appended to every terminal-state job notification (completed, failed,
+// cancelled). Prompts the agent to close the loop on any active Slack thread
+// before ending its turn.
+const TERMINAL_JOB_SLACK_HINT =
+  ' If this result is relevant to an active Slack thread, post an update before ending this turn.';
+
 const MAX_LINE_LENGTH = 200;
 
 function formatDuration(ms: number): string {
@@ -29,7 +35,7 @@ export interface JobCompletedCompose {
 
 export function composeJobCompletedBody(j: JobCompletedCompose): string {
   const trailing = trailingLineHint(j.lastLines);
-  const base = `Your background job completed successfully (exit code ${j.exitCode}) after ${formatDuration(j.durationMs)}, writing ${formatBytes(j.outputBytes)} bytes of output.${trailing} Call job_output(jobId="${j.jobId}") to read the full output.`;
+  const base = `Your background job completed successfully (exit code ${j.exitCode}) after ${formatDuration(j.durationMs)}, writing ${formatBytes(j.outputBytes)} bytes of output.${trailing} Call job_output(jobId="${j.jobId}") to read the full output.${TERMINAL_JOB_SLACK_HINT}`;
   if (j.jobType === 'delegate') {
     return `${base} To continue this conversation thread, call delegate(resume="${j.jobId}", prompt="your message").`;
   }
@@ -40,7 +46,7 @@ export type JobFailedCompose = JobCompletedCompose;
 
 export function composeJobFailedBody(j: JobFailedCompose): string {
   const trailing = trailingLineHint(j.lastLines);
-  const base = `Your background job failed (exit code ${j.exitCode}) after ${formatDuration(j.durationMs)}, writing ${formatBytes(j.outputBytes)} bytes of output.${trailing} Call job_output(jobId="${j.jobId}") to read the full output.`;
+  const base = `Your background job failed (exit code ${j.exitCode}) after ${formatDuration(j.durationMs)}, writing ${formatBytes(j.outputBytes)} bytes of output.${trailing} Call job_output(jobId="${j.jobId}") to read the full output.${TERMINAL_JOB_SLACK_HINT}`;
   if (j.jobType === 'delegate') {
     return `${base} To continue this conversation thread, call delegate(resume="${j.jobId}", prompt="your message").`;
   }
@@ -59,7 +65,7 @@ export interface JobCancelledCompose {
 export function composeJobCancelledBody(j: JobCancelledCompose): string {
   const trailing = trailingLineHint(j.lastLines);
   const reasonText = j.reason ? ` Reason: ${j.reason}.` : '';
-  return `Your background job was cancelled after ${formatDuration(j.durationMs)}, having written ${formatBytes(j.outputBytes)} bytes of output.${reasonText}${trailing} Call job_output(jobId="${j.jobId}") to read the full output.`;
+  return `Your background job was cancelled after ${formatDuration(j.durationMs)}, having written ${formatBytes(j.outputBytes)} bytes of output.${reasonText}${trailing} Call job_output(jobId="${j.jobId}") to read the full output.${TERMINAL_JOB_SLACK_HINT}`;
 }
 
 export interface JobProgressCompose {

--- a/packages/agent/src/rpc/handlers/prompt.ts
+++ b/packages/agent/src/rpc/handlers/prompt.ts
@@ -536,19 +536,24 @@ export function registerPromptHandler(
       state.activeTurn = null;
       ownsActiveTurn = false;
 
-      // Bug 3 fix: catch immediate-inject events that landed in the closing
-      // microseconds of the turn (after the runner's last iteration but before
-      // turn_end). The setImmediate-based wake in injectNotification's
-      // triggerInternalTurn callback can no-op if it observes state.activeTurn=true
-      // before the turn ends, then the turn ends with the event unprocessed.
-      // We re-scan here, after activeTurn is cleared, and fire a synthetic
-      // internal turn if anything is waiting. The runner already consumed every
-      // inject up to the turn_end it just wrote, so the watermark is that
-      // turn_end's eventSeq.
+      // Catch immediate-inject events that landed after the runner's last
+      // readNew() call (during the final LLM round-trip) but before turn_end
+      // was written. The setImmediate-based idleWake in injectNotification
+      // no-ops while state.activeTurn is set, leaving those events unprocessed.
+      // We re-scan here, after activeTurn is cleared.
+      //
+      // Watermark: use the runner's lastSeenEventSeq — the highest eventSeq its
+      // inject tailer observed — so only genuinely unprocessed injects trigger a
+      // follow-up turn. Falling back to findLastTurnEndEventSeq (the prior
+      // approach) used the turn_end's seq as the watermark, which is HIGHER than
+      // any inject that arrived before turn_end; those injects would compare as
+      // seq <= watermark and be silently skipped even though the runner never saw
+      // them.
       scheduleImmediateInjectDrain(
         state,
         runPromptInternalRef,
-        state.activeSession ? (findLastTurnEndEventSeq(state.activeSession.dir) ?? 0) : 0
+        result.lastSeenEventSeq ??
+          (state.activeSession ? (findLastTurnEndEventSeq(state.activeSession.dir) ?? 0) : 0)
       );
 
       // RPC response uses the protocol-shaped usage.


### PR DESCRIPTION
Two independent fixes for the proactive wake triggered when a background/delegate job reaches terminal state.

## Fix 1 — Slack follow-up hint in all terminal job notifications

**Problem:** When a background job completes, fails, or is cancelled, lace fires a proactive internal turn to deliver the notification. The agent has no explicit prompt to close the loop on an active Slack thread in that same turn, so it routinely stops without posting an update.

**Change:** Add a shared constant `TERMINAL_JOB_SLACK_HINT` in `composers.ts` and append it to every terminal-state body (`composeJobCompletedBody`, `composeJobFailedBody`, `composeJobCancelledBody`). Progress notifications are unaffected — they carry ongoing status, not a final result.

The appended text reads:
> If this result is relevant to an active Slack thread, post an update before ending this turn.

**Files:** `packages/agent/src/notifications/composers.ts`, `…/__tests__/composers.test.ts`
**Tests added:** three containment assertions (one per terminal kind) + updated exact-match snapshot for `job-completed`.

## Fix 2 — Success-path inject-drain uses runner's `lastSeenEventSeq` as watermark

**Problem (reproduced):** The turn-end drain at `prompt.ts:scheduleImmediateInjectDrain` used `findLastTurnEndEventSeq` as its watermark. A `context_injected` (priority=`immediate`) event that arrived *after* the runner's last `readNew()` call — during the final LLM round-trip — but *before* `turn_end` was written would have:

```
inject.eventSeq  <  turn_end.eventSeq
```

Because the watermark was `turn_end.eventSeq`, `hasPendingImmediateInjects` returned `false` and the inject was silently deferred — the proactive follow-up turn never fired, and the agent only learned of the completed job on the next externally-triggered turn.

The abort/error/slash drain paths were already correct (they use `preTurnInjectWatermark`, which predates every inject that arrived during the turn). Only the **success path** was broken.

**Fix:** Add `lastSeenEventSeq` to `RunResult` — the highest `eventSeq` the runner's `InjectTailer` observed. The prompt handler uses this as the success-path drain watermark. Any inject with `seq > lastSeenEventSeq` genuinely was not seen by the runner and triggers a follow-up internal turn. The fallback (`findLastTurnEndEventSeq`) is kept for synthesised `RunResult`s in tests that don't set the field.

**Files:** `packages/agent/src/core/conversation/types.ts`, `…/runner.ts`, `packages/agent/src/rpc/handlers/prompt.ts`, `…/__tests__/runner.drain-on-exit.test.ts`
**Test added:** `'fires a follow-up turn when an immediate inject lands after the runner's last readNew() on the SUCCESS path'` — spies on `ConversationRunner.run()`, writes an inject before `turn_end` in the mock, returns a `lastSeenEventSeq` that predates the inject, and asserts the prompt handler schedules a second internal turn. Confirmed fails against pre-fix code.

## Checklist
- [x] `tsc --noEmit` passes
- [x] `biome check` passes on changed files
- [x] `composers.test.ts` — all tests pass (Fix 1)
- [x] `runner.drain-on-exit.test.ts` — all tests pass (Fix 2, includes fail-before/pass-after test)
