### PR TITLE
Emit compaction_complete session/update from ent/session/compact

### DIFF
--- a/packages/agent/src/rpc/handlers/__tests__/session-operations.compact-prompt.test.ts
+++ b/packages/agent/src/rpc/handlers/__tests__/session-operations.compact-prompt.test.ts
@@ -253,6 +253,47 @@ describe('ent/session/compact — track-based strategy', () => {
     }
   });
 
+  it('emits a compaction_complete session/update after compacting', async () => {
+    const state = createAgentServerState();
+    const { client, server } = createPairedPeers((peer) => registerAgentRpcMethods(peer, state));
+
+    const notifications: Array<Record<string, unknown>> = [];
+    client.onRequest('session/update', async (params) => {
+      notifications.push(params as Record<string, unknown>);
+      return undefined;
+    });
+
+    try {
+      await client.request('initialize', defaultInitializeParams());
+      const newResult = (await client.request('session/new', { cwd: workDir, mcpServers: [] })) as {
+        sessionId: string;
+      };
+
+      const sessionDir = getSessionDir(newResult.sessionId);
+      writeMinimalConversation(sessionDir);
+
+      const result = (await client.request('ent/session/compact', {
+        strategy: 'track-based',
+      })) as {
+        previousTokens: number;
+        currentTokens: number;
+        messagesCompacted: number;
+        strategy?: string;
+      };
+
+      const update = notifications.find((n) => n.type === 'compaction_complete');
+      expect(update).toBeDefined();
+      expect(update?.strategy).toBe(result.strategy);
+      expect(update?.messagesCompacted).toBe(result.messagesCompacted);
+      expect(typeof update?.sessionId).toBe('string');
+      expect(typeof update?.streamSeq).toBe('number');
+      expect(update?.tokensReclaimed).toBe(result.previousTokens - result.currentTokens);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+
   it('rejects legacy strategy names', async () => {
     const state = createAgentServerState();
     const { client, server } = createPairedPeers((peer) => registerAgentRpcMethods(peer, state));

--- a/packages/agent/src/rpc/handlers/session-operations.ts
+++ b/packages/agent/src/rpc/handlers/session-operations.ts
@@ -552,6 +552,26 @@ export function registerSessionOperationHandlers(
       const { messages: afterMessages } = buildProviderMessagesFromDurableEvents(sessionDir);
       const currentTokens = estimateProviderTokens(afterMessages) + estimateTokens(systemPrompt);
 
+      // Re-read state: rerenderPersonaForSession may have written a fresh
+      // system_prompt_set since sessionState was last captured above.
+      sessionState = readSessionState(sessionDir);
+      peer.notify('session/update', {
+        sessionId: state.activeSession!.meta.sessionId,
+        streamSeq: sessionState.nextStreamSeq,
+        type: 'compaction_complete',
+        strategy: name,
+        messagesCompacted: result.compactionEvent.data.messagesCompacted ?? 0,
+        tokensReclaimed: previousTokens - currentTokens,
+      });
+      // Advance the stream sequence so later session/update notifications on
+      // this session don't reuse this compaction_complete's streamSeq value,
+      // mirroring injectIntoActiveSession's post-notify bump above.
+      writeSessionState(sessionDir, {
+        ...sessionState,
+        nextStreamSeq: sessionState.nextStreamSeq + 1,
+      });
+      state.activeSession = loadSession(state.activeSession!.meta.sessionId);
+
       return {
         previousTokens,
         currentTokens,


### PR DESCRIPTION
The ent-protocol schema `SessionUpdateCompactionCompleteSchema` has existed since it was specified, but nothing emitted it. This makes the `ent/session/compact` handler notify `session/update` with `{sessionId, streamSeq, type: 'compaction_complete', strategy, messagesCompacted, tokensReclaimed}` after the durable `context_compacted` event is appended and before the RPC result resolves.

**Consumer:** sen-core's post-compaction wake (PRI-2884) subscribes to this so a single subscriber covers every compaction path (threshold-triggered, nightly rotation, any future in-process source) instead of hand-wiring each call site. sen-core's subscribing change must not deploy before this does.

Two things a reviewer should know:

- **This "notify" change also bumps and persists `nextStreamSeq`.** The compact handler previously never touched it, so a subsequent `session/update` on the same session would have reused this notification's `streamSeq`. The added read→notify→bump→`writeSessionState`→reload sequence reproduces the codebase's established convention (`injectIntoActiveSession` in the same file, and `emitSessionUpdate` in server.ts) rather than inventing a new one.
- **`tokensReclaimed` can be negative** (compaction overhead can exceed savings — a real production rotation measured 47,971 → 51,197 tokens). The schema is `z.number().optional()` with no nonnegative bound, and the test asserts exact equality, so no clamp.

TDD: failing test first in `session-operations.compact-prompt.test.ts`; packages/agent suite 275 passed / 12 skipped, typecheck + lint clean.

Notification delivery is requester-only (`JsonRpcPeer.notify` writes to its single wired transport) — operator CLIs compacting over their own connection do not notify the main sen-core process; that limitation is documented downstream.

Linear: PRI-2884