### PR TITLE
feat(catalog): add claude-opus-5

### DIFF
--- a/packages/agent/src/providers/catalog/data/anthropic.json
+++ b/packages/agent/src/providers/catalog/data/anthropic.json
@@ -8,6 +8,20 @@
   "default_small_model_id": "claude-3-5-haiku-20241022",
   "models": [
     {
+      "id": "claude-opus-5",
+      "name": "Claude Opus 5",
+      "cost_per_1m_in": 5,
+      "cost_per_1m_out": 25,
+      "cost_per_1m_in_cached": 6.25,
+      "cost_per_1m_out_cached": 0.5,
+      "context_window": 1000000,
+      "default_max_tokens": 50000,
+      "can_reason": true,
+      "has_reasoning_effort": true,
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
       "id": "claude-opus-4-8",
       "name": "Claude Opus 4.8",
       "cost_per_1m_in": 5,


### PR DESCRIPTION
Adds `claude-opus-5` to the anthropic catalog, cloned from the opus-4-8 entry (same $5/$25 pricing, 1M context, effort surface — it's a drop-in successor per the migration guide).

**Why it matters:** for a model missing from the catalog, `getModelReasoningEffort` returns `undefined` → the payload builder sends **neither effort nor adaptive thinking**, and `getModelMaxOutputTokens` falls back to 8192. So flipping a persona to `claude-opus-5` without this entry would be a silent capability downgrade (no thinking, tiny output budget), not an error.

Catalog + full agent suite green (3408).