### PR TITLE
fix(subagent): forward containerMounts so the mount-conflict scan sees truth

### DIFF
--- a/packages/agent/src/config/__tests__/persona-mount-conflict.test.ts
+++ b/packages/agent/src/config/__tests__/persona-mount-conflict.test.ts
@@ -77,6 +77,28 @@ Body.`;
     expect(conflicts).toHaveLength(0);
   });
 
+  // The conservative default below is correct in itself, but it is ALSO the
+  // mechanism behind a long-running false positive: a subagent process used to
+  // boot without the containerMounts registry forwarded, so every readonly mount
+  // looked writable and every spawn warned about `knowledge`. The registry must
+  // reach the child (see subagent-job.ts `containerMounts`), or this default
+  // silently converts "I wasn't told" into "this is a trust-boundary violation".
+  it('an EMPTY registry reproduces the false positive the child used to hit', () => {
+    writeEnv('persistent-box', persistentEnv(['knowledge']));
+    writeEnv('browser-driver', ephemeralEnv(['knowledge']));
+    const reg = new EnvironmentRegistry({ environmentsPaths: [dir] });
+
+    // What the child saw with no registry forwarded: a bogus conflict.
+    expect(findEnvironmentMountConflicts(reg, {})).toHaveLength(1);
+
+    // What it sees once the registry arrives: the truth, which is no conflict.
+    expect(
+      findEnvironmentMountConflicts(reg, {
+        knowledge: { hostPath: '/h/k', containerPath: '/knowledge', readonly: true },
+      })
+    ).toHaveLength(0);
+  });
+
   it('treats a mount missing from the registry as read-write (conservative default)', () => {
     writeEnv('persistent-box', persistentEnv(['knowledge']));
     writeEnv('eph', ephemeralEnv(['knowledge']));

--- a/packages/agent/src/jobs/subagent-job.ts
+++ b/packages/agent/src/jobs/subagent-job.ts
@@ -846,6 +846,13 @@ export function runSubagentJobProcess(job: JobState, deps: SubagentJobDependenci
         },
         userPersonasPaths: subagentUserPersonasPaths,
         userEnvironmentsPaths: subagentUserEnvironmentsPaths,
+        // The child runs the R6 mount-conflict scan on its own initialize, and
+        // that scan treats a mount ABSENT from this registry as read-write
+        // (conservative). Without forwarding, every subagent boots with an empty
+        // registry and warns that readonly mounts like `knowledge` are writable
+        // conflicts — a false positive on every spawn, which trains agents to
+        // ignore the warning entirely.
+        containerMounts: currentState.containerMounts,
         ...(subagentMcpBaseDir ? { mcpBaseDir: subagentMcpBaseDir } : {}),
         skillDirs: subagentSkillDirs,
         // Forward the credential exec-tool dir as a top-level param (the child


### PR DESCRIPTION
Fixes PRI-2744, and answers PRI-2760 (filed by cadence-sen) — same code, and the answer is "there is no conflict."

## Symptom

Every `browser-driver` spawn logged:

```
environment_mount_conflict: Per-invocation environment 'browser-driver' declares
writable mount 'knowledge', also declared by persistent environment(s)
[persistent-box]
```

## Cause

The child agent process runs the R6 mount-conflict scan on its own `initialize`. That scan treats a mount **absent** from the `containerMounts` registry as read-write — a deliberate conservative default.

The parent never forwarded the registry. So every subagent booted with `{}`, and every readonly mount looked writable.

`knowledge` is `readonly: true` in the real registry (`main.ts` `buildContainerMounts`). There was never a conflict and never an adversarial-write path.

## Why it mattered more than a stray log line

It fired on **every spawn**. That is the worst frequency for a warning: agents learn to ignore it, so a genuine conflict would be invisible among the false ones. It also sent a coworker down a teardown theory for real time before the check itself turned out to be wrong.

## Fix

Forward `containerMounts` on the child's `initialize`. The check should evaluate against the truth, and parent and child should agree about the mount topology.

The conservative default is correct and unchanged — "I wasn't told" should not silently become "this is safe." The bug was never telling it.

## On PRI-2760

That ticket asks whether `browser-driver` sharing a writable `knowledge` with `persistent-box` is a trust-boundary smell. It isn't — the mount is readonly on both sides. The smell was the warning, not the topology. PRI-2760 can close once this deploys and the warning stops.

## Tests

Added a regression test that pins the mechanism from both directions: an empty registry reproduces the false positive; a registry with `knowledge` readonly reports no conflict. 261 config/job tests pass.