### PR TITLE
fix(inject-drain): never dispatch an assistant prefill when draining a mid-turn inject

### DIFF
--- a/packages/agent/src/__tests__/agent-process.inject-drain-prefill.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.inject-drain-prefill.e2e.test.ts
@@ -1,0 +1,220 @@
+// ABOUTME: E2E reproduction of the inject-drain prefill wedge. An immediate
+// ABOUTME: context_injected that lands mid-turn is drained by a follow-up turn
+// ABOUTME: prompted with EMPTY content. That only surfaces the inject when it is
+// ABOUTME: still the last thing in the transcript; once the turn has emitted an
+// ABOUTME: assistant message, the drain dispatches a request whose conversation
+// ABOUTME: ends with an assistant message — an assistant prefill, which
+// ABOUTME: extended-thinking models reject with a hard 400.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  createE2EContext,
+  spawnAgentProcess,
+  withTimeout,
+  defaultInitializeParams,
+} from './helpers';
+
+/**
+ * Observed in production (ada-sen, 2026-07-29 18:03Z, and 8 further times since
+ * 2026-07-11). The transcript signature is always the same three events:
+ *
+ *   context_injected (folds to user) -> message (folds to assistant) -> turn_end
+ *
+ * followed by a `prompt` event carrying `content: []`, and a turn_end with
+ * `stopReason: 'provider_error_invalid'`. The provider error is:
+ *
+ *   400 invalid_request_error: This model does not support assistant message
+ *   prefill. The conversation must end with a user message.
+ *
+ * It is not retryable, so the turn dies and whatever prompted it is dropped
+ * silently — the agent simply goes deaf while every container stays healthy.
+ */
+describe('inject-drain prefill wedge (E2E)', () => {
+  const ctx = createE2EContext({ prefix: 'lace-inject-drain-prefill' });
+
+  beforeEach(() => ctx.setup());
+  afterEach(() => ctx.teardown());
+
+  function readRequestRoles(recordPath: string): string[][] {
+    if (!existsSync(recordPath)) return [];
+    return readFileSync(recordPath, 'utf8')
+      .split('\n')
+      .filter((l) => l.trim().length > 0)
+      .map((l) => (JSON.parse(l) as { roles: string[] }).roles);
+  }
+
+  /** Every durable event in the lace dir, from the JSONL shards on disk. */
+  function readSessionEvents(laceDir: string): Array<{ type?: string; data?: unknown }> {
+    const events: Array<{ type?: string; data?: unknown }> = [];
+    for (const file of findJsonlFiles(laceDir)) {
+      for (const line of readFileSync(file, 'utf8').split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          events.push(JSON.parse(line) as { type?: string });
+        } catch {
+          // ignore partial/malformed line
+        }
+      }
+    }
+    return events;
+  }
+
+  function findJsonlFiles(dir: string): string[] {
+    const found: string[] = [];
+    let entries: import('node:fs').Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return found;
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) found.push(...findJsonlFiles(full));
+      else if (entry.name.endsWith('.jsonl')) found.push(full);
+    }
+    return found;
+  }
+
+  async function sleep(ms: number): Promise<void> {
+    await new Promise((r) => setTimeout(r, ms));
+  }
+
+  it(
+    'drains a mid-turn inject with a request that ends on an assistant message',
+    { timeout: 30_000 },
+    async () => {
+      const recordPath = join(ctx.laceDir, 'provider-requests.jsonl');
+
+      ctx.agent = spawnAgentProcess({
+        laceDir: ctx.laceDir,
+        env: {
+          LACE_AGENT_TEST_PROVIDER: '1',
+          // Hold the provider call open long enough to land an inject while the
+          // turn is genuinely in flight — the production race, not a simulation
+          // of it: the inject must arrive AFTER the request was dispatched.
+          LACE_TEST_PROVIDER_STREAM_DELAY_MS: '2500',
+          LACE_TEST_PROVIDER_RECORD_REQUESTS: recordPath,
+        },
+      });
+
+      ctx.agent.peer.onRequest('session/update', async () => undefined);
+
+      await withTimeout(
+        ctx.agent.peer.request('initialize', defaultInitializeParams()),
+        5_000,
+        'initialize'
+      );
+      await withTimeout(
+        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+        5_000,
+        'session/new'
+      );
+
+      // Start a turn but do NOT await it: the provider call is now in flight.
+      const promptPromise = ctx.agent.peer.request('session/prompt', {
+        content: [{ type: 'text', text: 'Say hello and stop.' }],
+      });
+
+      // Land an immediate inject while that call is still open. This is exactly
+      // the production shape: the runner's inject tailer has already read for
+      // this round-trip, so the inject is genuinely undelivered at turn_end.
+      await sleep(800);
+      ctx.agent.peer.notify('ent/session/inject', {
+        content: [{ type: 'text', text: 'news?' }],
+        priority: 'immediate',
+      });
+
+      await withTimeout(promptPromise, 20_000, 'session/prompt');
+
+      // Let the scheduled drain turn run to completion.
+      await sleep(3_000);
+
+      const events = readSessionEvents(ctx.laceDir);
+      const injected = events.filter((e) => e.type === 'context_injected');
+      const emptyPrompts = events.filter(
+        (e) =>
+          e.type === 'prompt' &&
+          Array.isArray((e.data as { content?: unknown[] })?.content) &&
+          (e.data as { content: unknown[] }).content.length === 0
+      );
+
+      // Preconditions: the inject landed, and the drain fired an EMPTY prompt.
+      expect(injected.length).toBeGreaterThanOrEqual(1);
+      expect(emptyPrompts.length).toBeGreaterThanOrEqual(1);
+
+      // The hypothesis. The drain dispatched a real provider request, and that
+      // request's conversation ends on an assistant message — the prefill a
+      // thinking-enabled model rejects. Asserted against the request the
+      // provider was actually handed, not a re-derivation of it.
+      const requests = readRequestRoles(recordPath);
+      expect(requests.length).toBeGreaterThanOrEqual(2);
+
+      // Control: the ORIGINAL turn's request is well-formed and ends on the
+      // user. Without this the assertion below would pass even if every request
+      // ended on an assistant message, making the test meaningless.
+      const firstRequest = requests[0];
+      expect(firstRequest[firstRequest.length - 1]).toBe('user');
+
+      const drainRequest = requests[requests.length - 1];
+      expect(drainRequest.length).toBeGreaterThan(0);
+      expect(drainRequest[drainRequest.length - 1]).toBe('assistant');
+    }
+  );
+
+  it(
+    'control: with no mid-turn inject there is no empty-prompt drain',
+    { timeout: 30_000 },
+    async () => {
+      const recordPath = join(ctx.laceDir, 'provider-requests.jsonl');
+
+      ctx.agent = spawnAgentProcess({
+        laceDir: ctx.laceDir,
+        env: {
+          LACE_AGENT_TEST_PROVIDER: '1',
+          LACE_TEST_PROVIDER_STREAM_DELAY_MS: '2500',
+          LACE_TEST_PROVIDER_RECORD_REQUESTS: recordPath,
+        },
+      });
+
+      ctx.agent.peer.onRequest('session/update', async () => undefined);
+
+      await withTimeout(
+        ctx.agent.peer.request('initialize', defaultInitializeParams()),
+        5_000,
+        'initialize'
+      );
+      await withTimeout(
+        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+        5_000,
+        'session/new'
+      );
+
+      // Identical turn, identical timing — the ONLY difference is that no
+      // inject lands. This isolates the inject as the cause.
+      await withTimeout(
+        ctx.agent.peer.request('session/prompt', {
+          content: [{ type: 'text', text: 'Say hello and stop.' }],
+        }),
+        20_000,
+        'session/prompt'
+      );
+      await sleep(3_000);
+
+      const events = readSessionEvents(ctx.laceDir);
+      const emptyPrompts = events.filter(
+        (e) =>
+          e.type === 'prompt' &&
+          Array.isArray((e.data as { content?: unknown[] })?.content) &&
+          (e.data as { content: unknown[] }).content.length === 0
+      );
+      expect(emptyPrompts).toHaveLength(0);
+
+      // And every request the provider saw is well-formed.
+      for (const roles of readRequestRoles(recordPath)) {
+        expect(roles[roles.length - 1]).toBe('user');
+      }
+    }
+  );
+});

--- a/packages/agent/src/__tests__/agent-process.inject-drain-prefill.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.inject-drain-prefill.e2e.test.ts
@@ -87,7 +87,7 @@ describe('inject-drain prefill wedge (E2E)', () => {
   }
 
   it(
-    'drains a mid-turn inject with a request that ends on an assistant message',
+    'drains a mid-turn inject without ever dispatching an assistant prefill',
     { timeout: 30_000 },
     async () => {
       const recordPath = join(ctx.laceDir, 'provider-requests.jsonl');
@@ -145,26 +145,39 @@ describe('inject-drain prefill wedge (E2E)', () => {
           (e.data as { content: unknown[] }).content.length === 0
       );
 
-      // Preconditions: the inject landed, and the drain fired an EMPTY prompt.
+      // Precondition: the inject landed and a drain turn ran for it.
       expect(injected.length).toBeGreaterThanOrEqual(1);
-      expect(emptyPrompts.length).toBeGreaterThanOrEqual(1);
 
-      // The hypothesis. The drain dispatched a real provider request, and that
-      // request's conversation ends on an assistant message — the prefill a
-      // opus-4-8 rejects outright. Asserted against the request the
-      // provider was actually handed, not a re-derivation of it.
+      // The drain no longer prompts with empty content in this shape — an empty
+      // prompt here is precisely what produced the invalid request.
+      expect(emptyPrompts).toHaveLength(0);
+
+      // And it took the NUDGE path specifically. Without this the test would
+      // also pass if the drain had simply stopped running, which would trade
+      // one dropped notification for another.
+      const nudgePrompts = events.filter(
+        (e) =>
+          e.type === 'prompt' &&
+          JSON.stringify((e.data as { content?: unknown })?.content ?? '').includes(
+            'arrived while you were mid-turn'
+          )
+      );
+      expect(nudgePrompts).toHaveLength(1);
+
+      // The fix. The drain still dispatches a real provider request, but it now
+      // ends on a USER message, so it is not an assistant prefill. Asserted
+      // against the request the provider was actually handed — the request is
+      // built at dispatch time, so the transcript alone cannot show its shape.
       const requests = readRequestRoles(recordPath);
       expect(requests.length).toBeGreaterThanOrEqual(2);
 
-      // Control: the ORIGINAL turn's request is well-formed and ends on the
-      // user. Without this the assertion below would pass even if every request
-      // ended on an assistant message, making the test meaningless.
-      const firstRequest = requests[0];
-      expect(firstRequest[firstRequest.length - 1]).toBe('user');
-
-      const drainRequest = requests[requests.length - 1];
-      expect(drainRequest.length).toBeGreaterThan(0);
-      expect(drainRequest[drainRequest.length - 1]).toBe('assistant');
+      // EVERY request must be well-formed, the drain included. Checking all of
+      // them keeps this honest: asserting only the last would still pass if the
+      // drain had never run at all.
+      for (const roles of requests) {
+        expect(roles.length).toBeGreaterThan(0);
+        expect(roles[roles.length - 1]).toBe('user');
+      }
     }
   );
 

--- a/packages/agent/src/__tests__/agent-process.inject-drain-prefill.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.inject-drain-prefill.e2e.test.ts
@@ -4,7 +4,7 @@
 // ABOUTME: still the last thing in the transcript; once the turn has emitted an
 // ABOUTME: assistant message, the drain dispatches a request whose conversation
 // ABOUTME: ends with an assistant message — an assistant prefill, which
-// ABOUTME: extended-thinking models reject with a hard 400.
+// ABOUTME: claude-opus-4-8 rejects with a hard, non-retryable 400.
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
@@ -30,6 +30,11 @@ import {
  *
  * It is not retryable, so the turn dies and whatever prompted it is dropped
  * silently — the agent simply goes deaf while every container stays healthy.
+ *
+ * The refusal is a property of the MODEL, not of extended thinking: opus-4-8
+ * rejects the prefill with thinking on or off, while sonnet-4-5 accepts it. That
+ * contract is pinned live in anthropic-prefill-contract.live.test.ts, and it is
+ * why the wedge only began biting once Ada moved to opus-4.8.
  */
 describe('inject-drain prefill wedge (E2E)', () => {
   const ctx = createE2EContext({ prefix: 'lace-inject-drain-prefill' });
@@ -146,7 +151,7 @@ describe('inject-drain prefill wedge (E2E)', () => {
 
       // The hypothesis. The drain dispatched a real provider request, and that
       // request's conversation ends on an assistant message — the prefill a
-      // thinking-enabled model rejects. Asserted against the request the
+      // opus-4-8 rejects outright. Asserted against the request the
       // provider was actually handed, not a re-derivation of it.
       const requests = readRequestRoles(recordPath);
       expect(requests.length).toBeGreaterThanOrEqual(2);

--- a/packages/agent/src/__tests__/anthropic-prefill-contract.live.test.ts
+++ b/packages/agent/src/__tests__/anthropic-prefill-contract.live.test.ts
@@ -1,0 +1,120 @@
+// ABOUTME: LIVE contract test against the real Anthropic API. Pins the rule the
+// ABOUTME: inject-drain wedge trips over: claude-opus-4-8 refuses a conversation
+// ABOUTME: that ends with an assistant message ("assistant prefill"), while
+// ABOUTME: claude-sonnet-4-5 accepts one. No mocks — real key, real endpoint.
+
+import { describe, expect, it } from 'vitest';
+
+const API_KEY = process.env.ANTHROPIC_API_KEY;
+
+/**
+ * The second half of the inject-drain wedge (the first half is
+ * agent-process.inject-drain-prefill.e2e.test.ts, which proves the drain
+ * dispatches a request whose conversation ends on an assistant message).
+ *
+ * This test proves what the real API does with that shape. Together they close
+ * the loop on the production failure seen on ada-sen:
+ *
+ *   400 invalid_request_error: This model does not support assistant message
+ *   prefill. The conversation must end with a user message.
+ *
+ * Note the trigger is the MODEL, not extended thinking: opus-4-8 refuses the
+ * prefill with thinking on OR off. Turning thinking off is not a workaround.
+ * Skipped when ANTHROPIC_API_KEY is unset (CI without credentials).
+ */
+describe.skipIf(!API_KEY)('Anthropic assistant-prefill contract (LIVE)', () => {
+  async function send(body: Record<string, unknown>): Promise<{
+    status: number;
+    errorMessage?: string;
+    stopReason?: string;
+  }> {
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'x-api-key': API_KEY as string,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    const json = (await res.json()) as {
+      error?: { message?: string };
+      stop_reason?: string;
+    };
+    return {
+      status: res.status,
+      ...(json.error?.message !== undefined ? { errorMessage: json.error.message } : {}),
+      ...(json.stop_reason !== undefined ? { stopReason: json.stop_reason } : {}),
+    };
+  }
+
+  const TRAILING_ASSISTANT = [
+    { role: 'user', content: 'Say hello.' },
+    { role: 'assistant', content: 'Hello.' },
+  ];
+  const TRAILING_USER = [...TRAILING_ASSISTANT, { role: 'user', content: 'news?' }];
+
+  it(
+    'opus-4-8 REJECTS a conversation ending on an assistant message',
+    { timeout: 30_000 },
+    async () => {
+      const result = await send({
+        model: 'claude-opus-4-8',
+        max_tokens: 2000,
+        thinking: { type: 'adaptive' },
+        output_config: { effort: 'medium' },
+        messages: TRAILING_ASSISTANT,
+      });
+
+      expect(result.status).toBe(400);
+      expect(result.errorMessage).toContain('does not support assistant message prefill');
+      expect(result.errorMessage).toContain('must end with a user message');
+    }
+  );
+
+  it(
+    'opus-4-8 ACCEPTS the same conversation once a user message closes it',
+    { timeout: 30_000 },
+    async () => {
+      const result = await send({
+        model: 'claude-opus-4-8',
+        max_tokens: 2000,
+        thinking: { type: 'adaptive' },
+        output_config: { effort: 'medium' },
+        messages: TRAILING_USER,
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.errorMessage).toBeUndefined();
+    }
+  );
+
+  it(
+    'the refusal is the MODEL, not thinking — same 400 with no thinking block',
+    { timeout: 30_000 },
+    async () => {
+      const result = await send({
+        model: 'claude-opus-4-8',
+        max_tokens: 1000,
+        messages: TRAILING_ASSISTANT,
+      });
+
+      expect(result.status).toBe(400);
+      expect(result.errorMessage).toContain('does not support assistant message prefill');
+    }
+  );
+
+  it(
+    'sonnet-4-5 still accepts prefill — the contract is model-specific',
+    { timeout: 30_000 },
+    async () => {
+      const result = await send({
+        model: 'claude-sonnet-4-5',
+        max_tokens: 1000,
+        messages: TRAILING_ASSISTANT,
+      });
+
+      expect(result.status).toBe(200);
+    }
+  );
+});

--- a/packages/agent/src/notifications/__tests__/inject-drain-content.test.ts
+++ b/packages/agent/src/notifications/__tests__/inject-drain-content.test.ts
@@ -1,0 +1,101 @@
+// ABOUTME: Unit tests for the inject-drain follow-up content decision: an empty
+// ABOUTME: prompt is only safe while the conversation still ends on a user
+// ABOUTME: message; once an assistant message trails it, the drain must carry
+// ABOUTME: content or the dispatched request is an assistant prefill.
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { injectDrainContent } from '../inject-drain-content';
+
+describe('injectDrainContent', () => {
+  let sessionDir: string;
+
+  beforeEach(() => {
+    sessionDir = mkdtempSync(join(tmpdir(), 'inject-drain-content-'));
+  });
+
+  afterEach(() => {
+    rmSync(sessionDir, { recursive: true, force: true });
+  });
+
+  /** Write durable events as the session's JSONL shard. */
+  function writeEvents(events: Array<Record<string, unknown>>): void {
+    mkdirSync(sessionDir, { recursive: true });
+    const lines = events
+      .map((e, i) => JSON.stringify({ eventSeq: i + 1, timestamp: new Date().toISOString(), ...e }))
+      .join('\n');
+    writeFileSync(join(sessionDir, 'events.jsonl'), `${lines}\n`);
+  }
+
+  const userText = (text: string) => ({
+    type: 'prompt',
+    data: { content: [{ type: 'text', text }] },
+  });
+  const assistantText = (text: string) => ({
+    type: 'message',
+    data: { content: [{ type: 'text', text }] },
+  });
+  const injected = (text: string) => ({
+    type: 'context_injected',
+    data: { content: [{ type: 'text', text }], priority: 'immediate' },
+  });
+
+  it('returns empty content when the inject is still the last message', () => {
+    // The healthy shape: nothing followed the inject, so it is already the
+    // trailing user message and an empty prompt surfaces it as-is.
+    writeEvents([userText('hi'), assistantText('hello'), injected('job finished')]);
+
+    expect(injectDrainContent(sessionDir)).toEqual([]);
+  });
+
+  it('returns a nudge when an assistant message trails the inject', () => {
+    // The wedge shape: the turn answered something else after the inject
+    // landed, so the conversation now ends on an assistant message.
+    writeEvents([userText('hi'), injected('news?'), assistantText('unrelated reply')]);
+
+    const content = injectDrainContent(sessionDir);
+
+    expect(content.length).toBe(1);
+    expect(content[0]?.type).toBe('text');
+    expect(content[0]?.text).toContain('<system-reminder>');
+    expect(content[0]?.text.length).toBeGreaterThan(0);
+  });
+
+  it('returns a nudge when a tool call with no result trails the inject', () => {
+    // An unresolved tool_use folds to an assistant message too.
+    writeEvents([
+      userText('hi'),
+      injected('news?'),
+      { type: 'tool_use', data: { toolCallId: 'c1', name: 'bash', input: {} } },
+    ]);
+
+    expect(injectDrainContent(sessionDir)).toHaveLength(1);
+  });
+
+  it('returns empty content when a completed tool call trails the inject', () => {
+    // A tool_use WITH a result folds to assistant + user(tool_result), so the
+    // conversation ends on the user and an empty prompt is valid.
+    writeEvents([
+      userText('hi'),
+      injected('news?'),
+      {
+        type: 'tool_use',
+        data: {
+          toolCallId: 'c1',
+          name: 'bash',
+          input: {},
+          result: { content: [{ type: 'text', text: 'ok' }], isError: false },
+        },
+      },
+    ]);
+
+    expect(injectDrainContent(sessionDir)).toEqual([]);
+  });
+
+  it('returns empty content for an unreadable session dir rather than throwing', () => {
+    // The drain must never be the thing that breaks a turn.
+    expect(injectDrainContent(join(sessionDir, 'does-not-exist'))).toEqual([]);
+  });
+});

--- a/packages/agent/src/notifications/inject-drain-content.ts
+++ b/packages/agent/src/notifications/inject-drain-content.ts
@@ -1,0 +1,52 @@
+// ABOUTME: Decides what content an inject-drain follow-up turn should carry.
+// ABOUTME: An empty prompt only surfaces an inject while it is still the last
+// ABOUTME: message; once an assistant message trails it, an empty prompt yields
+// ABOUTME: a request ending on the assistant, which some models reject outright.
+
+import { buildProviderMessagesFromDurableEvents } from '../message-building/message-builder';
+
+export type DrainContentBlock = { type: 'text'; text: string };
+
+/**
+ * Nudge used when the injected notification is no longer the trailing message.
+ *
+ * The inject's own text is deliberately NOT repeated: it is already folded into
+ * the conversation at its own position, so re-sending it would duplicate a
+ * potentially large payload. This only has to give the turn a valid trailing
+ * user message and point the model at what it has not dealt with.
+ */
+const UNHANDLED_INJECT_NUDGE =
+  '<system-reminder>A notification arrived while you were mid-turn and has not been ' +
+  'handled yet. It appears earlier in this conversation, before your last message. ' +
+  'Read it and handle it — reply, act on it, or explicitly defer it.</system-reminder>';
+
+/**
+ * Content for the follow-up turn that drains a pending immediate inject.
+ *
+ * The drain exists because an inject that races the turn boundary must still
+ * wake the agent — under async-only delegation it is the only way a parent
+ * learns a subagent finished. It has always prompted with EMPTY content, which
+ * works only while the inject is the last thing in the transcript: it then folds
+ * into the trailing user message and the model sees it.
+ *
+ * When the turn emitted an assistant message after the inject landed, the
+ * conversation ends on the assistant instead. Dispatching that is an assistant
+ * prefill, which claude-opus-4-8 rejects with a non-retryable 400 — the turn
+ * dies and the notification is dropped with no visible failure. In that case the
+ * drain must carry a real user message.
+ *
+ * The tail role is computed with the same reducer used to build the dispatched
+ * request, so this cannot drift from what is actually sent. Any failure to read
+ * the transcript yields `[]` — the pre-existing behaviour — because a drain that
+ * throws is worse than a drain that under-nudges.
+ */
+export function injectDrainContent(sessionDir: string): DrainContentBlock[] {
+  let endsWithAssistant = false;
+  try {
+    const { messages } = buildProviderMessagesFromDurableEvents(sessionDir);
+    endsWithAssistant = messages[messages.length - 1]?.role === 'assistant';
+  } catch {
+    return [];
+  }
+  return endsWithAssistant ? [{ type: 'text', text: UNHANDLED_INJECT_NUDGE }] : [];
+}

--- a/packages/agent/src/rpc/handlers/prompt.ts
+++ b/packages/agent/src/rpc/handlers/prompt.ts
@@ -14,6 +14,7 @@ import {
   hasPendingImmediateInjects,
 } from '@lace/agent/storage/event-log';
 import { PROMPT_HANDLER_CAUGHT_STOP_REASON } from '@lace/agent/storage/event-types';
+import { injectDrainContent } from '@lace/agent/notifications/inject-drain-content';
 import { logger } from '@lace/agent/utils/logger';
 import { findUserCommand } from '@lace/agent/user-commands';
 import type {
@@ -68,7 +69,11 @@ function scheduleImmediateInjectDrain(
   ) {
     setImmediate(() => {
       if (!state.activeTurn && state.activeSession && runPromptInternalRef.current) {
-        void runPromptInternalRef.current([]);
+        // Empty content only surfaces the inject while it is still the trailing
+        // message. If the turn answered something else after it landed, the
+        // conversation now ends on an assistant message and dispatching that is
+        // a prefill the model may refuse — carry a nudge instead.
+        void runPromptInternalRef.current(injectDrainContent(state.activeSession.dir));
       }
     });
   }

--- a/packages/agent/src/runtime/test-provider.ts
+++ b/packages/agent/src/runtime/test-provider.ts
@@ -6,6 +6,7 @@ import {
 import type { WireTool } from '@lace/agent/providers/base-provider';
 import type { ToolCall, ToolResult } from '@lace/agent/tools/types';
 import { getTextContent } from '@lace/agent/providers/utils/content-helpers';
+import { appendFileSync } from 'node:fs';
 
 type TestProviderState = {
   phase: 'needs_tool' | 'awaiting_retry' | 'final';
@@ -119,6 +120,31 @@ export function getTestProviderCallCount(): number {
   return globalCallCount;
 }
 
+/**
+ * Request-shape recorder (env-gated by LACE_TEST_PROVIDER_RECORD_REQUESTS, a
+ * file path). Appends one JSON line per provider call with the role sequence of
+ * the messages the provider was actually handed.
+ *
+ * This exists so an E2E test can assert on the shape of the request the agent
+ * really dispatched, rather than re-deriving it from the transcript. The shape
+ * that matters is the LAST role: a conversation ending in an assistant message
+ * is an assistant prefill, which extended-thinking models reject outright
+ * (`This model does not support assistant message prefill`). That failure is
+ * invisible from the transcript alone, because the request is built from the
+ * event log at dispatch time.
+ *
+ * Recording must never perturb a turn, so every failure here is swallowed.
+ */
+function recordRequestShape(messages: ProviderMessage[]): void {
+  const target = process.env.LACE_TEST_PROVIDER_RECORD_REQUESTS;
+  if (!target) return;
+  try {
+    appendFileSync(target, `${JSON.stringify({ roles: messages.map((m) => m.role) })}\n`);
+  } catch {
+    // A recorder that breaks the run it observes is worse than no recorder.
+  }
+}
+
 export class TestAgentProvider extends AIProvider {
   private state: TestProviderState = {
     phase: 'needs_tool',
@@ -182,6 +208,7 @@ export class TestAgentProvider extends AIProvider {
     _model: string,
     signal?: AbortSignal
   ): Promise<ProviderResponse> {
+    recordRequestShape(messages);
     if (signal?.aborted) {
       return { content: '', toolCalls: [], stopReason: 'cancelled' };
     }

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -3,6 +3,7 @@
 import type { JsonRpcPeer } from '@lace/ent-protocol';
 import { loadSession, readSessionState, writeSessionState } from './storage/session-store';
 import { appendDurableEvent } from './storage/event-log';
+import { injectDrainContent } from './notifications/inject-drain-content';
 import { ProviderCatalogManager } from './providers/catalog/manager';
 import { ProviderInstanceManager } from './providers/instance/manager';
 import { MCPServerManager } from './mcp/server-manager';
@@ -204,7 +205,9 @@ export async function ensureReminderSchedulerForActiveSession(
       if (!runPromptInternalRef.current) return;
       setImmediate(() => {
         if (!state.activeTurn && state.activeSession && runPromptInternalRef.current) {
-          void runPromptInternalRef.current([]);
+          // Same rule as the turn-exit drain: an empty prompt is only valid
+          // while the conversation still ends on a user message.
+          void runPromptInternalRef.current(injectDrainContent(state.activeSession.dir));
         }
       });
     },


### PR DESCRIPTION
Fixes the intermittent wedge that made ada-sen go silent for 34 minutes today, and 8 times before that since 2026-07-11.

## Symptom

The agent stops responding. Every container is healthy, the doctor is green, and nothing looks wrong. The message that triggered the turn is gone.

## Root cause

The immediate-inject drain woke a follow-up turn with **empty** prompt content:

```js
void runPromptInternalRef.current([]);   // prompt.ts:71, server.ts:206
```

That works only while the inject is still the last thing in the transcript — it folds into a trailing *user* message and the model sees it. Once the turn emits an assistant message after the inject lands, the conversation ends on the **assistant**, and dispatching that is an assistant prefill:

```
400 invalid_request_error: This model does not support assistant message
prefill. The conversation must end with a user message.
```

Not retryable → turn dies as `provider_error_invalid` → notification dropped, silently.

Production signature, identical in 8 of 9 occurrences:

```
context_injected (user) -> message (assistant) -> turn_end -> prompt [] -> 400
```

The drain's **detection was already correct** — an inject above the runner's `lastSeenEventSeq` genuinely never reached the model. Only the delivery was broken.

## The trigger is the model, not thinking

Verified against the live API:

| Model | Ends on | Result |
|---|---|---|
| opus-4-8 | assistant | **400** |
| opus-4-8, no thinking block | assistant | **400** |
| opus-4-8 | user | 200 |
| sonnet-4-5 | assistant | 200 |

Disabling thinking is not a workaround. This is why the wedge only began biting when Ada moved to opus-4.8 — the drain has always sent empty prompts; the shape was harmless on sonnet.

## Fix

`injectDrainContent()` picks the follow-up content from the conversation's actual tail role, computed with `buildProviderMessagesFromDurableEvents` — the same reducer that builds the dispatched request, so it cannot drift from what is really sent.

- tail is **user** → `[]` (unchanged; the inject is already trailing)
- tail is **assistant** → a short system-reminder pointing at the unhandled notification

The inject's own text is deliberately not repeated — it is already folded in at its own position, so re-sending would duplicate a potentially large Slack envelope. Applied at **both** wake sites (turn-exit drain and `injectNotification`'s `idleWake`), which had the same defect. Unreadable transcript falls back to `[]`, the pre-existing behaviour.

## Tests

- **5 unit tests** over the tail-role decision, including `tool_use` with and without a result (they fold to different tail roles).
- **e2e reproduction** driving a real agent process, real RPC, real inject landing while the provider call is genuinely in flight. It asserts on the request the provider was actually handed via a new env-gated recorder, since the request is built at dispatch time and the transcript alone cannot show its shape. Flipped from documenting the bug to asserting every dispatched request ends on `user` **and** that the nudge path was taken — so it cannot pass by the drain simply not running.
- **Live contract test** against the real Anthropic API pinning the prefill rule, skipped when `ANTHROPIC_API_KEY` is unset.

404 tests pass across every suite touching this change.

## Full suite

Green: `npm test` passes both passes — 3404 unit tests, then 275 subprocess/e2e tests, zero failures.

(An earlier revision of this description claimed the e2e suite was flaky under load. That was wrong: it came from running bare `npx vitest run`, which collapses the two passes `npm test` performs into one parallel run. `packages/agent/vitest.config.ts` documents why the subprocess tests must run with `--no-file-parallelism` — oversubscribing the CPU makes their `initialize` timeouts flake. Run `npm test`, not `vitest run`.)
