### PR TITLE
fix(catalog): a cached Anthropic catalog must not shadow new static metadata

### DIFF
--- a/packages/agent/src/providers/anthropic/dynamic-provider.test.ts
+++ b/packages/agent/src/providers/anthropic/dynamic-provider.test.ts
@@ -1,0 +1,107 @@
+// ABOUTME: Tests that the Anthropic dynamic catalog never downgrades a model the
+// ABOUTME: static catalog already describes, and that an inferred entry for an
+// ABOUTME: unknown model cannot silently impose a truncating output cap. A cached
+// ABOUTME: catalog is merged against the CURRENT static catalog for the same reason:
+// ABOUTME: the 24h TTL must not outlive a deploy that adds a model.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { AnthropicDynamicProvider } from './dynamic-provider';
+import type { CatalogProvider } from '../catalog/types';
+
+/**
+ * A static catalog carrying the rich metadata a deploy adds — the real
+ * claude-opus-5 shape: 1M context, a 50k output budget, effort enabled.
+ */
+function staticCatalog(): CatalogProvider {
+  return {
+    name: 'Anthropic',
+    default_large_model_id: 'claude-opus-5',
+    default_small_model_id: 'claude-haiku-4-5-20251001',
+    models: [
+      {
+        id: 'claude-opus-5',
+        name: 'Claude Opus 5',
+        context_window: 1_000_000,
+        default_max_tokens: 50_000,
+        can_reason: true,
+        has_reasoning_effort: true,
+        default_reasoning_effort: 'medium',
+      },
+    ],
+  } as unknown as CatalogProvider;
+}
+
+describe('AnthropicDynamicProvider catalog merge', () => {
+  let tempDir: string;
+  let originalLaceDir: string | undefined;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lace-dyncat-'));
+    originalLaceDir = process.env.LACE_DIR;
+    process.env.LACE_DIR = tempDir;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalLaceDir === undefined) delete process.env.LACE_DIR;
+    else process.env.LACE_DIR = originalLaceDir;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('keeps the static entry for a model the API also reports', async () => {
+    // The API returns the model; the static catalog knows its real limits. The
+    // dynamic layer exists to filter by availability, never to re-describe.
+    const provider = new AnthropicDynamicProvider('sen-anthropic');
+    const inner = (provider as unknown as { client: { fetchAllModels: unknown } }).client;
+    vi.spyOn(
+      inner as { fetchAllModels: () => Promise<unknown> },
+      'fetchAllModels'
+    ).mockResolvedValue([{ id: 'claude-opus-5', display_name: 'Claude Opus 5' }]);
+
+    const merged = await provider.getCatalog('sk-test', staticCatalog(), true);
+    const model = merged.models.find((m) => m.id === 'claude-opus-5');
+    expect(model?.default_max_tokens).toBe(50_000);
+    expect(model?.context_window).toBe(1_000_000);
+  });
+
+  it('a STALE cache must not shadow a model the static catalog just gained', async () => {
+    // The 24h TTL outlived a deploy: Cadence went silent on 2026-08-04 because a
+    // cache written before the claude-opus-5 catalog entry landed kept serving an
+    // inferred 8192-token cap. Adaptive thinking counts against max_tokens, so an
+    // 8192 ceiling truncates any substantial turn — the reply was cut mid-flight.
+    const provider = new AnthropicDynamicProvider('sen-anthropic');
+    const cacheDir = path.join(tempDir, 'catalogs');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(cacheDir, 'anthropic-sen-anthropic.json'),
+      JSON.stringify({
+        _meta: {
+          fetchedAt: new Date().toISOString(), // fresh by TTL, stale by content
+          version: '1',
+          availableModelCount: 1,
+          source: 'api',
+        },
+        provider: {
+          name: 'Anthropic',
+          models: [
+            // What inferModelMetadata produced before the deploy.
+            {
+              id: 'claude-opus-5',
+              name: 'Claude Opus 5',
+              context_window: 200_000,
+              default_max_tokens: 8192,
+            },
+          ],
+        },
+      })
+    );
+
+    const merged = await provider.getCatalog('sk-test', staticCatalog(), false);
+    const model = merged.models.find((m) => m.id === 'claude-opus-5');
+    expect(model?.default_max_tokens).toBe(50_000);
+    expect(model?.context_window).toBe(1_000_000);
+  });
+});

--- a/packages/agent/src/providers/anthropic/dynamic-provider.ts
+++ b/packages/agent/src/providers/anthropic/dynamic-provider.ts
@@ -9,6 +9,13 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { logger } from '@lace/agent/utils/logger';
 
+// Fallbacks for a model the static catalog does not describe. Both are guesses;
+// they are sized so a wrong guess degrades cost, not correctness. A too-small
+// output budget is the dangerous direction — thinking tokens count against
+// max_tokens, so a low cap truncates a turn mid-answer with no error.
+const INFERRED_MAX_OUTPUT_TOKENS = 32_000;
+const INFERRED_CONTEXT_WINDOW = 200_000;
+
 interface CachedCatalog {
   _meta: {
     fetchedAt: string;
@@ -38,11 +45,17 @@ export class AnthropicDynamicProvider {
     staticCatalog: CatalogProvider,
     forceRefresh = false
   ): Promise<CatalogProvider> {
-    // Check cache first (unless force refresh)
+    // Check cache first (unless force refresh). A cache hit is reconciled
+    // against the CURRENT static catalog rather than returned as-is: the TTL is
+    // 24h, so a cache written before a deploy that ADDS a model would otherwise
+    // keep serving that model's inferred placeholder metadata long after the
+    // real entry shipped. That is not cosmetic — an inferred entry carries a
+    // deliberately conservative output cap, and with adaptive thinking counted
+    // against max_tokens a too-small cap truncates turns instead of erroring.
     if (!forceRefresh) {
       const cached = await this.loadCache();
       if (cached && !this.isCacheStale(cached)) {
-        return cached.provider;
+        return this.reconcileWithStatic(cached.provider, staticCatalog);
       }
     }
 
@@ -109,15 +122,50 @@ export class AnthropicDynamicProvider {
     };
   }
 
+  /**
+   * Metadata for a model the API reports but the static catalog has never heard
+   * of. Everything here is a guess, so it is deliberately shaped to fail loudly
+   * rather than quietly: the output budget is large enough that a real turn is
+   * not truncated mid-response (a small "conservative" cap is the more harmful
+   * guess — with thinking counted against max_tokens it silently cuts answers
+   * off), and the context window follows the current-generation default.
+   *
+   * The right fix for any model that shows up here is a static catalog entry.
+   */
   private inferModelMetadata(apiModel: AnthropicModel): CatalogModel {
-    // Use display_name from API for new models
-    // Conservative defaults for context window and max tokens
     return {
       id: apiModel.id,
       name: apiModel.display_name,
-      context_window: 200000, // All Claude models have 200k context
-      default_max_tokens: 8192, // Conservative default
+      context_window: INFERRED_CONTEXT_WINDOW,
+      default_max_tokens: INFERRED_MAX_OUTPUT_TOKENS,
     };
+  }
+
+  /**
+   * Merge a cached (or otherwise inferred) catalog with the current static one:
+   * availability comes from the cache, metadata from the static catalog whenever
+   * it knows the model. Never widens availability — a model absent from the
+   * cache stays absent.
+   */
+  private reconcileWithStatic(
+    cachedProvider: CatalogProvider,
+    staticCatalog: CatalogProvider
+  ): CatalogProvider {
+    const staticById = new Map(staticCatalog.models.map((m) => [m.id, m]));
+    let upgraded = 0;
+    const models = cachedProvider.models.map((cachedModel) => {
+      const staticModel = staticById.get(cachedModel.id);
+      if (!staticModel) return cachedModel;
+      if (staticModel !== cachedModel) upgraded += 1;
+      return staticModel;
+    });
+    if (upgraded > 0) {
+      logger.debug('Reconciled cached Anthropic catalog against static metadata', {
+        instanceId: this.instanceId,
+        upgraded,
+      });
+    }
+    return { ...cachedProvider, models };
   }
 
   private async loadCache(): Promise<CachedCatalog | null> {


### PR DESCRIPTION
## The symptom

Cadence didn't reply to a message that mentioned her. It **was** delivered — admitted at 00:23:38, envelope built with her ts, turn ran. But:

```
model: claude-opus-5   maxTokens: 8192   outputTokens: 8192
```

Output tokens exactly equal max tokens: truncated mid-response. One queued `slack_send_message` never landed. Meanwhile the catalog on disk in her container correctly said `default_max_tokens: 50000`.

## The cause

`AnthropicDynamicProvider` caches its merged catalog for 24h and returned that cache **verbatim**. Her cache was written *before* the deploy that added `claude-opus-5`, so it still held the placeholder `inferModelMetadata()` invents for an unknown model — `context_window: 200000`, `default_max_tokens: 8192`. The real static entry was never consulted. **The TTL outlived the deploy.**

Compounding it: opus-5 thinks by default and thinking counts against `max_tokens`, so an 8192 ceiling nearly guarantees truncation on a substantial turn. That's why she died on a long multi-ticket reply and not on a short one.

## Two fixes

1. **Reconcile a cache hit against the current static catalog.** Availability still comes from the cache (never widened — a model absent from the cache stays absent); metadata comes from the static catalog wherever it knows the model. A deploy that adds a model now takes effect immediately.
2. **Stop inferring a truncating cap.** 8192 was commented "Conservative default", but it's conservative in the *harmful* direction — a low output cap silently cuts answers off instead of erroring. Inferred entries get 32k now, and both fallbacks are named constants that document why.

## Verification

Two tests: the fresh-fetch path (already correct) and the stale-cache path (the bug). Confirmed the stale-cache test **fails against the unfixed code** before trusting it. Full agent suite 3410 green, typecheck clean.

## What I'd flag about my own process

I verified that opus-5 bump by checking the catalog file on disk and the personas in-container, then called it done. The `maxTokens: 8192` was sitting in the very log line I'd already read and I didn't look at the number. Checking the artifact isn't checking the behaviour — same lesson as the deploy-verification one, in a new costume.