### PR TITLE
fix(jobs): route job_kill --destroy through the shim even when untracked

### DIFF
--- a/packages/agent/src/jobs/workspace-reaper.ts
+++ b/packages/agent/src/jobs/workspace-reaper.ts
@@ -101,6 +101,18 @@ export class WorkspaceReaper {
     this.released.add(childId);
   }
 
+  /**
+   * Route a release for a child this process never tracked (the tracker is
+   * per-process; a lace restart forgets live containers). Same shim route as
+   * dispose but with the parent supplied by the caller, since there is no
+   * entry to read it from. The shim's release verb is idempotent, so a child
+   * with no container is a harmless no-op server-side.
+   */
+  async disposeUntracked(parentId: string, childId: string): Promise<void> {
+    await this.containerManager?.releasePerInvocation(parentId, childId);
+    this.released.add(childId);
+  }
+
   /** True once this child has been disposed in this process (non-resumable). */
   isReleased(childId: string): boolean {
     return this.released.has(childId);

--- a/packages/agent/src/providers/bedrock-provider.test.ts
+++ b/packages/agent/src/providers/bedrock-provider.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Tests for BedrockProvider - Claude via AWS Bedrock
 // ABOUTME: Mirrors the AnthropicProvider tests against the bedrock-sdk client
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, onTestFinished } from 'vitest';
 import { BedrockProvider } from './bedrock-provider';
 import { Tool } from '@lace/agent/tools/tool';
 import { ToolResult, ToolContext } from '@lace/agent/tools/types';
@@ -99,8 +99,16 @@ describe('BedrockProvider', () => {
     });
 
     it('reports not configured when no region is supplied', () => {
-      const p = new BedrockProvider({});
-      expect(p.isConfigured()).toBe(false);
+      // The provider deliberately falls back to process.env.AWS_REGION, so a
+      // developer shell with AWS_REGION set would flip this test unless we
+      // isolate the env.
+      vi.stubEnv('AWS_REGION', '');
+      try {
+        const p = new BedrockProvider({});
+        expect(p.isConfigured()).toBe(false);
+      } finally {
+        vi.unstubAllEnvs();
+      }
     });
   });
 
@@ -142,6 +150,8 @@ describe('BedrockProvider', () => {
     });
 
     it('throws when no region is configured at request time', async () => {
+      vi.stubEnv('AWS_REGION', '');
+      onTestFinished(() => vi.unstubAllEnvs());
       const p = new BedrockProvider({});
       p.setSystemPrompt('s');
       // Defeat retries so the error surfaces immediately

--- a/packages/agent/src/tools/implementations/__tests__/job-kill-destroy-container.test.ts
+++ b/packages/agent/src/tools/implementations/__tests__/job-kill-destroy-container.test.ts
@@ -111,6 +111,40 @@ describe('job_kill destroy_container', () => {
     expect(reaper.get('sess_child')).toBeDefined();
   });
 
+  it('releases an UNTRACKED child through the shim instead of claiming no container exists', async () => {
+    // The reaper is a per-process tracker. After a lace restart the entry for a
+    // live container is gone — and job_kill(destroy_container) used to report
+    // "no container to destroy" while that container demonstrably kept holding
+    // its port (Cadence, 2026-08-01, container b08acf20). The shim's release
+    // verb is idempotent, so when the job names a child session we route the
+    // release regardless of tracking and let the shim decide.
+    const calls: string[] = [];
+    const releasePerInvocation = vi.fn(async (parent: string, child: string) => {
+      calls.push(`release:${parent}:${child}`);
+    });
+    const reaper = new WorkspaceReaper();
+    reaper.bindRuntime({ releasePerInvocation } as unknown as ContainerManager);
+    // NOT tracked: no reaper.track() call — simulates the post-restart process.
+    const job = {
+      jobId: 'job_x',
+      status: 'completed',
+      subagentSessionId: 'sess_child',
+    } as JobState;
+    const jobManager = {
+      getJob: vi.fn().mockReturnValue(job),
+      cancelJob: vi.fn(),
+    } as unknown as JobManager;
+
+    const result = await new JobKillTool().execute(
+      { jobId: 'job_x', destroy_container: true },
+      ctx({ jobManager, workspaceReaper: reaper, activeSessionId: 'sess_parent' })
+    );
+    expect(result.status).toBe('completed');
+    expect(calls).toEqual(['release:sess_parent:sess_child']);
+    expect(result.content[0].text).not.toContain('no container to destroy');
+    expect(reaper.isReleased('sess_child')).toBe(true);
+  });
+
   it('destroy_container on an unknown job fails', async () => {
     const reaper = new WorkspaceReaper();
     const jobManager = { getJob: vi.fn().mockReturnValue(undefined) } as unknown as JobManager;

--- a/packages/agent/src/tools/implementations/job_kill.ts
+++ b/packages/agent/src/tools/implementations/job_kill.ts
@@ -77,9 +77,28 @@ Parameters:
         await workspaceReaper.runExclusive(childId, () => workspaceReaper.dispose(childId));
         return ok(`Job ${jobId} torn down — container destroyed and workspace removed.`);
       }
+      // Tracked by a DIFFERENT session: not ours to tear down.
+      if (entry) {
+        return ok(
+          `Job ${jobId} ${wasRunning ? 'cancelled' : 'already finished'} (container owned by another session; not destroyed).`
+        );
+      }
+      // Untracked. The reaper is per-process, so after a lace restart the entry
+      // for a live container is simply gone — reporting "no container to
+      // destroy" here left a finished browser holding its port with no
+      // self-serve way to reclaim it. The job is already scoped to this
+      // session, and the shim's release verb is idempotent (releasing a child
+      // with no container is a no-op there), so route the release and let the
+      // shim decide.
+      await workspaceReaper.runExclusive(childId, () =>
+        workspaceReaper.disposeUntracked(activeSessionId ?? '', childId)
+      );
+      return ok(
+        `Job ${jobId} ${wasRunning ? 'cancelled' : 'already finished'}; release routed to the shim for its container (untracked in this process).`
+      );
     }
-    // Nothing tracked to tear down (host subagent, persistent box, or already
-    // gone): the kill above is the whole effect.
+    // No child session at all (host subagent / persistent box): the kill above
+    // is the whole effect.
     return ok(
       `Job ${jobId} ${wasRunning ? 'cancelled' : 'already finished'} (no container to destroy).`
     );


### PR DESCRIPTION
## The bug Cadence hit

`job_kill(destroy_container=true)` on a *finished* browser job reported **"no container to destroy"** while the container demonstrably kept holding port 6080 inside the 5-min busy window — no self-serve way to reclaim it (2026-08-01, container `b08acf20`).

## Root cause

The gate was the `WorkspaceReaper`, a **per-process** tracker. After a lace restart, the entry for a live container is gone, and `job_kill` treated "untracked in this process" as "no container exists". Those are different claims.

## Fix

The job still names its child session; the shim's `release` verb is idempotent (releasing a child with no container is a harmless no-op server-side) and routes by `(parent, child)`. So when the child is untracked, send the release and let the shim — which actually knows — decide. Cross-session ownership stays untouched, now with an honest message ("owned by another session") instead of the false "no container".

New test simulates the post-restart process (no `track()` call) and pins that the release is routed and the misleading message is gone.

## Drive-by: two pre-existing Bedrock test failures

`bedrock-provider.test.ts` failed in any shell with `AWS_REGION` set, because the provider deliberately falls back to `process.env.AWS_REGION` — so "no region supplied" was false in that environment. Verified pre-existing on a clean tree before touching them. The tests now stub the env.

Full agent workspace green: 3408 passed.