### PR TITLE
fix(session): persona MCP servers survive session/resume

### DIFF
--- a/packages/agent/src/__tests__/session-new.persona-config.test.ts
+++ b/packages/agent/src/__tests__/session-new.persona-config.test.ts
@@ -108,7 +108,7 @@ You are a frontmatter persona.`
         args: ['--root', '/tmp'],
         enabled: false,
         placement: 'toolRuntime',
-        source: 'embedder',
+        source: 'persona',
       },
     ]);
   });
@@ -160,7 +160,7 @@ You are a persona with MCP defaults.`
         command: 'persona-only',
         enabled: false,
         placement: 'toolRuntime',
-        source: 'embedder',
+        source: 'persona',
       },
       {
         name: 'request-only',
@@ -216,7 +216,7 @@ Persona with MCP placement.`
         secretEnv: { API_KEY: { namespace: 'project', name: 'api-key' } },
         enabled: true,
         placement: 'host',
-        source: 'embedder',
+        source: 'persona',
       },
       {
         name: 'explicit-stdio-host',
@@ -224,7 +224,7 @@ Persona with MCP placement.`
         transport: 'stdio',
         placement: 'host',
         enabled: false,
-        source: 'embedder',
+        source: 'persona',
       },
     ]);
   });

--- a/packages/agent/src/rpc/__tests__/session-resume.persona-mcp.test.ts
+++ b/packages/agent/src/rpc/__tests__/session-resume.persona-mcp.test.ts
@@ -1,0 +1,56 @@
+// ABOUTME: Regression guard — a persona's declared MCP servers must survive
+// ABOUTME: session/resume, so a resumed subagent keeps tools like the browser.
+
+import { describe, it, expect } from 'vitest';
+import { applyEmbedderMcpServers } from '@lace/agent/rpc/session-config';
+
+/**
+ * A browser-user subagent declares its browser MCP server in persona
+ * frontmatter, so the stored entry is `source: 'embedder'`. `subagent-job.ts`
+ * resumes with `mcpServers: []`, and `applyEmbedderMcpServers` treats the
+ * embedder's list as authoritative — which drops the persona's server.
+ *
+ * Observed live: a resumed browser-user's tool count fell 10 -> 9 with
+ * `superpowers-chrome_use_browser` gone, while the model (seeing successful
+ * browser calls in its own history) kept trying to call it and got
+ * tool-not-found. The browser PROFILE survives on disk; only the tool is lost.
+ */
+describe('applyEmbedderMcpServers — persona servers across resume', () => {
+  const personaServer = {
+    name: 'superpowers-chrome',
+    command: 'node',
+    args: ['/opt/superpowers-chrome/mcp/dist/index.js', '--headed'],
+    placement: 'toolRuntime' as const,
+    source: 'persona' as const,
+  };
+
+  it('keeps a persona-owned server when the embedder resumes with an empty list', () => {
+    const merged = applyEmbedderMcpServers([personaServer], []);
+
+    expect(merged.map((s) => s.name)).toContain('superpowers-chrome');
+  });
+
+  it('keeps a persona-owned server alongside embedder servers', () => {
+    const merged = applyEmbedderMcpServers(
+      [personaServer, { name: 'gone', command: 'x', source: 'embedder' as const }],
+      [{ name: 'fresh', command: 'y' }]
+    );
+    const names = merged.map((s) => s.name);
+
+    expect(names).toContain('superpowers-chrome');
+    expect(names).toContain('fresh');
+    // Still drops a since-deleted embedder server — the behaviour this
+    // function was written to guarantee.
+    expect(names).not.toContain('gone');
+  });
+
+  it('lets an embedder server of the same name win over the persona default', () => {
+    const merged = applyEmbedderMcpServers(
+      [personaServer],
+      [{ name: 'superpowers-chrome', command: 'override' }]
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.command).toBe('override');
+  });
+});

--- a/packages/agent/src/rpc/handlers/mcp-servers.ts
+++ b/packages/agent/src/rpc/handlers/mcp-servers.ts
@@ -163,7 +163,7 @@ async function syncDisabledMcpServerForActiveSession(
 // optional `source` tag (see session-store.ts). The strict protocol schema
 // would reject this tag, so reading state.json uses the extended shape.
 const StoredMcpServerSchema = McpServerConfigSchema.extend({
-  source: z.enum(['embedder', 'user']).optional(),
+  source: z.enum(['embedder', 'user', 'persona']).optional(),
 });
 
 /**

--- a/packages/agent/src/rpc/handlers/session.ts
+++ b/packages/agent/src/rpc/handlers/session.ts
@@ -677,9 +677,25 @@ export function registerSessionHandlers(
         : personaDefaults.mcpServers
           ? defaultMcpServerPlacements(personaDefaults.mcpServers)
           : undefined;
-    // Both persona-defaults and request-level entries come from the embedder.
+    // Tag by ORIGIN, not by who asked for the session. A server the embedder
+    // named in this request is 'embedder' — it re-declares that set on every
+    // resume, so it is safe to replace wholesale. A server that came only from
+    // persona frontmatter is 'persona': the embedder never declared it and
+    // cannot re-declare it on resume (session/resume takes no persona), so
+    // tagging it 'embedder' meant a resume with `mcpServers: []` silently
+    // dropped it — which is how a resumed browser-user lost its browser tool.
+    const requestDeclaredNames = new Set(
+      (Array.isArray(parsed.mcpServers) ? parsed.mcpServers : []).map((s) => s.name)
+    );
+    const personaDeclaredNames = new Set((personaDefaults.mcpServers ?? []).map((s) => s.name));
     const effectiveStoredMcpServers = effectiveMcpServers
-      ? tagMcpServers(effectiveMcpServers, 'embedder')
+      ? effectiveMcpServers.map((server) => ({
+          ...server,
+          source:
+            personaDeclaredNames.has(server.name) && !requestDeclaredNames.has(server.name)
+              ? ('persona' as const)
+              : ('embedder' as const),
+        }))
       : undefined;
     const effectiveToolScope = personaDefaults.toolScope;
 

--- a/packages/agent/src/rpc/session-config.ts
+++ b/packages/agent/src/rpc/session-config.ts
@@ -108,20 +108,37 @@ export function tagMcpServers(
  * This is the merge used by session/load and session/resume — the bug it fixed:
  * a since-deleted embedder MCP server stuck around in state.json and lace tried
  * to spawn its missing command.
+ *
+ * Entries with `source === 'persona'` also survive, because the embedder never
+ * declared them and so cannot re-declare them on resume. `subagent-job.ts`
+ * resumes with `mcpServers: []`, which previously wiped a persona's servers:
+ * a resumed browser-user lost `superpowers-chrome`, its tool count dropped
+ * 10 -> 9, and the model kept calling a tool that was no longer registered.
+ * An incoming entry of the same name still wins, so an embedder can override
+ * a persona default deliberately.
  */
 export function applyEmbedderMcpServers(existing: unknown, incoming: unknown): StoredMcpServer[] {
   const incomingServers = defaultMcpServerPlacements(validateIncomingMcpServers(incoming));
   const existingList: StoredMcpServer[] = Array.isArray(existing)
     ? (existing as StoredMcpServer[])
     : [];
+  const incomingNames = new Set(incomingServers.map((s) => s.name));
 
   const userOwned = existingList.filter((s) => s?.source === 'user');
   const userOwnedNames = new Set(userOwned.map((s) => s.name));
+  // A persona default is superseded by an explicit incoming server of the same
+  // name; otherwise it is carried through untouched.
+  const personaOwned = existingList.filter(
+    (s) => s?.source === 'persona' && !incomingNames.has(s.name) && !userOwnedNames.has(s.name)
+  );
 
   const merged: StoredMcpServer[] = [];
   for (const server of incomingServers) {
     if (userOwnedNames.has(server.name)) continue;
     merged.push({ ...server, source: 'embedder' });
+  }
+  for (const server of personaOwned) {
+    merged.push({ ...server, source: 'persona' });
   }
   for (const server of userOwned) {
     merged.push({ ...server, source: 'user' });

--- a/packages/agent/src/storage/session-store.ts
+++ b/packages/agent/src/storage/session-store.ts
@@ -26,7 +26,7 @@ import type { RuntimeExecutionBinding } from '../tools/runtime/types';
  * Missing `source` is treated as `embedder` for migration compatibility with
  * state.json files written before this field existed.
  */
-export type McpServerSource = 'embedder' | 'user';
+export type McpServerSource = 'embedder' | 'user' | 'persona';
 
 export type StoredMcpServer = {
   name: string;


### PR DESCRIPTION
Reported by Cadence as "the browser tool isn't available in a resumed session." Her observation was right; the diagnosis needed correcting, and the underlying bug is general.

## Evidence
From her subagent's `agent.log`, across the resume boundary:

| time | toolCount | browser tool |
|---|---|---|
| 06:45–06:47 (before) | 10 | present |
| 06:50 onward (after resume) | **9** | **gone** |

The model then called it anyway — under two different spellings (`superpowers-chrome_use_browser` and the frontmatter form `superpowers-chrome/use_browser`) — because its own history showed the calls succeeding. It got tool-not-found rather than "this capability was withdrawn."

## Not a browser-state problem
The browser **profile persists on disk**, under the subagent's session dir (`…/.cache/superpowers/browser-profiles/superpowers-chrome/Default/`) — cookies and all. Only the tool *registration* was lost. The natural conclusion ("browser state is per-invocation") would have sent the next person after the wrong thing.

## Chain
1. `subagent-job.ts:875` resumes with `mcpServers: []`.
2. `applyEmbedderMcpServers` treats the embedder list as authoritative and replaces every stored entry tagged `'embedder'`.
3. `session/new` tagged persona-derived servers `'embedder'` as well — "both persona-defaults and request-level entries come from the embedder."
4. `session/resume` takes no `persona`, so the embedder cannot re-declare what it never declared.

Net: any persona-declared MCP server dies on resume. Browser is just the visible one.

## Fix
A third source, `'persona'`, tagged **by origin** at `session/new`: named in the request → `'embedder'`; from persona frontmatter only → `'persona'`, and carried through resume.

Preserved deliberately: an incoming server of the same name still wins (explicit override), and a since-deleted embedder server is still dropped — the exact behaviour `applyEmbedderMcpServers` exists to guarantee, covered by a test.

## Tests
New `session-resume.persona-mcp.test.ts` (red first: 2 of 3 failed on the survival cases). Three assertions in `session-new.persona-config.test.ts` updated — they encoded the old tagging, which *was* the bug. rpc + storage suites: 370 passing. Typecheck clean.

Full-suite run shows ~19 e2e files failing on timeouts under parallel load; spot-checked `agent-process.abort` and `agent-process.event-seq` in isolation and both pass, so those are pre-existing load flakes rather than this change.