### PR TITLE
fix(runner): stop announcing a notification as "a new message"

### DIFF
--- a/packages/agent/src/core/conversation/__tests__/runner.context-inject.test.ts
+++ b/packages/agent/src/core/conversation/__tests__/runner.context-inject.test.ts
@@ -279,15 +279,32 @@ describe('ConversationRunner - mid-turn context_injected re-read', () => {
   });
 
   it('bareTextStopReminder returns the verify reminder when no injection was seen', () => {
-    const reminder = bareTextStopReminder(false);
+    const reminder = bareTextStopReminder('none');
     expect(reminder).toContain('verify your work before stopping');
-    expect(reminder).not.toContain('new message arrived mid-turn');
+    expect(reminder).not.toContain('arrived mid-turn');
   });
 
-  it('bareTextStopReminder returns a handle-the-new-message directive when an injection was seen', () => {
-    const reminder = bareTextStopReminder(true);
+  it('bareTextStopReminder returns a handle-the-new-message directive for a real message', () => {
+    const reminder = bareTextStopReminder('message');
     expect(reminder).toContain('new message arrived mid-turn');
     expect(reminder).not.toContain('verify your work before stopping');
+  });
+
+  it('bareTextStopReminder calls a notification a notification, not a new message', () => {
+    // A job-completion or fired reminder is NOT an inbound message. Announcing
+    // it as one sends the agent looking for a message that does not exist —
+    // it reads as a phantom, and the defensive fix is to re-fetch the thread
+    // before every reply, which is a per-turn tax.
+    const reminder = bareTextStopReminder('notification');
+    expect(reminder).toContain('notification');
+    expect(reminder).not.toContain('new message arrived');
+    expect(reminder).not.toContain('verify your work before stopping');
+  });
+
+  it('bareTextStopReminder names both when a message and a notification both landed', () => {
+    const reminder = bareTextStopReminder('both');
+    expect(reminder).toContain('new message');
+    expect(reminder).toContain('notification');
   });
 
   it('flips the bare-text stop reminder to a directive when a mid-turn injection was seen', async () => {

--- a/packages/agent/src/core/conversation/runner.ts
+++ b/packages/agent/src/core/conversation/runner.ts
@@ -251,10 +251,52 @@ const CLEAN_STOP_REASONS = new Set(['end_turn', 'stop_sequence', 'max_turns']);
  * handle the new message. The reminder keeps its original value (catching a
  * premature "Done") on turns with no pending inbound.
  */
-export function bareTextStopReminder(sawInjectionThisTurn: boolean): string {
-  return sawInjectionThisTurn
-    ? '<system-reminder>A new message arrived mid-turn and is now in your context above. Read it and handle it — reply, act on it, or explicitly defer it — before stopping. Do not just restate your prior status. Call a tool.</system-reminder>'
-    : '<system-reminder>You must use a tool to verify your work before stopping. Do not respond with text — call a tool.</system-reminder>';
+export type MidTurnArrival = 'none' | 'message' | 'notification' | 'both';
+
+/**
+ * What a `context_injected` event actually carries. A job-completion or a
+ * fired reminder is a NOTIFICATION, not an inbound message — announcing it as
+ * "a new message arrived" sends the agent hunting for a message that does not
+ * exist. That reads as a phantom, and the rational defence is to re-fetch the
+ * thread before every reply, which taxes every turn.
+ */
+export function classifyInjectedArrival(texts: string[]): MidTurnArrival {
+  let sawNotification = false;
+  let sawMessage = false;
+  for (const text of texts) {
+    if (/<notification\b/.test(text)) sawNotification = true;
+    else sawMessage = true;
+  }
+  if (sawNotification && sawMessage) return 'both';
+  if (sawNotification) return 'notification';
+  if (sawMessage) return 'message';
+  return 'none';
+}
+
+export function bareTextStopReminder(arrival: MidTurnArrival): string {
+  const handle =
+    ' Read it and handle it — reply, act on it, or explicitly defer it — before stopping.' +
+    ' Do not just restate your prior status. Call a tool.</system-reminder>';
+  switch (arrival) {
+    case 'message':
+      return (
+        '<system-reminder>A new message arrived mid-turn and is now in your context above.' + handle
+      );
+    case 'notification':
+      return (
+        '<system-reminder>A notification arrived mid-turn and is now in your context above.' +
+        ' It is a notification, not an inbound message — there is no new message to look for.' +
+        handle
+      );
+    case 'both':
+      return (
+        '<system-reminder>A new message and a notification arrived mid-turn and are now in' +
+        ' your context above.' +
+        handle
+      );
+    case 'none':
+      return '<system-reminder>You must use a tool to verify your work before stopping. Do not respond with text — call a tool.</system-reminder>';
+  }
 }
 
 function hasFutureTenseIntent(text: string): boolean {
@@ -561,7 +603,7 @@ export class ConversationRunner {
     // bare-text stop-checkpoint reminder from "verify before stopping" to
     // "handle the new message", so a mid-turn inbound isn't crowded out by the
     // standby/verify wrap-up.
-    let sawInjectionThisTurn = false;
+    let injectedArrival: MidTurnArrival = 'none';
     let nextRequestOptions: RequestOptions | undefined;
     // Carries forward the parsed structured object from the last provider
     // response that produced one, surfaced on the RunResult for the prompt
@@ -604,7 +646,21 @@ export class ConversationRunner {
         for (const content of injections) {
           providerMessages = appendOrMergeUser(providerMessages, content);
         }
-        if (injections.length > 0) sawInjectionThisTurn = true;
+        if (injections.length > 0) {
+          // Describe what actually landed. Calling a job-completion "a new
+          // message" is the phantom-inbound bug.
+          const arrival = classifyInjectedArrival(
+            injections.flatMap((content) =>
+              typeof content === 'string'
+                ? [content]
+                : (content as Array<{ type?: string; text?: string }>)
+                    .filter((b) => typeof b?.text === 'string')
+                    .map((b) => b.text as string)
+            )
+          );
+          injectedArrival =
+            injectedArrival === 'none' || injectedArrival === arrival ? arrival : 'both';
+        }
         lastSeenEventSeq = newWatermark;
 
         // Inject a reminder every LOOP_CHECK_INTERVAL turns to help detect
@@ -1015,7 +1071,7 @@ export class ConversationRunner {
               { role: 'assistant' as const, content: assistantPlaceholder },
               {
                 role: 'user' as const,
-                content: bareTextStopReminder(sawInjectionThisTurn),
+                content: bareTextStopReminder(injectedArrival),
               },
             ];
             nextRequestOptions = { toolChoice: 'required' };


### PR DESCRIPTION
## Reported

Cadence: every job-completion and reminder reaches her *twice*, each tripping a phantom "new message arrived mid-turn" with no actual new message behind it. She's been defensively `fetch`-ing the thread before nearly every reply all week to tell ghosts from real inbound — a per-turn tax and a real misread risk.

## What's actually happening

Nothing is duplicated. Her transcript shows every `job-id` appearing **exactly once** in `context_injected`.

What doubles is the *announcement*. `bareTextStopReminder` fires at the bare-text stop-checkpoint for **any** `context_injected` event and says:

> A new message arrived mid-turn and is now in your context above. Read it and handle it…

For a job-completion or a fired reminder that's false. The agent is told to find and handle a message that does not exist. One event, two prompts, the second describing a ghost — which is precisely what she described.

## Fix

Classify what landed, then say that:

- **notification** → announced as a notification, with an explicit *"there is no new message to look for"*
- **message** → unchanged directive
- **both** → names both

The mid-turn steering this checkpoint exists for (the Slack-delivery reliability work) is untouched.

## A theory I killed before building it

My first read was `JobManager.fanoutToInject` calling `inject()` once per matching subscription — which *would* genuinely double-write a session-level notification. I checked Cadence's transcript before writing any code and it disproved the theory. Noted in the commit so the next reader doesn't re-derive it.

## Verification

Full agent workspace green (3407 passed). I confirmed the new tests actually execute rather than trusting the reporter's silence: broke one assertion with a sentinel, watched it fail by name, restored it.