### PR TITLE
fix(tests): skip integration suites on the model they actually use; fix compact fixture

### DIFF
--- a/packages/agent/src/providers/lmstudio-integration.test.ts
+++ b/packages/agent/src/providers/lmstudio-integration.test.ts
@@ -42,15 +42,22 @@ class FailingTool extends Tool {
   }
 }
 
+// The model this suite actually exercises — both the provider's configured
+// model and the one passed to every createResponse call, and what the gate
+// checks for. The two used to disagree (configured 1.7b, called 30b-a3b), which
+// meant a machine running LMStudio with any other model would pass the gate and
+// then fail every test on a missing model.
+const LMSTUDIO_TEST_MODEL = 'qwen/qwen3-1.7b';
+
 // Check provider availability once at module level
 const provider = new LMStudioProvider({
-  model: 'qwen/qwen3-1.7b',
+  model: LMSTUDIO_TEST_MODEL,
   systemPrompt: 'You are a helpful assistant. Use tools when asked.',
 });
 
 // Suppress all output during provider availability check to prevent WebSocket connection errors
 const isLMStudioAvailable = await withSuppressedStdio(async () => {
-  return await checkProviderAvailability('LMStudio', provider);
+  return await checkProviderAvailability('LMStudio', provider, LMSTUDIO_TEST_MODEL);
 });
 
 const conditionalDescribe = isLMStudioAvailable ? describe.sequential : describe.skip;
@@ -72,7 +79,7 @@ conditionalDescribe('LMStudio Provider Integration Tests', () => {
       },
     ];
 
-    const response = await provider.createResponse(messages, [mockTool], 'qwen/qwen3-30b-a3b');
+    const response = await provider.createResponse(messages, [mockTool], LMSTUDIO_TEST_MODEL);
 
     // With native tool calling, we should get proper tool calls
     expect(response.content).toBeTruthy();
@@ -109,7 +116,7 @@ conditionalDescribe('LMStudio Provider Integration Tests', () => {
       { role: 'user' as const, content: 'Now use it again with action "followup"' },
     ];
 
-    const response = await provider.createResponse(messages, [mockTool], 'qwen/qwen3-30b-a3b');
+    const response = await provider.createResponse(messages, [mockTool], LMSTUDIO_TEST_MODEL);
 
     expect(response.toolCalls.length).toBeGreaterThanOrEqual(1);
     expect(response.toolCalls[0].name).toBe('mock_tool');
@@ -147,7 +154,7 @@ conditionalDescribe('LMStudio Provider Integration Tests', () => {
     ];
 
     // Try multiple times as AI models can be unpredictable under load
-    let response = await provider.createResponse(messages, [complexTool], 'qwen/qwen3-30b-a3b');
+    let response = await provider.createResponse(messages, [complexTool], LMSTUDIO_TEST_MODEL);
     let attempts = 0;
     const maxAttempts = 3;
 
@@ -156,7 +163,7 @@ conditionalDescribe('LMStudio Provider Integration Tests', () => {
       if (attempts < maxAttempts) {
         // Wait a bit before retrying
         await new Promise((resolve) => setTimeout(resolve, 1000));
-        response = await provider.createResponse(messages, [complexTool], 'qwen/qwen3-30b-a3b');
+        response = await provider.createResponse(messages, [complexTool], LMSTUDIO_TEST_MODEL);
       }
     }
 
@@ -172,7 +179,7 @@ conditionalDescribe('LMStudio Provider Integration Tests', () => {
       { role: 'user' as const, content: 'Use the failing_tool with message "test failure"' },
     ];
 
-    const response = await provider.createResponse(messages, [failingTool], 'qwen/qwen3-30b-a3b');
+    const response = await provider.createResponse(messages, [failingTool], LMSTUDIO_TEST_MODEL);
 
     // Should still generate a tool call even if we know it will fail
     expect(response.toolCalls.length).toBeGreaterThanOrEqual(1);
@@ -188,7 +195,7 @@ conditionalDescribe('LMStudio Provider Integration Tests', () => {
       },
     ];
 
-    const response = await provider.createResponse(messages, [mockTool], 'qwen/qwen3-30b-a3b');
+    const response = await provider.createResponse(messages, [mockTool], LMSTUDIO_TEST_MODEL);
 
     // Should have both text content and tool calls
     // Should have both text content and tool calls
@@ -202,7 +209,7 @@ conditionalDescribe('LMStudio Provider Integration Tests', () => {
   it('should handle no available tools', async () => {
     const messages = [{ role: 'user' as const, content: 'Hello, can you help me?' }];
 
-    const response = await provider.createResponse(messages, [], 'qwen/qwen3-30b-a3b');
+    const response = await provider.createResponse(messages, [], LMSTUDIO_TEST_MODEL);
 
     expect(response.content).toBeTruthy();
     expect(response.toolCalls.length).toBe(0);
@@ -216,7 +223,7 @@ conditionalDescribe('LMStudio Provider Integration Tests', () => {
       },
     ];
 
-    const response = await provider.createResponse(messages, [mockTool], 'qwen/qwen3-30b-a3b');
+    const response = await provider.createResponse(messages, [mockTool], LMSTUDIO_TEST_MODEL);
 
     // Should respond without crashing, might not generate tool calls for nonexistent tool
     expect(response.content).toBeTruthy();
@@ -230,7 +237,7 @@ conditionalDescribe('LMStudio Provider Integration Tests', () => {
       },
     ];
 
-    const response = await provider.createResponse(messages, [], 'qwen/qwen3-30b-a3b');
+    const response = await provider.createResponse(messages, [], LMSTUDIO_TEST_MODEL);
 
     expect(response.content).toBeTruthy();
     // Should handle the request without crashing
@@ -262,7 +269,7 @@ conditionalDescribe('LMStudio Provider Integration Tests', () => {
       },
     ];
 
-    const response = await provider.createResponse(messages, [simpleTool], 'qwen/qwen3-30b-a3b');
+    const response = await provider.createResponse(messages, [simpleTool], LMSTUDIO_TEST_MODEL);
 
     // Verify native tool calling works
     expect(response.toolCalls.length).toBeGreaterThan(0);

--- a/packages/agent/src/providers/ollama-integration.test.ts
+++ b/packages/agent/src/providers/ollama-integration.test.ts
@@ -25,13 +25,21 @@ class MockTool extends Tool {
   }
 }
 
+// The model this suite actually exercises. It is BOTH the provider's configured
+// model and the one passed to every createResponse call, and the availability
+// gate checks for exactly it. Previously the provider was configured with
+// `qwen3:0.6b` while every call passed `qwen3:32b`, so a machine with Ollama
+// running and any other model pulled sailed through the gate and then failed
+// every test on `Model "qwen3:32b" is not available`.
+const OLLAMA_TEST_MODEL = 'qwen3:0.6b';
+
 // Check provider availability once at module level
 const provider = new OllamaProvider({
-  model: 'qwen3:0.6b',
+  model: OLLAMA_TEST_MODEL,
   systemPrompt: 'You are a helpful assistant. Use tools when asked.',
 });
 
-const isOllamaAvailable = await checkProviderAvailability('Ollama', provider);
+const isOllamaAvailable = await checkProviderAvailability('Ollama', provider, OLLAMA_TEST_MODEL);
 
 const conditionalDescribe = isOllamaAvailable ? describe.sequential : describe.skip;
 
@@ -50,7 +58,7 @@ conditionalDescribe('Ollama Provider Integration Tests', () => {
       },
     ];
 
-    const response = await provider.createResponse(messages, [], 'qwen3:32b');
+    const response = await provider.createResponse(messages, [], OLLAMA_TEST_MODEL);
 
     expect(response.content).toBeTruthy();
     expect(response.content.length).toBeGreaterThan(0);
@@ -65,7 +73,7 @@ conditionalDescribe('Ollama Provider Integration Tests', () => {
       },
     ];
 
-    const response = await provider.createResponse(messages, [mockTool], 'qwen3:32b');
+    const response = await provider.createResponse(messages, [mockTool], OLLAMA_TEST_MODEL);
 
     // Ollama tool calling might be less reliable than other providers
     expect(response.content).toBeTruthy();
@@ -76,7 +84,7 @@ conditionalDescribe('Ollama Provider Integration Tests', () => {
   it('should handle conversation without tools', async () => {
     const messages = [{ role: 'user' as const, content: 'What is 2 + 2?' }];
 
-    const response = await provider.createResponse(messages, [], 'qwen3:32b');
+    const response = await provider.createResponse(messages, [], OLLAMA_TEST_MODEL);
 
     expect(response.content).toBeTruthy();
     expect(response.content.toLowerCase()).toContain('4');
@@ -88,14 +96,14 @@ conditionalDescribe('Ollama Provider Integration Tests', () => {
       { role: 'user', content: 'What is 5 + 3?' },
     ];
 
-    let response = await provider.createResponse(messages, [], 'qwen3:32b');
+    let response = await provider.createResponse(messages, [], OLLAMA_TEST_MODEL);
     expect(response.content).toBeTruthy();
     expect(response.content.toLowerCase()).toContain('8');
 
     messages.push({ role: 'assistant', content: response.content });
     messages.push({ role: 'user', content: 'What was that answer again?' });
 
-    response = await provider.createResponse(messages, [], 'qwen3:32b');
+    response = await provider.createResponse(messages, [], OLLAMA_TEST_MODEL);
     expect(response.content).toBeTruthy();
     expect(response.content.toLowerCase()).toContain('8');
   }, 45000);
@@ -103,7 +111,7 @@ conditionalDescribe('Ollama Provider Integration Tests', () => {
   it('should return usage metadata', async () => {
     const messages = [{ role: 'user' as const, content: 'Hello' }];
 
-    const response = await provider.createResponse(messages, [], 'qwen3:32b');
+    const response = await provider.createResponse(messages, [], OLLAMA_TEST_MODEL);
 
     expect(response.content).toBeTruthy();
     expect(response.stopReason).toBeDefined();

--- a/packages/agent/src/rpc/handlers/__tests__/session-operations.compact-prompt.test.ts
+++ b/packages/agent/src/rpc/handlers/__tests__/session-operations.compact-prompt.test.ts
@@ -11,7 +11,13 @@ import { createNdjsonStdioTransport, JsonRpcPeer } from '@lace/ent-protocol';
 import { createAgentServerState, registerAgentRpcMethods } from '../../../server';
 import { defaultInitializeParams } from '../../../__tests__/helpers/initialize';
 import { getSessionDir } from '@lace/agent/storage/session-store';
-import { readDurableEvents } from '@lace/agent/storage/event-log';
+import {
+  readDurableEvents,
+  deriveNextEventSeqAcrossSessionFiles,
+} from '@lace/agent/storage/event-log';
+import { reconcileHead } from '@lace/agent/storage/seq-head';
+import { getLaceDir } from '@lace/agent/config/lace-dir';
+import { basename } from 'node:path';
 
 function createPairedPeers(register: (peer: JsonRpcPeer) => void) {
   const aToB = new PassThrough();
@@ -102,6 +108,19 @@ function writeMinimalConversation(sessionDir: string): void {
   for (const event of events) {
     appendFileSync(eventsPath, JSON.stringify(event) + '\n', { encoding: 'utf8' });
   }
+
+  // The fixture appends to the JSONL out of band, AFTER the session was opened.
+  // eventSeq is handed out from a persisted head file (`.seq`) that is only
+  // reconciled against the JSONL on session open, so without this the head still
+  // reflects the empty session: compaction's own events would be assigned seqs
+  // that collide with the fixture's, the tail split would land in the wrong
+  // place, and the "compacted" prompt would come back LARGER than the original.
+  // Reconciling here leaves the session in the state production is always in by
+  // the time it appends — the same call the open path makes.
+  reconcileHead(
+    sessionDir,
+    () => deriveNextEventSeqAcrossSessionFiles(getLaceDir(), basename(sessionDir)) - 1
+  );
 }
 
 describe('ent/session/compact — track-based strategy', () => {

--- a/packages/agent/src/test-utils/provider-test-helpers.test.ts
+++ b/packages/agent/src/test-utils/provider-test-helpers.test.ts
@@ -1,0 +1,49 @@
+// ABOUTME: Tests for the integration-test availability gate
+// ABOUTME: Ensures a suite skips when the model it actually exercises is absent
+
+import { describe, it, expect } from 'vitest';
+import { checkProviderAvailability } from './provider-test-helpers';
+
+function fakeProvider(connected: boolean, models: string[]) {
+  return {
+    diagnose: () => Promise.resolve({ connected, models }),
+  };
+}
+
+describe('checkProviderAvailability', () => {
+  it('reports unavailable when the server is unreachable', async () => {
+    await expect(checkProviderAvailability('Fake', fakeProvider(false, []))).resolves.toBe(false);
+  });
+
+  it('reports unavailable when the server has no models at all', async () => {
+    await expect(checkProviderAvailability('Fake', fakeProvider(true, []))).resolves.toBe(false);
+  });
+
+  it('reports available when connected and no specific model is required', async () => {
+    await expect(
+      checkProviderAvailability('Fake', fakeProvider(true, ['some-model']))
+    ).resolves.toBe(true);
+  });
+
+  it('reports unavailable when the REQUIRED model is not pulled', async () => {
+    // The gate previously only asked "is the server up with any model at all?".
+    // A suite could therefore pass the gate on a machine holding a completely
+    // different model and then fail every test on `Model "x" is not available`.
+    // An integration test whose dependency is missing must SKIP, not fail — a
+    // red suite that means "you didn't pull a 32b model" trains people to
+    // ignore red.
+    await expect(
+      checkProviderAvailability('Fake', fakeProvider(true, ['gemma4:latest']), 'qwen3:32b')
+    ).resolves.toBe(false);
+  });
+
+  it('reports available when the required model is present', async () => {
+    await expect(
+      checkProviderAvailability(
+        'Fake',
+        fakeProvider(true, ['gemma4:latest', 'qwen3:32b']),
+        'qwen3:32b'
+      )
+    ).resolves.toBe(true);
+  });
+});

--- a/packages/agent/src/test-utils/provider-test-helpers.ts
+++ b/packages/agent/src/test-utils/provider-test-helpers.ts
@@ -9,9 +9,20 @@
  * @param provider - Provider instance with diagnose() method
  * @returns Promise<boolean> - true if provider is available, false otherwise
  */
+/**
+ * Whether an integration suite can run against a live local provider.
+ *
+ * `requiredModel` is the model the suite actually calls. Without it the gate
+ * only asks "is the server up with any model at all?", so a machine holding a
+ * different model passes the gate and then fails every test on
+ * `Model "x" is not available`. An integration test whose dependency is missing
+ * must skip, not fail — a red suite that really means "you didn't pull a 32b
+ * model" trains people to ignore red.
+ */
 export async function checkProviderAvailability(
   providerName: string,
-  provider: { diagnose(): Promise<{ connected: boolean; models: string[]; error?: string }> }
+  provider: { diagnose(): Promise<{ connected: boolean; models: string[]; error?: string }> },
+  requiredModel?: string
 ): Promise<boolean> {
   try {
     // Add timeout to prevent hanging (give extra time for provider's own timeout)
@@ -23,6 +34,10 @@ export async function checkProviderAvailability(
     if (!diagnostics.connected || diagnostics.models.length === 0) {
       // Silently skip unavailable providers to reduce test noise
       // Original message: `Skipping ${providerName} tests - ${diagnostics.error || 'not available'}`
+      return false;
+    }
+    if (requiredModel && !diagnostics.models.includes(requiredModel)) {
+      // Server is up but holds different models — skip rather than fail.
       return false;
     }
     return true;


### PR DESCRIPTION
Two deterministic failures that had been sitting red in the suite. Neither is a product bug, but both trained people to ignore red.

## Integration gates checked a different model than the tests used

`checkProviderAvailability` only asked *"is the server up with any model at all?"*. The Ollama suite configured `qwen3:0.6b` and then passed `qwen3:32b` to every `createResponse` call. On a machine running Ollama with some other model pulled, the gate passed and all five tests failed:

```
Error: Model "qwen3:32b" is not available in Ollama.
Available models: gemma4:latest
```

LMStudio had the identical mismatch — configured `qwen/qwen3-1.7b`, called `qwen/qwen3-30b-a3b` — latent only because LMStudio was not running here.

The gate now takes the model the suite actually exercises, and each suite uses one constant for its configured model, its call sites, and the gate, so they cannot drift apart again. An integration test whose dependency is missing must **skip**, not fail.

## The compact fixture left the seq head stale

```
AssertionError: expected 17064 to be less than 15158
```

Compaction was *growing* the context 24%. Bisected to `5ff5a89c3` ("assign eventSeq via locked head reserve"), which stopped re-deriving the seq from the JSONL on every append and started handing it out from a persisted `.seq` head.

That head is reconciled against the JSONL on session **open**. This fixture appends to the JSONL out of band *after* opening, so the head still described an empty session — compaction's own events then took seqs colliding with the fixture's, the tail split landed in the wrong place, and the "compacted" prompt came back larger than the original.

The fixture now calls `reconcileHead` after writing, the same call the open path makes, leaving the session in the state production is always in by the time it appends.

**This is not a compaction regression** — the product guard exists and works; the fixture was bypassing it. Verified at the bisect boundary: `5ff5a89c3^` passes, `5ff5a89c3` fails.

## Verification

Typecheck and lint clean. Full suite green: 3396 passed / 27 skipped in pass 1, 269 passed / 8 skipped in pass 2, zero failures. Ollama and LMStudio now report as skipped rather than failed on a machine without those models.