### PR TITLE
fix(providers): treat SDK connection errors as retryable

### DIFF
--- a/packages/agent/src/providers/__tests__/base-provider.test.ts
+++ b/packages/agent/src/providers/__tests__/base-provider.test.ts
@@ -5,6 +5,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ProviderMessage, ProviderResponse } from '../base-provider';
 import { Tool } from '@lace/agent/tools/tool';
 import { BaseMockProvider } from '@lace/agent/test-utils/base-mock-provider';
+import {
+  APIConnectionError,
+  APIConnectionTimeoutError,
+  AuthenticationError,
+} from '@anthropic-ai/sdk';
 
 // Mock implementation for testing
 class TestProvider extends BaseMockProvider {
@@ -78,6 +83,53 @@ describe('AIProvider retry functionality', () => {
       networkErrors.forEach((error) => {
         expect(provider.isRetryableError(error)).toBe(true);
       });
+    });
+
+    it('should identify a real SDK connection error as retryable', () => {
+      // Built from the real SDK class, not a hand-rolled lookalike: the shape is
+      // the whole point. APIConnectionError carries NO status and NO code, and
+      // its `.name` is plain "Error" — only `constructor.name` identifies it.
+      // The underlying ECONNREFUSED sits on `.cause`. Classifying this as
+      // permanent meant a transient blip failed a turn outright: during a real
+      // outage the credential arbiter logged `maxAttempts: 10` and gave up after
+      // attempt 1, every single time.
+      const sdkConnectionError = new APIConnectionError({
+        message: undefined,
+        cause: Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:9999'), {
+          code: 'ECONNREFUSED',
+        }),
+      });
+
+      expect(sdkConnectionError.name).toBe('Error');
+      expect(sdkConnectionError.status).toBeUndefined();
+      expect(provider.isRetryableError(sdkConnectionError)).toBe(true);
+    });
+
+    it('should identify a real SDK connection timeout as retryable', () => {
+      // APIConnectionTimeoutError extends APIConnectionError and arrives with no
+      // cause at all, so a cause-code check alone would miss it.
+      const sdkTimeout = new APIConnectionTimeoutError({});
+
+      expect(sdkTimeout.cause).toBeUndefined();
+      expect(provider.isRetryableError(sdkTimeout)).toBe(true);
+    });
+
+    it('should still refuse to retry an abort', () => {
+      // An abort is deliberate — it must not be resurrected by the connection
+      // classification above, even though it is also a transport-level failure.
+      const aborted = Object.assign(new Error('Aborted'), {
+        name: 'AbortError',
+        cause: Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }),
+      });
+
+      expect(provider.isRetryableError(aborted)).toBe(false);
+    });
+
+    it('should not retry an SDK auth error just because it came from the SDK', () => {
+      // A 401 is a real decision from the API and must stay permanent.
+      const authError = new AuthenticationError(401, { message: 'bad key' }, 'bad key', undefined);
+
+      expect(provider.isRetryableError(authError)).toBe(false);
     });
 
     it('should identify HTTP 5xx errors as retryable', () => {

--- a/packages/agent/src/providers/base-provider.ts
+++ b/packages/agent/src/providers/base-provider.ts
@@ -685,19 +685,36 @@ export abstract class AIProvider extends EventEmitter {
     }
 
     // Check for network errors (Node.js error codes)
+    const retryableCodes = ['ECONNREFUSED', 'ENOTFOUND', 'ETIMEDOUT', 'ECONNRESET', 'EHOSTUNREACH'];
     if (err.code) {
-      const retryableCodes = [
-        'ECONNREFUSED',
-        'ENOTFOUND',
-        'ETIMEDOUT',
-        'ECONNRESET',
-        'EHOSTUNREACH',
-      ];
       if (typeof err.code === 'string' && retryableCodes.includes(err.code)) {
         return true;
       }
       // Check for rate_limit_exceeded code (OpenAI SDK)
       if (err.code === 'rate_limit_exceeded') {
+        return true;
+      }
+    }
+
+    // The Anthropic and OpenAI SDKs both wrap a transport failure in
+    // `APIConnectionError`, constructed with NO status and NO code — the real
+    // ECONNREFUSED/ECONNRESET sits on `.cause`. Neither the code check above nor
+    // the status check below sees it, so the single most retryable failure class
+    // there is was classified as permanent: one blip failed a turn outright,
+    // with the retry log reporting `maxAttempts: 10` and stopping at attempt 1.
+    //
+    // Identify it by CONSTRUCTOR name, not `.name`: these SDK classes never set
+    // `name`, so it reads as plain "Error". The subclass
+    // `APIConnectionTimeoutError` also arrives with no cause at all, so the
+    // cause-code check below cannot stand on its own.
+    const constructorName = (err as { constructor?: { name?: unknown } }).constructor?.name;
+    if (typeof constructorName === 'string' && constructorName.startsWith('APIConnection')) {
+      return true;
+    }
+    const cause = err.cause;
+    if (cause && typeof cause === 'object') {
+      const causeCode = (cause as Record<string, unknown>).code;
+      if (typeof causeCode === 'string' && retryableCodes.includes(causeCode)) {
         return true;
       }
     }

--- a/packages/agent/src/providers/provider-instance-e2e.test.ts
+++ b/packages/agent/src/providers/provider-instance-e2e.test.ts
@@ -722,6 +722,11 @@ describe('Provider Instance E2E Tests', () => {
           'gpt-4'
         );
 
+        // As above: the SDK wraps the DNS failure in a retryable
+        // APIConnectionError, so cap retries — this asserts the surfaced error,
+        // not the retry schedule.
+        provider.RETRY_CONFIG = { maxRetries: 1 };
+
         await expect(
           provider.createResponse([{ role: 'user', content: 'Hello' }], [], 'gpt-4')
         ).rejects.toThrow(/getaddrinfo ENOTFOUND|fetch failed|Connection error/i);
@@ -770,6 +775,14 @@ describe('Provider Instance E2E Tests', () => {
           'invalid-url-test',
           'gpt-4'
         );
+
+        // A connection failure is retryable — the SDK wraps ENOTFOUND in an
+        // APIConnectionError, and treating that class as permanent is what let a
+        // transient blip fail a turn outright. This test is about the error the
+        // caller finally sees, not about retry policy, so cap the retries rather
+        // than let the default schedule (10 attempts, exponential backoff) decide
+        // how long the assertion takes.
+        provider.RETRY_CONFIG = { maxRetries: 1 };
 
         await expect(
           provider.createResponse([{ role: 'user', content: 'Hello' }], [], 'gpt-4')


### PR DESCRIPTION
PRI-2714.

The Anthropic and OpenAI SDKs wrap a transport failure in `APIConnectionError`, constructed with **no status and no code** — the real `ECONNREFUSED` sits on `.cause`, and `.name` is left as plain `"Error"`, so only `constructor.name` identifies it. Neither the code check nor the status check in `isRetryableError` saw it, so the single most retryable failure class there is was classified as permanent.

The cost showed up during a credential outage on a production coworker. The credential arbiter logged, on every approval:

```
[ERROR] Streaming error from Anthropic {"error":"Connection error."}
[DEBUG] Retry decision {"attempt":1,"maxAttempts":10,"isRetryable":false,"shouldRetry":false}
```

`maxAttempts: 10`, stopping at attempt 1. Retries would not have saved that particular incident (the container was stranded on a dead network namespace), but a one-off blip should not fail a turn outright.

Fixed in `BaseProvider` so every SDK-backed provider benefits. Aborts stay non-retryable via the existing `AbortError` check, and the streaming guard (`canRetry: () => !streamingStarted`) still prevents replaying a partially-streamed turn.

## On the tests

They construct the **real** SDK error classes rather than hand-rolled lookalikes, and that mattered: the first version of this fix keyed on `.name` and passed happily against a fake object with `name: 'APIConnectionError'`. Against a genuine `APIConnectionError` it failed immediately — the SDK never sets `name`. The test now asserts that shape explicitly (`expect(err.name).toBe('Error')`) so the next person does not have to rediscover it.

Two provider e2e tests pointed at a non-existent domain and asserted the error within a fixed time budget. Now that connection errors retry, they were pinning the retry schedule rather than the surfaced error, so they cap `maxRetries` explicitly.

## Verification

Typecheck and lint clean. Full suite: 3390 passed, 6 failed — all in container integration tests (`apple-container`, `container-cleanup-validation`, `persona-container-sharing`), which pass in isolation and are unrelated to provider code.

## One consequence worth flagging

A genuinely dead endpoint now takes the full retry schedule to surface instead of failing immediately. With the default config (10 attempts, exponential backoff capped at 30s) that is a couple of minutes before the caller sees the error. That is the intended trade — transient blips recover — but it is a real change in how a misconfigured endpoint presents.
