### PR TITLE
Fix prettier drift breaking CI on main

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -42,3 +42,6 @@ CHANGELOG.md
 
 # Byte-identical test fixtures - tests assert exact match against these
 tests/scenarios/persona-path-migration-baseline/
+# Golden byte snapshots — exact committed bytes compared via toMatchFileSnapshot;
+# formatting them breaks the golden-bytes tests
+packages/agent/src/providers/__tests__/golden/*.json

--- a/docs/architecture/CODE-MAP.md
+++ b/docs/architecture/CODE-MAP.md
@@ -16,7 +16,8 @@
 - `packages/cli/src/main.ts`: CLI executable.
 - `packages/agent/src/plugins/`: the plugin system — one `LACE_PLUGINS` loader
   feeding four typed registries (tools, compaction, recall, runtimes) plus the
-  persona/skill directory contributions. Embedders extend lace here. See [Writing Plugins](../writing-plugins.md) and the
+  persona/skill directory contributions. Embedders extend lace here. See
+  [Writing Plugins](../writing-plugins.md) and the
   [Plugin System Reference](../reference/plugins.md). For external tools (exec
   binaries, MCP servers) see [External Tools](../external-tools.md).
 

--- a/docs/architecture/event-seq-authority.md
+++ b/docs/architecture/event-seq-authority.md
@@ -23,10 +23,10 @@ Each session directory holds:
 2. Write `H + 1` to the head file — **reserving** `H` before appending.
 3. Append the JSONL line with `seq = H`.
 
-The lock is held across the JSONL append, so reading `MAX(JSONL)` for seeding and
-the turn_end dedup both see a stable log with no concurrent appender interleaving.
-The recall/journal index write-through happens outside the lock — it is
-best-effort and never on a correctness path.
+The lock is held across the JSONL append, so reading `MAX(JSONL)` for seeding
+and the turn_end dedup both see a stable log with no concurrent appender
+interleaving. The recall/journal index write-through happens outside the lock —
+it is best-effort and never on a correctness path.
 
 ## Why reserve-before-append
 
@@ -39,8 +39,8 @@ event was never durable, the caller never saw success, and the next append gets
 
 When a session is opened, the head is reconciled monotonically:
 `head = MAX(readHead() | 0, MAX(JSONL) + 1)`. This only ever moves the head
-**up**, so a stale or lost head (an un-fsync'd write lost to a crash, a head that
-never existed) can never hand out a seq `<=` an existing JSONL seq.
+**up**, so a stale or lost head (an un-fsync'd write lost to a crash, a head
+that never existed) can never hand out a seq `<=` an existing JSONL seq.
 
 ## Sequence numbers are unique and monotonic; gaps are normal
 
@@ -48,6 +48,6 @@ never existed) can never hand out a seq `<=` an existing JSONL seq.
 expected** — a burned reserve leaves a hole — and every consumer tolerates them:
 the reducer sorts by seq, watermarks compare with `>` / `<=` (never `+1`),
 checkpoints match exact stored seqs, and range reads tolerate missing neighbors.
-Nothing assumes gapless seqs. `SessionState.nextEventSeq` is advisory only: it is
-derived from the reconciled head on open and never drives assignment, and a gap
-no longer triggers a state-file rewrite.
+Nothing assumes gapless seqs. `SessionState.nextEventSeq` is advisory only: it
+is derived from the reconciled head on open and never drives assignment, and a
+gap no longer triggers a state-file rewrite.

--- a/docs/architecture/jobs.md
+++ b/docs/architecture/jobs.md
@@ -1,27 +1,53 @@
 # Jobs system architecture
 
-This document describes Lace's jobs system as implemented in this checkout. It is intentionally code-path oriented: if behavior changes, update the references below alongside the code.
+This document describes Lace's jobs system as implemented in this checkout. It
+is intentionally code-path oriented: if behavior changes, update the references
+below alongside the code.
 
 ## Scope and vocabulary
 
-A **job** is one asynchronous unit of work owned by the current parent session. Lace currently has two job types (`JobType` in `packages/agent/src/server-types.ts`):
+A **job** is one asynchronous unit of work owned by the current parent session.
+Lace currently has two job types (`JobType` in
+`packages/agent/src/server-types.ts`):
 
 - `bash`: a shell command running in the configured tool runtime.
 - `delegate`: one subagent turn spawned by the `delegate` model tool.
 
-A **delegate session** is different from a delegate job. A delegate session is the subagent's persisted conversation history. Each call to `delegate(prompt=...)` creates a new job; `delegate(resume=<prior jobId>, prompt=...)` creates another new job that binds to the prior job's subagent session. This distinction is surfaced directly in the `delegate`, `job_notify`, and `jobs_list` tool descriptions (`packages/agent/src/tools/implementations/delegate.ts`, `job_notify.ts`, `jobs_list.ts`) and in the persona delegation instructions (`packages/agent/config/agent-personas/sections/delegation.md`).
+A **delegate session** is different from a delegate job. A delegate session is
+the subagent's persisted conversation history. Each call to
+`delegate(prompt=...)` creates a new job;
+`delegate(resume=<prior jobId>, prompt=...)` creates another new job that binds
+to the prior job's subagent session. This distinction is surfaced directly in
+the `delegate`, `job_notify`, and `jobs_list` tool descriptions
+(`packages/agent/src/tools/implementations/delegate.ts`, `job_notify.ts`,
+`jobs_list.ts`) and in the persona delegation instructions
+(`packages/agent/config/agent-personas/sections/delegation.md`).
 
-A **parent session** is the active Lace session that owns the job manager. Jobs are scoped to this active session's session directory. Job history is persisted in that session's durable event log.
+A **parent session** is the active Lace session that owns the job manager. Jobs
+are scoped to this active session's session directory. Job history is persisted
+in that session's durable event log.
 
-A **run** is the execution of one job process. For `delegate` jobs, a run may create or resume a child delegate session; for `bash` jobs, a run is one process invocation. Lace does not model a separate durable run id in the jobs subsystem; the durable identity is `jobId`, and delegate continuation identity is `subagentSessionId`.
+A **run** is the execution of one job process. For `delegate` jobs, a run may
+create or resume a child delegate session; for `bash` jobs, a run is one process
+invocation. Lace does not model a separate durable run id in the jobs subsystem;
+the durable identity is `jobId`, and delegate continuation identity is
+`subagentSessionId`.
 
 Important identifiers:
 
-- `jobId`: generated as `job_${randomUUID()}` when a job is created (`packages/agent/src/jobs/job-manager.ts`, `packages/agent/src/jobs/job-creation.ts`).
-- `parentJobId`: optional job nesting link, used when subagents start nested jobs and those child job ids are forwarded/namespaced into the parent.
-- `sessionId`: parent Lace session id. The active session supplies the session directory for logs and events.
-- `subagentSessionId`: delegate conversation id assigned by the child `session/new` or supplied by resume/preallocation; persisted in `job_session_assigned` so later `delegate(resume=<jobId>)` can find the child session.
-- `turnId`/`turnSeq`: the parent turn context captured on job creation and reused when emitting job updates.
+- `jobId`: generated as `job_${randomUUID()}` when a job is created
+  (`packages/agent/src/jobs/job-manager.ts`,
+  `packages/agent/src/jobs/job-creation.ts`).
+- `parentJobId`: optional job nesting link, used when subagents start nested
+  jobs and those child job ids are forwarded/namespaced into the parent.
+- `sessionId`: parent Lace session id. The active session supplies the session
+  directory for logs and events.
+- `subagentSessionId`: delegate conversation id assigned by the child
+  `session/new` or supplied by resume/preallocation; persisted in
+  `job_session_assigned` so later `delegate(resume=<jobId>)` can find the child
+  session.
+- `turnId`/`turnSeq`: the parent turn context captured on job creation and
+  reused when emitting job updates.
 
 ## Main components
 
@@ -29,36 +55,68 @@ Important identifiers:
 
 The tool implementations live in `packages/agent/src/tools/implementations/`:
 
-- `delegate.ts`: creates `delegate` jobs through `JobManager.createJob('delegate', ...)`. It supports synchronous and background modes, `resume`, provider/model overrides, persona bundles, per-invocation workspace tracking, and progress cadence override.
-- `job_notify.ts`: registers lifecycle/progress subscriptions through `JobManager.subscribe()`.
-- `job_output.ts`: reads status and output for an in-memory running job via `JobManager.getJob()` and `JobManager.getJobOutput()`; optionally blocks on `job.completion`.
-- `jobs_list.ts`: lists durable job records through `JobManager.listJobs()` with status/type/limit filters.
-- `job_kill.ts`: cancels running jobs through `JobManager.cancelJob()` and optionally disposes tracked per-invocation delegate workspaces through `WorkspaceReaper`.
+- `delegate.ts`: creates `delegate` jobs through
+  `JobManager.createJob('delegate', ...)`. It supports synchronous and
+  background modes, `resume`, provider/model overrides, persona bundles,
+  per-invocation workspace tracking, and progress cadence override.
+- `job_notify.ts`: registers lifecycle/progress subscriptions through
+  `JobManager.subscribe()`.
+- `job_output.ts`: reads status and output for an in-memory running job via
+  `JobManager.getJob()` and `JobManager.getJobOutput()`; optionally blocks on
+  `job.completion`.
+- `jobs_list.ts`: lists durable job records through `JobManager.listJobs()` with
+  status/type/limit filters.
+- `job_kill.ts`: cancels running jobs through `JobManager.cancelJob()` and
+  optionally disposes tracked per-invocation delegate workspaces through
+  `WorkspaceReaper`.
 
-These tools require a `jobManager` in `ToolContext`; each returns a structured tool failure if it is absent.
+These tools require a `jobManager` in `ToolContext`; each returns a structured
+tool failure if it is absent.
 
 ### JobManager
 
-`packages/agent/src/jobs/job-manager.ts` is the session-scoped service that owns:
+`packages/agent/src/jobs/job-manager.ts` is the session-scoped service that
+owns:
 
 - the in-memory running job map: `Map<string, JobState>`;
 - cached durable list reconstruction from the active session event log;
 - job subscriptions and per-job subscription indexes;
 - progress notification batching;
-- job creation, internal finalization, cancellation, output reads, and streaming-mode configuration.
+- job creation, internal finalization, cancellation, output reads, and
+  streaming-mode configuration.
 
-`AgentServerState.jobManager` replaces older scattered job state (`packages/agent/src/server-types.ts`). Job execution itself is delegated to dependencies injected into `JobManagerDeps`: `runShellProcess`, `runSubagentProcess`, `persistEvent`, `emitUpdate`, optional `setupProgressTimer`, and optional `fetchEmbedderSpawnEnv`.
+`AgentServerState.jobManager` replaces older scattered job state
+(`packages/agent/src/server-types.ts`). Job execution itself is delegated to
+dependencies injected into `JobManagerDeps`: `runShellProcess`,
+`runSubagentProcess`, `persistEvent`, `emitUpdate`, optional
+`setupProgressTimer`, and optional `fetchEmbedderSpawnEnv`.
 
 ### Execution helpers
 
-- `packages/agent/src/jobs/shell-job.ts` starts shell processes via a `RuntimeExecutionBinding`, captures stdout/stderr, enforces permissions, writes the per-job log, emits `job_update` stream events, and finalizes status from the process exit.
-- `packages/agent/src/jobs/subagent-job.ts` spawns a host-side `lace-agent` process, speaks JSON-RPC over stdio, initializes/configures the child session, forwards child updates/jobs/permissions, writes the delegate log, appends subagent diagnostics, and tears down the child process/transport.
-- `packages/agent/src/jobs/job-notifications.ts` composes job lifecycle/progress notifications, injects them into the session via the unified notification path, sets progress timers, and finalizes jobs in the server notification path.
-- `packages/agent/src/jobs/job-output.ts` contains lower-level byte/tail readers. The current `job_output` model tool uses `JobManager.getJobOutput()` rather than the offset reader.
-- `packages/agent/src/jobs/job-derivation.ts` derives job history from durable events for non-JobManager callers.
-- `packages/agent/src/jobs/job-file-utils.ts` provides per-job output path and tail helpers.
+- `packages/agent/src/jobs/shell-job.ts` starts shell processes via a
+  `RuntimeExecutionBinding`, captures stdout/stderr, enforces permissions,
+  writes the per-job log, emits `job_update` stream events, and finalizes status
+  from the process exit.
+- `packages/agent/src/jobs/subagent-job.ts` spawns a host-side `lace-agent`
+  process, speaks JSON-RPC over stdio, initializes/configures the child session,
+  forwards child updates/jobs/permissions, writes the delegate log, appends
+  subagent diagnostics, and tears down the child process/transport.
+- `packages/agent/src/jobs/job-notifications.ts` composes job lifecycle/progress
+  notifications, injects them into the session via the unified notification
+  path, sets progress timers, and finalizes jobs in the server notification
+  path.
+- `packages/agent/src/jobs/job-output.ts` contains lower-level byte/tail
+  readers. The current `job_output` model tool uses `JobManager.getJobOutput()`
+  rather than the offset reader.
+- `packages/agent/src/jobs/job-derivation.ts` derives job history from durable
+  events for non-JobManager callers.
+- `packages/agent/src/jobs/job-file-utils.ts` provides per-job output path and
+  tail helpers.
 
-There is also an older standalone creation/control layer (`packages/agent/src/jobs/job-creation.ts`, `job-control.ts`) with the same core concepts. Current model tool creation goes through `JobManager.createJob()`; the standalone modules are still part of the jobs codebase and tests.
+There is also an older standalone creation/control layer
+(`packages/agent/src/jobs/job-creation.ts`, `job-control.ts`) with the same core
+concepts. Current model tool creation goes through `JobManager.createJob()`; the
+standalone modules are still part of the jobs codebase and tests.
 
 ## Job state model
 
@@ -66,11 +124,18 @@ There is also an older standalone creation/control layer (`packages/agent/src/jo
 
 - identity: `jobId`, optional `parentJobId`;
 - classification: `type: 'bash' | 'delegate'`;
-- lifecycle: `status: 'running' | 'completed' | 'failed' | 'cancelled'`, `startedAt`, optional `exitCode`, `finished`, `completion`, `resolveCompletion`;
-- output/control: `outputPath`, optional `proc`, optional `permissionAbortController`;
-- delegate-specific runtime: `subagentContent`, `childPeer`, `childTransportClose`, `subagentSessionId`, `subagentSessionPreallocated`, `connectionId`, `modelId`, `runtimeBinding`, `executionEnv`, `persona`;
-- progress: `progressIntervalMs`, `lastProgressAt`, `lastProgressBytes`, `progressTimer`;
-- per-invocation container/workspace: `scratchDirHostPath`, `containerSharing`, `containerSpecName`.
+- lifecycle: `status: 'running' | 'completed' | 'failed' | 'cancelled'`,
+  `startedAt`, optional `exitCode`, `finished`, `completion`,
+  `resolveCompletion`;
+- output/control: `outputPath`, optional `proc`, optional
+  `permissionAbortController`;
+- delegate-specific runtime: `subagentContent`, `childPeer`,
+  `childTransportClose`, `subagentSessionId`, `subagentSessionPreallocated`,
+  `connectionId`, `modelId`, `runtimeBinding`, `executionEnv`, `persona`;
+- progress: `progressIntervalMs`, `lastProgressAt`, `lastProgressBytes`,
+  `progressTimer`;
+- per-invocation container/workspace: `scratchDirHostPath`, `containerSharing`,
+  `containerSpecName`.
 
 Constants in `server-types.ts`:
 
@@ -83,96 +148,186 @@ Constants in `server-types.ts`:
 
 ### Common creation
 
-`JobManager.createJob(type, options)` performs the main current creation flow (`packages/agent/src/jobs/job-manager.ts`):
+`JobManager.createJob(type, options)` performs the main current creation flow
+(`packages/agent/src/jobs/job-manager.ts`):
 
 1. Rejects mutually exclusive `newSubagentSessionId` and `resumeSessionId`.
-2. Requires an active session; otherwise throws `JobCreationError('No active session', -32001, 'session')`.
-3. Enforces `MAX_CONCURRENT_JOBS` by counting in-memory jobs with `status === 'running'`; overflow throws `JobCreationError(..., -32003, 'session')`.
+2. Requires an active session; otherwise throws
+   `JobCreationError('No active session', -32001, 'session')`.
+3. Enforces `MAX_CONCURRENT_JOBS` by counting in-memory jobs with
+   `status === 'running'`; overflow throws
+   `JobCreationError(..., -32003, 'session')`.
 4. Generates `jobId`, `startedAt`, and `outputPath`.
 5. Creates a `JobState` and adds it to the in-memory map.
-6. Persists a `job_started` durable event containing `jobId`, `parentJobId`, `jobType`, `description`, `command`, optional runtime/workspace/container metadata.
+6. Persists a `job_started` durable event containing `jobId`, `parentJobId`,
+   `jobType`, `description`, `command`, optional runtime/workspace/container
+   metadata.
 7. Emits a live `session/update` with `type: 'job_started'`.
 8. Arms a progress timer only if `progressIntervalMs` was explicitly supplied.
 9. Dispatches to `runShellProcess(job)` or `runSubagentProcess(job)`.
-10. Returns `{ jobId, job }` immediately; process execution continues asynchronously.
+10. Returns `{ jobId, job }` immediately; process execution continues
+    asynchronously.
 
-The standalone `createShellJob()`/`createSubagentJob()` in `packages/agent/src/jobs/job-creation.ts` implement the same scaffold/finalize pattern for library/RPC use.
+The standalone `createShellJob()`/`createSubagentJob()` in
+`packages/agent/src/jobs/job-creation.ts` implement the same scaffold/finalize
+pattern for library/RPC use.
 
 ### `delegate` tool creation
 
-`DelegateTool.executeValidated()` (`packages/agent/src/tools/implementations/delegate.ts`) resolves delegate-specific inputs before calling `JobManager.createJob('delegate', ...)`:
+`DelegateTool.executeValidated()`
+(`packages/agent/src/tools/implementations/delegate.ts`) resolves
+delegate-specific inputs before calling `JobManager.createJob('delegate', ...)`:
 
-- `resume=<prior jobId>` is resolved by scanning `jobManager.listJobs()` for the prior job's `subagentSessionId`. If none exists, the tool fails and includes available jobs and jobs with session ids.
-- Fresh per-invocation persona delegates preallocate a child session id (`sess_${randomUUID()}`) so container names and workspace paths can be computed before the child `session/new` call.
-- Persona bundles are parsed through the persona registry. Container personas resolve an environment and build a projected runtime binding.
-- Per-invocation container delegates reserve and track a child workspace under the results tree using `WorkspaceReaper`; a fresh delegate fails if the parent has reached `LACE_WORKSPACE_MAX_PER_PARENT` (default 128 retained workspaces).
-- Per-invocation resume refuses to run if the prior workspace was released or is missing/empty, instead of resurrecting an empty `/work`.
-- Per-call `modelId` wins over persona defaults; otherwise persona model defaults can set the subagent model. `connectionId` and unset model/connection fields can be inherited later by the subagent run path.
+- `resume=<prior jobId>` is resolved by scanning `jobManager.listJobs()` for the
+  prior job's `subagentSessionId`. If none exists, the tool fails and includes
+  available jobs and jobs with session ids.
+- Fresh per-invocation persona delegates preallocate a child session id
+  (`sess_${randomUUID()}`) so container names and workspace paths can be
+  computed before the child `session/new` call.
+- Persona bundles are parsed through the persona registry. Container personas
+  resolve an environment and build a projected runtime binding.
+- Per-invocation container delegates reserve and track a child workspace under
+  the results tree using `WorkspaceReaper`; a fresh delegate fails if the parent
+  has reached `LACE_WORKSPACE_MAX_PER_PARENT` (default 128 retained workspaces).
+- Per-invocation resume refuses to run if the prior workspace was released or is
+  missing/empty, instead of resurrecting an empty `/work`.
+- Per-call `modelId` wins over persona defaults; otherwise persona model
+  defaults can set the subagent model. `connectionId` and unset model/connection
+  fields can be inherited later by the subagent run path.
 
-In background mode (`background=true`), `delegate` returns immediately with JSON text like `{ "jobId": "...", "status": "started" }`. For per-invocation container delegates it also returns `subagentSessionId`, `workspace`, and a `workspaceNote` that frames the workspace as untrusted and possibly incomplete.
+In background mode (`background=true`), `delegate` returns immediately with JSON
+text like `{ "jobId": "...", "status": "started" }`. For per-invocation
+container delegates it also returns `subagentSessionId`, `workspace`, and a
+`workspaceNote` that frames the workspace as untrusted and possibly incomplete.
 
-In sync mode (`background=false`, the default), `delegate` waits for `job.completion` unless the parent tool call is aborted. It then returns the job output prefixed with `delegate jobId=<id>`. If the sync delegate has a per-invocation workspace, the preamble includes the workspace framing and a reclaim hint.
+In sync mode (`background=false`, the default), `delegate` waits for
+`job.completion` unless the parent tool call is aborted. It then returns the job
+output prefixed with `delegate jobId=<id>`. If the sync delegate has a
+per-invocation workspace, the preamble includes the workspace framing and a
+reclaim hint.
 
 ## Execution path
 
 ### Shell jobs
 
-`createRunShellJobProcess()` in `packages/agent/src/jobs/shell-job.ts` returns the runner used by the server. It:
+`createRunShellJobProcess()` in `packages/agent/src/jobs/shell-job.ts` returns
+the runner used by the server. It:
 
 1. Reads the active session and effective approval mode.
 2. Cancels immediately if approval mode is `deny`.
-3. If permission is required for `bash`, emits a `job_update` with `tool_use` status `awaiting_permission`, requests permission from the client, then either proceeds, records denial, or cancels on request failure.
-4. Builds a runtime from the job's `runtimeBinding`, or a default bounded host binding for the active session workdir.
-5. Starts `/bin/bash -c <command>`. On POSIX it runs detached and adapts the runtime process so cancellation can signal the whole process group.
-6. Appends stdout and stderr to the per-job output log until `MAX_JOB_OUTPUT_BYTES` is reached.
-7. Emits `job_update` `text_delta` events for stdout/stderr unless job streaming mode is `none`.
-8. On process completion, sets `completed` for exit code `0`, `failed` otherwise, unless the job was already cancelled; then finalizes with the exit code.
-9. On start/runtime errors, appends a `[BASH ERROR]` block, marks failed, and finalizes with exit code `1`.
+3. If permission is required for `bash`, emits a `job_update` with `tool_use`
+   status `awaiting_permission`, requests permission from the client, then
+   either proceeds, records denial, or cancels on request failure.
+4. Builds a runtime from the job's `runtimeBinding`, or a default bounded host
+   binding for the active session workdir.
+5. Starts `/bin/bash -c <command>`. On POSIX it runs detached and adapts the
+   runtime process so cancellation can signal the whole process group.
+6. Appends stdout and stderr to the per-job output log until
+   `MAX_JOB_OUTPUT_BYTES` is reached.
+7. Emits `job_update` `text_delta` events for stdout/stderr unless job streaming
+   mode is `none`.
+8. On process completion, sets `completed` for exit code `0`, `failed`
+   otherwise, unless the job was already cancelled; then finalizes with the exit
+   code.
+9. On start/runtime errors, appends a `[BASH ERROR]` block, marks failed, and
+   finalizes with exit code `1`.
 
-`jobStreaming`/`JobManager.streamingMode` supports `'full' | 'coalesced' | 'none'`; the inspected shell runner only suppresses stream updates when the mode is `none`.
+`jobStreaming`/`JobManager.streamingMode` supports
+`'full' | 'coalesced' | 'none'`; the inspected shell runner only suppresses
+stream updates when the mode is `none`.
 
 ### Delegate/subagent jobs
 
-`runSubagentJobProcess()` in `packages/agent/src/jobs/subagent-job.ts` is the delegate runner. It:
+`runSubagentJobProcess()` in `packages/agent/src/jobs/subagent-job.ts` is the
+delegate runner. It:
 
-1. Validates an active parent session and `subagentContent`; missing prerequisites fail the job and append `[SUBAGENT ERROR]` to the job log.
-2. Builds any runtime binding augmented with `executionEnv`, then deletes `job.executionEnv` so secrets/env are not retained on `JobState` longer than needed.
-3. Creates an ephemeral host `$TMPDIR` under `<results-base>/.tmp` for the child host process. Normal/finally cleanup removes it; SIGKILL leaks are bounded to that tree.
-4. Spawns a host-side `lace-agent` process and creates an NDJSON JSON-RPC peer over stdio.
-5. Captures child stderr; abnormal child exits persist a diagnostic block and close the peer so pending RPC requests reject instead of hanging.
+1. Validates an active parent session and `subagentContent`; missing
+   prerequisites fail the job and append `[SUBAGENT ERROR]` to the job log.
+2. Builds any runtime binding augmented with `executionEnv`, then deletes
+   `job.executionEnv` so secrets/env are not retained on `JobState` longer than
+   needed.
+3. Creates an ephemeral host `$TMPDIR` under `<results-base>/.tmp` for the child
+   host process. Normal/finally cleanup removes it; SIGKILL leaks are bounded to
+   that tree.
+4. Spawns a host-side `lace-agent` process and creates an NDJSON JSON-RPC peer
+   over stdio.
+5. Captures child stderr; abnormal child exits persist a diagnostic block and
+   close the peer so pending RPC requests reject instead of hanging.
 6. Registers child `session/update` handlers for:
-   - child `job_started`, `job_finished`, and `job_update`, mapped into parent-visible/namespaced jobs;
-   - direct delegate `text_delta`, appended to the parent job log and emitted as a parent `job_update`;
-   - child `tool_use`, namespaced as `<parentJobId>:<childToolCallId>`, mirrored into the job log, and forwarded as `job_update`;
+   - child `job_started`, `job_finished`, and `job_update`, mapped into
+     parent-visible/namespaced jobs;
+   - direct delegate `text_delta`, appended to the parent job log and emitted as
+     a parent `job_update`;
+   - child `tool_use`, namespaced as `<parentJobId>:<childToolCallId>`, mirrored
+     into the job log, and forwarded as `job_update`;
    - child `context_injected`, forwarded as a job update;
-   - `pending_reminders_on_exit`, converted in the parent process into a `subagent-exited` notification event.
-7. Registers child `session/request_permission` forwarding. Child job ids and tool call ids are mapped/namespaced before asking the parent client. If the parent job has finished or been cancelled, permission returns deny.
-8. Initializes the child process with inherited capabilities, job streaming mode, persona/environment search paths, skill dirs, MCP base dir, and effective config inherited from the parent.
-9. Either resumes a child session (`session/resume`) or creates one (`session/new`). Three cases are explicit in code:
+   - `pending_reminders_on_exit`, converted in the parent process into a
+     `subagent-exited` notification event.
+7. Registers child `session/request_permission` forwarding. Child job ids and
+   tool call ids are mapped/namespaced before asking the parent client. If the
+   parent job has finished or been cancelled, permission returns deny.
+8. Initializes the child process with inherited capabilities, job streaming
+   mode, persona/environment search paths, skill dirs, MCP base dir, and
+   effective config inherited from the parent.
+9. Either resumes a child session (`session/resume`) or creates one
+   (`session/new`). Three cases are explicit in code:
    - resume: `subagentSessionId` exists and is not preallocated;
-   - preallocated fresh: `subagentSessionId` exists with `subagentSessionPreallocated === true`, and the child must echo it back;
+   - preallocated fresh: `subagentSessionId` exists with
+     `subagentSessionPreallocated === true`, and the child must echo it back;
    - legacy fresh: no id, child mints one.
-10. Persists `job_session_assigned` with `jobId` and `subagentSessionId` for future resume.
-11. Applies inherited/effective provider config, calls `ent/session/configure` for `connectionId`, and `session/set_config_option` for `modelId`.
-12. Sends `session/prompt` with `subagentContent` and maps the returned stop reason to a job status. Stop details/refusals/provider failures are appended as `[SUBAGENT STOP: ...]` diagnostic output.
-13. On errors, marks failed unless already cancelled and appends a `[SUBAGENT ERROR]` block including JSON-RPC code/data and buffered stderr when available.
-14. In `finally`, SIGTERMs the child, waits up to 3 seconds for graceful exit/reminder emission, SIGKILLs if still alive, closes the peer and transport, finalizes the job, and removes the host tmpdir. Per-invocation `/work` teardown is deliberately left to the shim/workspace reaper, not this runner.
+10. Persists `job_session_assigned` with `jobId` and `subagentSessionId` for
+    future resume.
+11. Applies inherited/effective provider config, calls `ent/session/configure`
+    for `connectionId`, and `session/set_config_option` for `modelId`.
+12. Sends `session/prompt` with `subagentContent` and maps the returned stop
+    reason to a job status. Stop details/refusals/provider failures are appended
+    as `[SUBAGENT STOP: ...]` diagnostic output.
+13. On errors, marks failed unless already cancelled and appends a
+    `[SUBAGENT ERROR]` block including JSON-RPC code/data and buffered stderr
+    when available.
+14. In `finally`, SIGTERMs the child, waits up to 3 seconds for graceful
+    exit/reminder emission, SIGKILLs if still alive, closes the peer and
+    transport, finalizes the job, and removes the host tmpdir. Per-invocation
+    `/work` teardown is deliberately left to the shim/workspace reaper, not this
+    runner.
 
-Nested child jobs are represented in the parent by mapping child job ids to `${parentJobId}_${childJobId}`. Forwarded records are added to the parent `JobManager` in memory and persisted as parent-session `job_started`/`job_finished` events, with `parentJobId` mapped to the parent job or mapped child parent.
+Nested child jobs are represented in the parent by mapping child job ids to
+`${parentJobId}_${childJobId}`. Forwarded records are added to the parent
+`JobManager` in memory and persisted as parent-session
+`job_started`/`job_finished` events, with `parentJobId` mapped to the parent job
+or mapped child parent.
 
 ## Output model
 
-Each job has an output file at `getJobOutputPath(activeSession.dir, jobId)` under the session job log directory. Runners append to this file under the session mutex (`runExclusive`) and cap writes at `MAX_JOB_OUTPUT_BYTES`.
+Each job has an output file at `getJobOutputPath(activeSession.dir, jobId)`
+under the session job log directory. Runners append to this file under the
+session mutex (`runExclusive`) and cap writes at `MAX_JOB_OUTPUT_BYTES`.
 
-`JobManager.getJobOutput(jobId)` reads the full output file for the active session and returns an empty string if there is no active session or the file is missing.
+`JobManager.getJobOutput(jobId)` reads the full output file for the active
+session and returns an empty string if there is no active session or the file is
+missing.
 
-The `job_output` model tool (`packages/agent/src/tools/implementations/job_output.ts`) currently requires the job to exist in the in-memory running job map. If `jobManager.getJob(jobId)` returns missing, the tool fails with `Job <id> not found`; it does not currently fall back to durable `jobs_list()` records. With `block=true` and a running job, it waits for `job.completion` or timeout. The requested timeout is clamped upward to `JOB_OUTPUT_MIN_BLOCKING_TIMEOUT_MS = 120000`; this is deliberate anti-polling behavior. The returned JSON includes `jobId`, `status`, `output` (trimmed or `(no output)`), and optional `exitCode`.
+The `job_output` model tool
+(`packages/agent/src/tools/implementations/job_output.ts`) currently requires
+the job to exist in the in-memory running job map. If `jobManager.getJob(jobId)`
+returns missing, the tool fails with `Job <id> not found`; it does not currently
+fall back to durable `jobs_list()` records. With `block=true` and a running job,
+it waits for `job.completion` or timeout. The requested timeout is clamped
+upward to `JOB_OUTPUT_MIN_BLOCKING_TIMEOUT_MS = 120000`; this is deliberate
+anti-polling behavior. The returned JSON includes `jobId`, `status`, `output`
+(trimmed or `(no output)`), and optional `exitCode`.
 
-`packages/agent/src/jobs/job-output.ts` provides lower-level readers with byte offsets, `maxSize`, tail reads, and truncation metadata. Notable behavior: when `afterOffset` and `tailBytes` are both set, the effective start is the later of `afterOffset` and `totalBytes - tailBytes`; `afterOffset` alone is not considered truncation.
+`packages/agent/src/jobs/job-output.ts` provides lower-level readers with byte
+offsets, `maxSize`, tail reads, and truncation metadata. Notable behavior: when
+`afterOffset` and `tailBytes` are both set, the effective start is the later of
+`afterOffset` and `totalBytes - tailBytes`; `afterOffset` alone is not
+considered truncation.
 
 ## Notification and subscription model
 
-`job_notify` registers subscriptions; notifications are composed and injected by `packages/agent/src/jobs/job-notifications.ts` and routed through `JobManager.fanoutToInject()`.
+`job_notify` registers subscriptions; notifications are composed and injected by
+`packages/agent/src/jobs/job-notifications.ts` and routed through
+`JobManager.fanoutToInject()`.
 
 ### Notification kinds
 
@@ -183,89 +338,183 @@ The `job_output` model tool (`packages/agent/src/tools/implementations/job_outpu
 - `cancelled` → `<notification kind="job-cancelled" job-id="...">`
 - `progress` → `<notification kind="job-progress" job-id="...">`
 
-`createQueueJobNotification()` computes output bytes, duration, and a tail preview from the job log. Delegate notifications include the last 8 lines; bash completed notifications include 1 line; other bash notifications include 3 lines. The notification is written via `injectNotification()`. If the agent is idle, the `idleWake` hook schedules an internal turn so the injected event is picked up promptly.
+`createQueueJobNotification()` computes output bytes, duration, and a tail
+preview from the job log. Delegate notifications include the last 8 lines; bash
+completed notifications include 1 line; other bash notifications include 3
+lines. The notification is written via `injectNotification()`. If the agent is
+idle, the `idleWake` hook schedules an internal turn so the injected event is
+picked up promptly.
 
 ### Subscription semantics
 
 `JobManager.subscribe()` accepts `jobId`, `on`, and optional `filter`:
 
-- Calls are idempotent for the exact same `jobId`, `on` set, and `filter`; the existing subscription is returned.
-- Invalid filter regexes are rejected at subscribe time and surfaced by `job_notify` as a tool failure.
-- Subscriptions can be registered for unknown/not-yet-added job ids. If a progress subscriber exists when the job is later added, `JobManager.addJob()` arms progress.
-- If a job has one or more subscriptions, only matching subscriptions deliver notifications. A `failed`-only subscription does not deliver on completion.
-- If a job has no subscriptions, `fanoutToInject()` invokes the inject callback once as an always-on fallback. This preserves terminal wakeups for unsubscribed jobs.
-- Filters apply only to `progress`, against the raw tail preview using a multiline regex. Terminal states always ignore filters.
-- Progress delivery is batched per subscription for 200ms. Multiple progress fanouts inside the window replace the buffered injection; latest preview wins.
-- Terminal fanout flushes pending progress batches for that job before terminal delivery, preventing stale progress notifications after job death.
-- `unsubscribe()` cancels a pending progress batch without delivering it; job cleanup flushes batches before clearing subscriptions.
+- Calls are idempotent for the exact same `jobId`, `on` set, and `filter`; the
+  existing subscription is returned.
+- Invalid filter regexes are rejected at subscribe time and surfaced by
+  `job_notify` as a tool failure.
+- Subscriptions can be registered for unknown/not-yet-added job ids. If a
+  progress subscriber exists when the job is later added, `JobManager.addJob()`
+  arms progress.
+- If a job has one or more subscriptions, only matching subscriptions deliver
+  notifications. A `failed`-only subscription does not deliver on completion.
+- If a job has no subscriptions, `fanoutToInject()` invokes the inject callback
+  once as an always-on fallback. This preserves terminal wakeups for
+  unsubscribed jobs.
+- Filters apply only to `progress`, against the raw tail preview using a
+  multiline regex. Terminal states always ignore filters.
+- Progress delivery is batched per subscription for 200ms. Multiple progress
+  fanouts inside the window replace the buffered injection; latest preview wins.
+- Terminal fanout flushes pending progress batches for that job before terminal
+  delivery, preventing stale progress notifications after job death.
+- `unsubscribe()` cancels a pending progress batch without delivering it; job
+  cleanup flushes batches before clearing subscriptions.
 
 ### Progress timers
 
 Progress is opt-in in two ways:
 
-1. Operator-created cadence: a job created with explicit `progressIntervalMs` arms a timer immediately and it survives progress subscriber churn.
-2. Subscriber demand: a `job_notify` subscription whose `on` includes `progress` arms the timer if the job is running. If the last progress subscriber unsubscribes and the job did not have explicit `progressIntervalMs`, the timer stops.
+1. Operator-created cadence: a job created with explicit `progressIntervalMs`
+   arms a timer immediately and it survives progress subscriber churn.
+2. Subscriber demand: a `job_notify` subscription whose `on` includes `progress`
+   arms the timer if the job is running. If the last progress subscriber
+   unsubscribes and the job did not have explicit `progressIntervalMs`, the
+   timer stops.
 
-The timer interval is `job.progressIntervalMs ?? DEFAULT_PROGRESS_INTERVAL_MS`. Each tick computes current output file bytes, delta since the last tick, and queues a `progress` notification. The timer self-clears if the job is no longer running.
+The timer interval is `job.progressIntervalMs ?? DEFAULT_PROGRESS_INTERVAL_MS`.
+Each tick computes current output file bytes, delta since the last tick, and
+queues a `progress` notification. The timer self-clears if the job is no longer
+running.
 
 ## Persistence, listing, and rehydration
 
-The durable job history is the parent session's event log, read by `readAllSessionEventLines(sessionDir)`. The relevant events are:
+The durable job history is the parent session's event log, read by
+`readAllSessionEventLines(sessionDir)`. The relevant events are:
 
-- `job_started`: creates/updates a record with `jobId`, `jobType`, optional `parentJobId`, `description`, `command`, and timestamp as `startTime`.
+- `job_started`: creates/updates a record with `jobId`, `jobType`, optional
+  `parentJobId`, `description`, `command`, and timestamp as `startTime`.
 - `job_session_assigned`: adds `subagentSessionId` to an existing job record.
-- `job_finished`: sets `status` to the durable `outcome` (`completed`, `failed`, `cancelled`) and records optional `exitCode`.
+- `job_finished`: sets `status` to the durable `outcome` (`completed`, `failed`,
+  `cancelled`) and records optional `exitCode`.
 
-`JobManager.listJobs()` reconstructs `JobRecord[]` from these events and caches by `(sessionId, lineCount)`. The cache uses `fileSize` to store line count and `fileMtime` as `0`; event line counts are monotonic, so appends bust the cache. It overlays in-memory status afterward: any durable record still marked `running` but missing from the running job map is reported as `failed`.
+`JobManager.listJobs()` reconstructs `JobRecord[]` from these events and caches
+by `(sessionId, lineCount)`. The cache uses `fileSize` to store line count and
+`fileMtime` as `0`; event line counts are monotonic, so appends bust the cache.
+It overlays in-memory status afterward: any durable record still marked
+`running` but missing from the running job map is reported as `failed`.
 
-`packages/agent/src/jobs/job-derivation.ts` implements a similar derived-job reader and additionally parses persisted `runtimeBinding` when present.
+`packages/agent/src/jobs/job-derivation.ts` implements a similar derived-job
+reader and additionally parses persisted `runtimeBinding` when present.
 
-Important limitation: this is history rehydration for listing/resume metadata, not process rehydration. Running processes are kept only in memory. After a restart/session reopen, a job that never wrote `job_finished` is listed as `failed` because it is no longer in the running map.
+Important limitation: this is history rehydration for listing/resume metadata,
+not process rehydration. Running processes are kept only in memory. After a
+restart/session reopen, a job that never wrote `job_finished` is listed as
+`failed` because it is no longer in the running map.
 
-`jobs_list` formats only `jobId`, `type`, `status`, `description`, and `startTime`, even though `JobManager.listJobs()` may carry `command`, `exitCode`, and `subagentSessionId`. The `delegate` tool uses the richer `listJobs()` result internally to resolve resumes.
+`jobs_list` formats only `jobId`, `type`, `status`, `description`, and
+`startTime`, even though `JobManager.listJobs()` may carry `command`,
+`exitCode`, and `subagentSessionId`. The `delegate` tool uses the richer
+`listJobs()` result internally to resolve resumes.
 
 ## Finalization and result semantics
 
 There are two finalization paths in the codebase:
 
-- `createFinalizeJob()` in `packages/agent/src/jobs/job-notifications.ts` is the server notification path. It marks unfinished jobs terminal, persists `job_finished`, emits live `job_finished`, clears progress timers, queues the terminal notification, and resolves `job.completion`.
-- `JobManager.finalizeJob()` in `packages/agent/src/jobs/job-manager.ts` is an internal manager path. It persists/emits `job_finished`, resolves completion, stops progress, removes the job from the running map, and clears subscriptions.
+- `createFinalizeJob()` in `packages/agent/src/jobs/job-notifications.ts` is the
+  server notification path. It marks unfinished jobs terminal, persists
+  `job_finished`, emits live `job_finished`, clears progress timers, queues the
+  terminal notification, and resolves `job.completion`.
+- `JobManager.finalizeJob()` in `packages/agent/src/jobs/job-manager.ts` is an
+  internal manager path. It persists/emits `job_finished`, resolves completion,
+  stops progress, removes the job from the running map, and clears
+  subscriptions.
 
 Status conventions:
 
 - Shell exit code `0` → `completed`; non-zero → `failed` (`shell-job.ts`).
-- Subagent status is derived from the child prompt stop reason (`subagent-job.ts` via helper functions); diagnostic stop details are appended to output.
-- If finalization sees a job still `running`, the notification finalizer converts it to `failed` before persisting. This avoids leaving a terminal event with a running outcome.
-- Cancellation sets `status = 'cancelled'`; terminal notification kind is chosen from final status.
-- `exitCode` is recorded when supplied by the runner. Delegate jobs may not have a meaningful process exit code for model-level failures; their diagnostic details are in the job output.
+- Subagent status is derived from the child prompt stop reason
+  (`subagent-job.ts` via helper functions); diagnostic stop details are appended
+  to output.
+- If finalization sees a job still `running`, the notification finalizer
+  converts it to `failed` before persisting. This avoids leaving a terminal
+  event with a running outcome.
+- Cancellation sets `status = 'cancelled'`; terminal notification kind is chosen
+  from final status.
+- `exitCode` is recorded when supplied by the runner. Delegate jobs may not have
+  a meaningful process exit code for model-level failures; their diagnostic
+  details are in the job output.
 
-One edge to be aware of: `JobManager.finalizeJob()` removes the job from the in-memory map, but `job_output` requires the job to be in that map before reading. Callers relying on `job_output` after a manager-finalized job may see `Job <id> not found`; notification previews and direct log files remain durable, and `jobs_list` can still show the durable record.
+One edge to be aware of: `JobManager.finalizeJob()` removes the job from the
+in-memory map, but `job_output` requires the job to be in that map before
+reading. Callers relying on `job_output` after a manager-finalized job may see
+`Job <id> not found`; notification previews and direct log files remain durable,
+and `jobs_list` can still show the durable record.
 
 ## Cancellation, kill, and cleanup
 
 ### Plain cancellation
 
-The model-facing `job_kill` tool (`packages/agent/src/tools/implementations/job_kill.ts`) only accepts an in-memory job. With `destroy_container=false`, it requires `job.status === 'running'`; otherwise it fails with the current status. For a running job it calls `terminateJob()` (`packages/agent/src/jobs/job-control.ts`), which (1) notifies the child agent with `session/cancel` so its active turn aborts and the abort signal kills in-flight tool work (including in-container execs), (2) runs `killJob()` — SIGTERM to the POSIX process group with a direct-signal fallback, grace window, then SIGKILL — and (3) waits for the process to actually exit, then closes the child peer and transport so the parent-side job driver finalizes. Only when the process is confirmed dead does the tool call `jobManager.cancelJob(jobId)` (idempotent finalize) and return `Job <id> cancelled — process terminated.` If the process survives the grace window, the tool returns a **failed** result stating that in-flight work may still land; it does not finalize the job.
+The model-facing `job_kill` tool
+(`packages/agent/src/tools/implementations/job_kill.ts`) only accepts an
+in-memory job. With `destroy_container=false`, it requires
+`job.status === 'running'`; otherwise it fails with the current status. For a
+running job it calls `terminateJob()`
+(`packages/agent/src/jobs/job-control.ts`), which (1) notifies the child agent
+with `session/cancel` so its active turn aborts and the abort signal kills
+in-flight tool work (including in-container execs), (2) runs `killJob()` —
+SIGTERM to the POSIX process group with a direct-signal fallback, grace window,
+then SIGKILL — and (3) waits for the process to actually exit, then closes the
+child peer and transport so the parent-side job driver finalizes. Only when the
+process is confirmed dead does the tool call `jobManager.cancelJob(jobId)`
+(idempotent finalize) and return `Job <id> cancelled — process terminated.` If
+the process survives the grace window, the tool returns a **failed** result
+stating that in-flight work may still land; it does not finalize the job.
 
-`JobManager.cancelJob()` sets `status = 'cancelled'` and calls `JobManager.finalizeJob()`. That manager path records the terminal state and removes the job from the in-memory map; it does **not** itself signal `job.proc` — it is the bookkeeping half, safe to call once the process is known dead. The process-signalling helper is `killJob()`: mark cancelled, abort pending permission, send SIGTERM to the process or POSIX process group (falling back to a direct `proc.kill` if the group signal fails), wait up to `waitMs` (default 500ms), and optionally SIGKILL if `forceKill=true`. Subagents are spawned `detached` on POSIX so they lead their own process group and the group signal reaches their host-side children.
+`JobManager.cancelJob()` sets `status = 'cancelled'` and calls
+`JobManager.finalizeJob()`. That manager path records the terminal state and
+removes the job from the in-memory map; it does **not** itself signal `job.proc`
+— it is the bookkeeping half, safe to call once the process is known dead. The
+process-signalling helper is `killJob()`: mark cancelled, abort pending
+permission, send SIGTERM to the process or POSIX process group (falling back to
+a direct `proc.kill` if the group signal fails), wait up to `waitMs` (default
+500ms), and optionally SIGKILL if `forceKill=true`. Subagents are spawned
+`detached` on POSIX so they lead their own process group and the group signal
+reaches their host-side children.
 
-The RPC job-control path (`packages/agent/src/rpc/handlers/jobs.ts`) uses `killJob(job, { waitMs: 500, forceKill: true })` for `ent/job/kill` when a running process exists, and session switching/close uses `killAllRunningJobs(..., { waitMs: 500, forceKill: true })` in `packages/agent/src/rpc/handlers/session.ts` before finalizing and clearing jobs.
+The RPC job-control path (`packages/agent/src/rpc/handlers/jobs.ts`) uses
+`killJob(job, { waitMs: 500, forceKill: true })` for `ent/job/kill` when a
+running process exists, and session switching/close uses
+`killAllRunningJobs(..., { waitMs: 500, forceKill: true })` in
+`packages/agent/src/rpc/handlers/session.ts` before finalizing and clearing
+jobs.
 
-Shell runner permission requests store `permissionAbortController`; process-level kill aborts them. Subagent permission forwarding returns deny if the parent job has finished or been cancelled.
+Shell runner permission requests store `permissionAbortController`;
+process-level kill aborts them. Subagent permission forwarding returns deny if
+the parent job has finished or been cancelled.
 
 ### Per-invocation container/workspace teardown
 
-`job_kill(jobId, destroy_container=true)` is also the reclaim path for per-invocation delegate workspaces:
+`job_kill(jobId, destroy_container=true)` is also the reclaim path for
+per-invocation delegate workspaces:
 
 1. If the job is running, cancel it first.
 2. Look up `job.subagentSessionId` in `WorkspaceReaper`.
-3. Only dispose if the tracked entry's `parentId` equals the active parent session id.
-4. Serialize disposal with `workspaceReaper.runExclusive(childId, ...)` to avoid racing a concurrent resume.
-5. `workspaceReaper.dispose()` routes through the container manager/shim release path, destroying the per-invocation container and removing `/work`.
+3. Only dispose if the tracked entry's `parentId` equals the active parent
+   session id.
+4. Serialize disposal with `workspaceReaper.runExclusive(childId, ...)` to avoid
+   racing a concurrent resume.
+5. `workspaceReaper.dispose()` routes through the container manager/shim release
+   path, destroying the per-invocation container and removing `/work`.
 
-If there is no tracked workspace (host subagent, persistent container, already released/gone), the tool reports that there was no container to destroy. Destroying a per-invocation workspace intentionally makes that delegate session non-resumable; a later `delegate(resume=<jobId>)` refuses with `Cannot resume job ...: this delegation was released; start a fresh delegate.`
+If there is no tracked workspace (host subagent, persistent container, already
+released/gone), the tool reports that there was no container to destroy.
+Destroying a per-invocation workspace intentionally makes that delegate session
+non-resumable; a later `delegate(resume=<jobId>)` refuses with
+`Cannot resume job ...: this delegation was released; start a fresh delegate.`
 
-Subagent runner cleanup is narrower: it tears down the child host process, JSON-RPC peer/transport, and ephemeral host tmpdir. It does not remove `/work`; the shim/workspace reaper owns that lifecycle.
+Subagent runner cleanup is narrower: it tears down the child host process,
+JSON-RPC peer/transport, and ephemeral host tmpdir. It does not remove `/work`;
+the shim/workspace reaper owns that lifecycle.
 
 ## Blocking vs non-blocking usage
 
@@ -274,42 +523,78 @@ The intended model-facing pattern is non-blocking:
 1. Start work with `delegate(..., background=true)` or a background shell job.
 2. Call `job_notify(jobId)` for terminal states, optionally progress.
 3. Return to the user or do other work.
-4. When Lace injects a job notification, inspect the preview or call `job_output(jobId, block=false)` if the job is still in memory and full output is needed.
-5. For delegate continuation, call `delegate(resume=<prior jobId>, prompt=...)`; that creates a new job under the same subagent session.
+4. When Lace injects a job notification, inspect the preview or call
+   `job_output(jobId, block=false)` if the job is still in memory and full
+   output is needed.
+5. For delegate continuation, call `delegate(resume=<prior jobId>, prompt=...)`;
+   that creates a new job under the same subagent session.
 
 Blocking exists but is intentionally discouraged for long work:
 
-- `delegate(background=false)` waits on the subagent job and halts the parent turn.
-- `job_output(block=true)` waits for completion but clamps the wait to at least 120 seconds to discourage short polling loops.
+- `delegate(background=false)` waits on the subagent job and halts the parent
+  turn.
+- `job_output(block=true)` waits for completion but clamps the wait to at least
+  120 seconds to discourage short polling loops.
 
 ## Known edge cases and accuracy notes
 
-- `jobs_list` schema accepts `pending` in its status filter, but `JobStatus` currently has no `pending`; created jobs enter `running` immediately.
-- Durable list order is insertion/event order from the reconstructed map, not explicitly sorted newest-first.
+- `jobs_list` schema accepts `pending` in its status filter, but `JobStatus`
+  currently has no `pending`; created jobs enter `running` immediately.
+- Durable list order is insertion/event order from the reconstructed map, not
+  explicitly sorted newest-first.
 - Malformed event log lines are ignored during listing/derivation.
-- A `job_finished` event without a prior `job_started` creates a fallback durable record with type `bash`, status from outcome or `failed`, and timestamp as start time.
-- `job_notify` can subscribe to an unknown job id. This is intentional and enables pre-registration, but if no such job ever appears the subscription remains until cleared by unsubscribe/job cleanup/session clear.
-- Terminal notifications ignore `filter`; a filter attached to a terminal-only subscription is accepted but no-op.
-- Progress-only subscriptions can miss job success/failure/cancellation if no terminal subscription is also registered. The tool description calls this out as "silence is not success."
-- Progress notifications use output-file byte deltas and tail previews; a tick can fire with `deltaBytes = 0`.
-- Output writes are capped by string slice length against a byte constant. For non-ASCII text this is not a perfect byte-level truncation boundary, although file size checks use bytes from `statSync`.
-- `job_output` has a `byteOffset` argument but the current tool implementation does not use it; byte/tail support exists in `jobs/job-output.ts`.
-- `job_output` only reads jobs present in the in-memory map. Durable completed jobs may appear in `jobs_list` while `job_output` says not found.
-- `JobManager.listJobs()` marks durable `running` jobs as `failed` when they are absent from memory. This is how Lace represents orphaned jobs after restart/reopen; it does not attempt to reconnect to processes.
-- Subagent abnormal child exit handling closes the JSON-RPC peer to avoid hung parent awaits and appends diagnostics to the job log.
-- Subagent final cleanup gives the child up to 3 seconds after SIGTERM to emit pending-reminder notifications, then SIGKILLs and waits up to 500ms.
-- Per-invocation resume refuses released/missing/empty workspaces. Persistent personas and host/native subagents do not use the same workspace teardown path.
-- Embedder-provided spawn environment for containerized delegate personas is best-effort. Invalid names, non-string values, and collisions with Lace-managed env are dropped with warnings; RPC failure does not block spawn.
-- Nested subagent job ids are namespaced with the parent job id. Tool call ids are likewise namespaced before forwarding to the parent.
+- A `job_finished` event without a prior `job_started` creates a fallback
+  durable record with type `bash`, status from outcome or `failed`, and
+  timestamp as start time.
+- `job_notify` can subscribe to an unknown job id. This is intentional and
+  enables pre-registration, but if no such job ever appears the subscription
+  remains until cleared by unsubscribe/job cleanup/session clear.
+- Terminal notifications ignore `filter`; a filter attached to a terminal-only
+  subscription is accepted but no-op.
+- Progress-only subscriptions can miss job success/failure/cancellation if no
+  terminal subscription is also registered. The tool description calls this out
+  as "silence is not success."
+- Progress notifications use output-file byte deltas and tail previews; a tick
+  can fire with `deltaBytes = 0`.
+- Output writes are capped by string slice length against a byte constant. For
+  non-ASCII text this is not a perfect byte-level truncation boundary, although
+  file size checks use bytes from `statSync`.
+- `job_output` has a `byteOffset` argument but the current tool implementation
+  does not use it; byte/tail support exists in `jobs/job-output.ts`.
+- `job_output` only reads jobs present in the in-memory map. Durable completed
+  jobs may appear in `jobs_list` while `job_output` says not found.
+- `JobManager.listJobs()` marks durable `running` jobs as `failed` when they are
+  absent from memory. This is how Lace represents orphaned jobs after
+  restart/reopen; it does not attempt to reconnect to processes.
+- Subagent abnormal child exit handling closes the JSON-RPC peer to avoid hung
+  parent awaits and appends diagnostics to the job log.
+- Subagent final cleanup gives the child up to 3 seconds after SIGTERM to emit
+  pending-reminder notifications, then SIGKILLs and waits up to 500ms.
+- Per-invocation resume refuses released/missing/empty workspaces. Persistent
+  personas and host/native subagents do not use the same workspace teardown
+  path.
+- Embedder-provided spawn environment for containerized delegate personas is
+  best-effort. Invalid names, non-string values, and collisions with
+  Lace-managed env are dropped with warnings; RPC failure does not block spawn.
+- Nested subagent job ids are namespaced with the parent job id. Tool call ids
+  are likewise namespaced before forwarding to the parent.
 
 ## Code map
 
 - Types/constants: `packages/agent/src/server-types.ts`
 - Manager: `packages/agent/src/jobs/job-manager.ts`
-- Current runners: `packages/agent/src/jobs/shell-job.ts`, `packages/agent/src/jobs/subagent-job.ts`
-- Notifications/finalization/progress: `packages/agent/src/jobs/job-notifications.ts`
-- Output readers: `packages/agent/src/jobs/job-output.ts`, `packages/agent/src/jobs/job-file-utils.ts`
+- Current runners: `packages/agent/src/jobs/shell-job.ts`,
+  `packages/agent/src/jobs/subagent-job.ts`
+- Notifications/finalization/progress:
+  `packages/agent/src/jobs/job-notifications.ts`
+- Output readers: `packages/agent/src/jobs/job-output.ts`,
+  `packages/agent/src/jobs/job-file-utils.ts`
 - Durable derivation: `packages/agent/src/jobs/job-derivation.ts`
-- Standalone creation/control helpers: `packages/agent/src/jobs/job-creation.ts`, `packages/agent/src/jobs/job-control.ts`
-- Model tools: `packages/agent/src/tools/implementations/delegate.ts`, `job_notify.ts`, `job_output.ts`, `jobs_list.ts`, `job_kill.ts`
-- Relevant tests: `packages/agent/src/jobs/__tests__/`, `packages/agent/src/tools/implementations/__tests__/`, `packages/agent/src/tools/__tests__/`
+- Standalone creation/control helpers:
+  `packages/agent/src/jobs/job-creation.ts`,
+  `packages/agent/src/jobs/job-control.ts`
+- Model tools: `packages/agent/src/tools/implementations/delegate.ts`,
+  `job_notify.ts`, `job_output.ts`, `jobs_list.ts`, `job_kill.ts`
+- Relevant tests: `packages/agent/src/jobs/__tests__/`,
+  `packages/agent/src/tools/implementations/__tests__/`,
+  `packages/agent/src/tools/__tests__/`

--- a/docs/architecture/persona-containers.md
+++ b/docs/architecture/persona-containers.md
@@ -43,21 +43,22 @@ guest: /work
 
 `<base>` = `LACE_WORK_DIR` (default `os.tmpdir()/lace-work`); `<parentId>` is
 the delegating session id, `<childId>` the subagent session id. The shim creates
-and owns this directory — lace only computes the host path (via `childWorkspaceDir`)
-so it can return the result path to the parent agent and track the entry in the
-`WorkspaceReaper`.
+and owns this directory — lace only computes the host path (via
+`childWorkspaceDir`) so it can return the result path to the parent agent and
+track the entry in the `WorkspaceReaper`.
 
 Each child mounts ONLY its own subdir — mount-scoping, not file modes, is the
 isolation boundary. The host root reads the full results tree directly via the
 filesystem.
 
-The workspace **survives the disposable container** and is the child's deliverable
-to the parent — returned by `delegate` framed as UNTRUSTED and
+The workspace **survives the disposable container** and is the child's
+deliverable to the parent — returned by `delegate` framed as UNTRUSTED and
 possibly-incomplete. The parent reclaims it with
-**`job_kill(jobId, destroy_container=true)`** (the primary explicit release path).
-Workspace reclamation also occurs on the parent's clean close and on process
-teardown. A retention ceiling (`LACE_WORKSPACE_MAX_PER_PARENT`, default 128) fails
-a fresh delegate that would exceed it — reclaim a completed one first.
+**`job_kill(jobId, destroy_container=true)`** (the primary explicit release
+path). Workspace reclamation also occurs on the parent's clean close and on
+process teardown. A retention ceiling (`LACE_WORKSPACE_MAX_PER_PARENT`,
+default 128) fails a fresh delegate that would exceed it — reclaim a completed
+one first.
 
 Persistent personas declare their own `/work` mount via the embedder's
 container-mount registry; lace does not auto-inject `/work` for them, and a
@@ -68,8 +69,8 @@ persistent box is never reaped.
 The sen-docker shim owns the full per_invocation lifecycle:
 
 1. **Create** — shim provisions the container and its `/work` at spawn time.
-2. **Idle-TTL reap** — when no `exec` arrives within the TTL the shim destroys the
-   container and removes `/work`.
+2. **Idle-TTL reap** — when no `exec` arrives within the TTL the shim destroys
+   the container and removes `/work`.
 3. **Release** — on an explicit release request the shim destroys the container
    and removes `/work` (the `release` verb).
 
@@ -79,8 +80,8 @@ lace's role is limited to:
   result and to track in-process.
 - Enforcing the per-parent retention ceiling and the resume guard against
   released or empty workspaces.
-- Routing teardown (`job_kill(destroy_container=true)` / clean-close /
-  process teardown) through `WorkspaceReaper.dispose` →
+- Routing teardown (`job_kill(destroy_container=true)` / clean-close / process
+  teardown) through `WorkspaceReaper.dispose` →
   `ContainerManager.releasePerInvocation` → the plane `release` verb.
 
 lace does NOT run a crash sweep, owner marker, or its own idle reaper. The shim
@@ -91,22 +92,21 @@ is the backstop for all orphan and idle cleanup.
 Every subagent gets an ephemeral, auto-cleaned `$TMPDIR` separate from `/work`
 (which is the retained, parent-visible result tree). A **host** subagent gets a
 `mkdtemp` host dir (opaque `lace-tmp-` prefix) under `<results-base>/.tmp` — the
-shim-owned tree — on its process env, removed in the job's exit `finally`. Placing
-it there means a SIGKILL leak (which skips the `finally`) lands in a known,
-shim-reclaimable location rather than the OS temp root. A **container** subagent
-gets `TMPDIR=/tmp` (the
-container's own fs), set last so a persona cannot redirect temp into `/work`;
-cleaned with the container.
+shim-owned tree — on its process env, removed in the job's exit `finally`.
+Placing it there means a SIGKILL leak (which skips the `finally`) lands in a
+known, shim-reclaimable location rather than the OS temp root. A **container**
+subagent gets `TMPDIR=/tmp` (the container's own fs), set last so a persona
+cannot redirect temp into `/work`; cleaned with the container.
 
 ## Host subagents are NOT a security boundary
 
-A host child-process subagent runs as the same uid, inherits the parent's env and
-workDir, and sees the whole host filesystem — it can read any sibling's workspace
-and the session store. The ephemeral workdir + `$TMPDIR` are **hygiene, not
-isolation**. Therefore **adversarial / untrusted / prompt-injectable work MUST
-run as a `per_invocation` container persona, never as a host subagent.** A
-container child is isolated by mount-scoping (only its own `/work`), so it cannot
-read or plant a sibling's workspace.
+A host child-process subagent runs as the same uid, inherits the parent's env
+and workDir, and sees the whole host filesystem — it can read any sibling's
+workspace and the session store. The ephemeral workdir + `$TMPDIR` are
+**hygiene, not isolation**. Therefore **adversarial / untrusted /
+prompt-injectable work MUST run as a `per_invocation` container persona, never
+as a host subagent.** A container child is isolated by mount-scoping (only its
+own `/work`), so it cannot read or plant a sibling's workspace.
 
 ## lace-ps: operator/debug visibility
 

--- a/docs/architecture/prompt-cache-stability.md
+++ b/docs/architecture/prompt-cache-stability.md
@@ -1,108 +1,113 @@
 # Prompt-cache stability
 
-This document describes how Lace keeps a turn's request prefix byte-stable so the
-model provider's prompt cache holds, and the tests and signals that enforce it. It
-is code-path oriented: if behavior changes, update the references below alongside
-the code.
+This document describes how Lace keeps a turn's request prefix byte-stable so
+the model provider's prompt cache holds, and the tests and signals that enforce
+it. It is code-path oriented: if behavior changes, update the references below
+alongside the code.
 
 ## Why byte-stability matters
 
-Each turn sends the conversation so far plus a small live tail. Providers cache the
-longest prefix of a request they have seen before and bill the cached portion at a
-steep discount. The cache keys on content, so the discount survives only when the
-serialized prefix is **byte-for-byte identical** to the previous turn's. A single
-stray byte early in the request — a reordered key, a re-rendered timestamp, a
-differently-sorted directory listing — invalidates the cache from that byte onward.
+Each turn sends the conversation so far plus a small live tail. Providers cache
+the longest prefix of a request they have seen before and bill the cached
+portion at a steep discount. The cache keys on content, so the discount survives
+only when the serialized prefix is **byte-for-byte identical** to the previous
+turn's. A single stray byte early in the request — a reordered key, a
+re-rendered timestamp, a differently-sorted directory listing — invalidates the
+cache from that byte onward.
 
 The stakes differ by provider, but the discipline is the same for all:
 
 - **Anthropic / Bedrock** — Lace places explicit `cache_control` markers in the
-  request. A prefix that drifts forces a full re-read of the cached tokens at roughly
-  5× the cached rate. This is the most expensive failure mode.
-- **OpenAI** — the prefix cache is automatic and server-side; Lace places no markers.
-  Drift silently loses the discount.
-- **Gemini and local backends** (ollama, lmstudio) — Lace manages no explicit cache;
-  a stable prefix still helps wherever the backend reuses prefix/KV state.
+  request. A prefix that drifts forces a full re-read of the cached tokens at
+  roughly 5× the cached rate. This is the most expensive failure mode.
+- **OpenAI** — the prefix cache is automatic and server-side; Lace places no
+  markers. Drift silently loses the discount.
+- **Gemini and local backends** (ollama, lmstudio) — Lace manages no explicit
+  cache; a stable prefix still helps wherever the backend reuses prefix/KV
+  state.
 
 ## The stable thing is the neutral prefix
 
 Lace holds conversation history as a provider-neutral `ProviderMessage[]`
-(`packages/agent/src/providers/base-provider.ts`). Each turn, the active provider's
-converter turns that neutral array into the provider's wire shape:
+(`packages/agent/src/providers/base-provider.ts`). Each turn, the active
+provider's converter turns that neutral array into the provider's wire shape:
 
 - `convertToAnthropicFormat`, `convertToOpenAIFormat`, `convertToGeminiFormat`,
   `convertToTextOnlyFormat` — all in
   `packages/agent/src/providers/format-converters.ts`.
 
 The neutral prefix is stable across turns because the events that produce it are
-immutable and the converters are deterministic. The cache *mechanism* is
-provider-specific and lives behind the provider adapter; the stable neutral prefix
-plus a deterministic conversion is what every provider's cache wants.
+immutable and the converters are deterministic. The cache _mechanism_ is
+provider-specific and lives behind the provider adapter; the stable neutral
+prefix plus a deterministic conversion is what every provider's cache wants.
 
 The providers serialize differently — Anthropic uses a `system` array (with
-`cache_control` markers) and `messages`; OpenAI prepends a `{role:'system'}` chat
-message into `messages`; Gemini keeps the system prompt in `systemInstruction` and
-the turns in `contents`. A session that switches provider keeps its conversation
-history but cold-starts its cache, because each provider serializes a different
-prefix shape into a different cache namespace.
+`cache_control` markers) and `messages`; OpenAI prepends a `{role:'system'}`
+chat message into `messages`; Gemini keeps the system prompt in
+`systemInstruction` and the turns in `contents`. A session that switches
+provider keeps its conversation history but cold-starts its cache, because each
+provider serializes a different prefix shape into a different cache namespace.
 
 ### Anthropic cache markers
 
-For Anthropic and Bedrock, `packages/agent/src/providers/cache-control.ts` stamps the
-markers: `buildSystemWithCaching` (system block), `markLastToolForCaching` (tool
-array), and `attachMessageCacheBreakpoints` (a rolling-tail marker plus a stable
-anchor placed `ANCHOR_OFFSET_RAW_BLOCKS` raw blocks behind the tail).
-`enforceBreakpointBudget` caps the total at Anthropic's four-marker limit, dropping
-newest-first to preserve the stable anchor. The anchor marker moves between turns;
-that is expected — the cache matches on content, not on marker position.
+For Anthropic and Bedrock, `packages/agent/src/providers/cache-control.ts`
+stamps the markers: `buildSystemWithCaching` (system block),
+`markLastToolForCaching` (tool array), and `attachMessageCacheBreakpoints` (a
+rolling-tail marker plus a stable anchor placed `ANCHOR_OFFSET_RAW_BLOCKS` raw
+blocks behind the tail). `enforceBreakpointBudget` caps the total at Anthropic's
+four-marker limit, dropping newest-first to preserve the stable anchor. The
+anchor marker moves between turns; that is expected — the cache matches on
+content, not on marker position.
 
 Just before the Anthropic request is serialized, `sanitizeLoneSurrogates`
-(`packages/agent/src/providers/anthropic/well-formed-json.ts`) replaces lone UTF-16
-surrogates with U+FFFD so the body is valid JSON. It returns the same object when
-nothing changes, so it never perturbs a clean prefix.
+(`packages/agent/src/providers/anthropic/well-formed-json.ts`) replaces lone
+UTF-16 surrogates with U+FFFD so the body is valid JSON. It returns the same
+object when nothing changes, so it never perturbs a clean prefix.
 
 ## One reducer
 
 Events become messages through a single pure reducer,
-`packages/agent/src/message-building/fold-event.ts` (`foldEvent(state, event)` and
-the `foldEvents(events)` batch wrapper). A turn's parallel tool calls fold into the
-canonical Anthropic parallel-tool form: **one assistant message carrying all
-`tool_use` blocks, followed by one user message carrying all `tool_result` blocks.**
-The reducer keeps message content verbatim (it never drops image blocks); a single
-`tool_use` event carries both the call and its result, so the reducer tracks the open
-tool batch to append a second parallel call to the same assistant and a second result
-to the same user.
+`packages/agent/src/message-building/fold-event.ts` (`foldEvent(state, event)`
+and the `foldEvents(events)` batch wrapper). A turn's parallel tool calls fold
+into the canonical Anthropic parallel-tool form: **one assistant message
+carrying all `tool_use` blocks, followed by one user message carrying all
+`tool_result` blocks.** The reducer keeps message content verbatim (it never
+drops image blocks); a single `tool_use` event carries both the call and its
+result, so the reducer tracks the open tool batch to append a second parallel
+call to the same assistant and a second result to the same user.
 
-Three paths share this reducer, which is what makes the shape sent on one turn equal
-the shape rebuilt on the next:
+Three paths share this reducer, which is what makes the shape sent on one turn
+equal the shape rebuilt on the next:
 
-- `buildProviderMessagesFromDurableEvents` (`message-builder.ts`) — the batch rebuild
-  of the whole log.
-- `buildPreservedTail` (`compaction/toolkit.ts`) — the post-compaction tail folded
-  into a `context_compacted` event's `preserved` array.
-- The runner's live tail (`core/conversation/runner.ts`) — as a turn's tools execute,
-  results accumulate into one user message, matching the canonical shape.
+- `buildProviderMessagesFromDurableEvents` (`message-builder.ts`) — the batch
+  rebuild of the whole log.
+- `buildPreservedTail` (`compaction/toolkit.ts`) — the post-compaction tail
+  folded into a `context_compacted` event's `preserved` array.
+- The runner's live tail (`core/conversation/runner.ts`) — as a turn's tools
+  execute, results accumulate into one user message, matching the canonical
+  shape.
 
-Because all three agree, an assistant turn with parallel tool calls serializes the
-same whether it was just sent or later rebuilt from the log, so the cached prefix
-holds across it. (Assistant text reaching a converter as a plain string and as a
-single-`text`-block array convert to byte-identical wire output — pinned by
-`assistant-content-normalization.test.ts` — so the rebuild's verbatim `ContentBlock[]`
-and the runner's string content are cache-equivalent.)
+Because all three agree, an assistant turn with parallel tool calls serializes
+the same whether it was just sent or later rebuilt from the log, so the cached
+prefix holds across it. (Assistant text reaching a converter as a plain string
+and as a single-`text`-block array convert to byte-identical wire output —
+pinned by `assistant-content-normalization.test.ts` — so the rebuild's verbatim
+`ContentBlock[]` and the runner's string content are cache-equivalent.)
 
-A few concerns stay **outside** the reducer, layered around it by the batch rebuild
-only: system-prompt extraction; the `context_compacted` reset to the preserved array
-followed by `dropOrphanedToolBlocks` (the orphan-pair guard); and the
-`context_injected` text-merge into a trailing user message.
+A few concerns stay **outside** the reducer, layered around it by the batch
+rebuild only: system-prompt extraction; the `context_compacted` reset to the
+preserved array followed by `dropOrphanedToolBlocks` (the orphan-pair guard);
+and the `context_injected` text-merge into a trailing user message.
 
 ## One read at turn entry
 
 Turn entry reads and parses the durable event log **once**, via
-`loadTurnEntryProjection` (`message-building/turn-entry-projection.ts`). That single
-parsed event array feeds three pure derivers: the provider message prefix + system
-prompt (the batch reducer above), the files-read set, and the last `turn_end` seq
-(the inject watermark). The per-append seq scan and the per-iteration inject read
-remain — those are addressed by the durable index, not by this read-coalescing.
+`loadTurnEntryProjection` (`message-building/turn-entry-projection.ts`). That
+single parsed event array feeds three pure derivers: the provider message
+prefix + system prompt (the batch reducer above), the files-read set, and the
+last `turn_end` seq (the inject watermark). The per-append seq scan and the
+per-iteration inject read remain — those are addressed by the durable index, not
+by this read-coalescing.
 
 ## The gates
 
@@ -113,90 +118,91 @@ All gates live under `packages/agent/src/providers/__tests__/golden/` and
 ### Golden request bytes (refactor-equivalence)
 
 `golden-bytes-anthropic.test.ts`, `golden-bytes-openai.test.ts`, and
-`golden-bytes-gemini.test.ts` pin each provider's serialized request for a shared
-fixture corpus (`_fixtures.ts`) against committed snapshot files (`anthropic-*.json`,
-`openai-*.json`, `gemini-*.json`). Any change that alters the request bytes shows up
-as a snapshot diff, so a refactor of the message-building path can be proven to
-produce identical output.
+`golden-bytes-gemini.test.ts` pin each provider's serialized request for a
+shared fixture corpus (`_fixtures.ts`) against committed snapshot files
+(`anthropic-*.json`, `openai-*.json`, `gemini-*.json`). Any change that alters
+the request bytes shows up as a snapshot diff, so a refactor of the
+message-building path can be proven to produce identical output.
 
 Capture differs by provider, because what reaches the cache differs:
 
-- **Anthropic** captures the **literal post-serializer body** by pointing the provider
-  at a local `node:http` server (`_capture-request-body.ts`) and reading the raw
-  request body. This is the most faithful gate, used where literal bytes carry the
-  cache.
-- **OpenAI and Gemini** capture the **request object** Lace hands the SDK, via the
-  same SDK module mock the provider's own unit test uses, then `JSON.stringify` it.
-  This is the object Lace controls; server-side (OpenAI) and absent (Gemini) cache
-  mechanisms make object-level fidelity sufficient.
+- **Anthropic** captures the **literal post-serializer body** by pointing the
+  provider at a local `node:http` server (`_capture-request-body.ts`) and
+  reading the raw request body. This is the most faithful gate, used where
+  literal bytes carry the cache.
+- **OpenAI and Gemini** capture the **request object** Lace hands the SDK, via
+  the same SDK module mock the provider's own unit test uses, then
+  `JSON.stringify` it. This is the object Lace controls; server-side (OpenAI)
+  and absent (Gemini) cache mechanisms make object-level fidelity sufficient.
 
 Each golden test also captures twice in one run and asserts the two captures are
-equal before comparing to the committed snapshot, so any nondeterminism in the body
-surfaces immediately.
+equal before comparing to the committed snapshot, so any nondeterminism in the
+body surfaces immediately.
 
-**To add a fixture or intentionally change the wire shape:** edit `_fixtures.ts` (or
-the converter), regenerate with
-`npx vitest run -u src/providers/__tests__/golden/`, and **review the snapshot diff**
-— a change to a committed golden is a deliberate wire change and must be read as one.
-The committed `.gitignore` ignores `anthropic-*.json` broadly; a scoped negation keeps
-the golden directory's files tracked.
+**To add a fixture or intentionally change the wire shape:** edit `_fixtures.ts`
+(or the converter), regenerate with
+`npx vitest run -u src/providers/__tests__/golden/`, and **review the snapshot
+diff** — a change to a committed golden is a deliberate wire change and must be
+read as one. The committed `.gitignore` ignores `anthropic-*.json` broadly; a
+scoped negation keeps the golden directory's files tracked.
 
 ### Cross-turn cache-stability
 
-`cross-turn-cache-stability.test.ts` sends a second turn whose only difference is a
-longer tail and asserts the shared prefix is byte-identical. Anthropic is compared
-with `cache_control` markers stripped (the rolling anchor legitimately moves inside
-the request between turns); OpenAI and Gemini are compared whole (no markers). Drift
-here — after stripping, for Anthropic — is the real cache regression this gate exists
-to catch.
+`cross-turn-cache-stability.test.ts` sends a second turn whose only difference
+is a longer tail and asserts the shared prefix is byte-identical. Anthropic is
+compared with `cache_control` markers stripped (the rolling anchor legitimately
+moves inside the request between turns); OpenAI and Gemini are compared whole
+(no markers). Drift here — after stripping, for Anthropic — is the real cache
+regression this gate exists to catch.
 
 ### Converter and render determinism
 
 The cached prefix rests on every input being byte-deterministic.
 
-- `converter-determinism.test.ts` feeds each of the four converters the corpus twice
-  and asserts byte-equality, including a fixture whose Gemini tool-call id is a
-  persisted `gemini_…` id. The Gemini converter encodes a tool id with
+- `converter-determinism.test.ts` feeds each of the four converters the corpus
+  twice and asserts byte-equality, including a fixture whose Gemini tool-call id
+  is a persisted `gemini_…` id. The Gemini converter encodes a tool id with
   `Date.now()`/`Math.random()` **only when parsing a response**
-  (`packages/agent/src/providers/gemini-provider.ts`); that id is then persisted and
-  replayed verbatim, never re-minted when rebuilding history, so conversion stays
-  deterministic.
-- `render-determinism.test.ts` asserts the system-prompt inputs render to identical
-  bytes regardless of directory-read order and wall-clock within a UTC day. The
-  concrete rules this enforces in code:
+  (`packages/agent/src/providers/gemini-provider.ts`); that id is then persisted
+  and replayed verbatim, never re-minted when rebuilding history, so conversion
+  stays deterministic.
+- `render-determinism.test.ts` asserts the system-prompt inputs render to
+  identical bytes regardless of directory-read order and wall-clock within a UTC
+  day. The concrete rules this enforces in code:
   - **Project tree** entries are sorted byte-stably before truncation in
-    `generateProjectTree` (`packages/agent/src/config/variable-providers.ts`); the
-    tree is rendered into the system prompt via
-    `packages/agent/config/agent-personas/sections/environment.md`, so an unsorted
-    listing would drift the cached system block.
-  - **Session date** is emitted date-only (`YYYY-MM-DD`), not a precise timestamp, so
-    it is stable within a UTC day (`variable-providers.ts`).
+    `generateProjectTree` (`packages/agent/src/config/variable-providers.ts`);
+    the tree is rendered into the system prompt via
+    `packages/agent/config/agent-personas/sections/environment.md`, so an
+    unsorted listing would drift the cached system block.
+  - **Session date** is emitted date-only (`YYYY-MM-DD`), not a precise
+    timestamp, so it is stable within a UTC day (`variable-providers.ts`).
   - **Tool order** is byte-stable-sorted with a binary comparator (not
     locale-dependent `localeCompare`) in `getAllTools`
     (`packages/agent/src/tools/executor.ts`).
 
 The system prompt is rendered once at session creation and frozen into a
 `system_prompt_set` event, then replayed each turn; a post-compaction persona
-re-render appends a fresh `system_prompt_set` only when the rendered text actually
-changes. Determinism is what makes that skip-if-unchanged guard correct.
+re-render appends a fresh `system_prompt_set` only when the rendered text
+actually changes. Determinism is what makes that skip-if-unchanged guard
+correct.
 
 ## The production signal
 
-Determinism gates run in CI against fixtures. A real session's state never appears in
-a fixture, so production is watched directly: every turn logs a `cache-health: turn
-complete` line. `buildCacheHealthLog`
-(`packages/agent/src/core/conversation/cache-health.ts`) is a pure function that turns
-the turn's accumulated usage into a flat record — uncached input, cache-creation, and
-cache-read token counts, a derived cache-read rate, and the cache-miss reason — and
-the runner emits it right after the `turn_end` event is written
-(`packages/agent/src/core/conversation/runner.ts`).
+Determinism gates run in CI against fixtures. A real session's state never
+appears in a fixture, so production is watched directly: every turn logs a
+`cache-health: turn complete` line. `buildCacheHealthLog`
+(`packages/agent/src/core/conversation/cache-health.ts`) is a pure function that
+turns the turn's accumulated usage into a flat record — uncached input,
+cache-creation, and cache-read token counts, a derived cache-read rate, and the
+cache-miss reason — and the runner emits it right after the `turn_end` event is
+written (`packages/agent/src/core/conversation/runner.ts`).
 
 The cache fields come from each provider's parsed usage
-(`cacheCreationInputTokens` / `cacheReadInputTokens` on `ProviderResponse.usage` in
-`base-provider.ts`). Anthropic populates them on every response; OpenAI and Gemini
-report no cache split today, so their counts read zero and the signal is most
-meaningful for Anthropic, where the cost of drift is highest. A sustained drop in the
-cache-read rate, or a recurring miss reason, means a prefix regression reached
-production — investigate the most recent change to the message-building or
-prompt-rendering path. The line is logged at `info`; set `LACE_LOG_LEVEL=info` (or
-lower) to see it.
+(`cacheCreationInputTokens` / `cacheReadInputTokens` on `ProviderResponse.usage`
+in `base-provider.ts`). Anthropic populates them on every response; OpenAI and
+Gemini report no cache split today, so their counts read zero and the signal is
+most meaningful for Anthropic, where the cost of drift is highest. A sustained
+drop in the cache-read rate, or a recurring miss reason, means a prefix
+regression reached production — investigate the most recent change to the
+message-building or prompt-rendering path. The line is logged at `info`; set
+`LACE_LOG_LEVEL=info` (or lower) to see it.

--- a/docs/architecture/session-state-projection.md
+++ b/docs/architecture/session-state-projection.md
@@ -6,8 +6,8 @@
 At the start of every turn the agent needs the conversation projection: the
 provider message prefix, the system prompt, the files-read set, and the
 last-turn-end watermark. Rather than re-parsing the whole durable event log each
-turn, the agent process holds the projection **in memory across turns**, keyed by
-session, and on each turn folds only the events appended since the last turn.
+turn, the agent process holds the projection **in memory across turns**, keyed
+by session, and on each turn folds only the events appended since the last turn.
 
 ## The mechanism
 
@@ -25,8 +25,9 @@ projection is cached for the active session and the tip has not moved backward,
 the runner tail-reads only the events with `eventSeq >= headSeq` and folds them
 into the cached projection — O(tail) instead of O(events). Because `headSeq` is
 the next seq to fold, an event already folded is never re-applied. Both
-own-process and cross-process appends advance `.seq`, so the tail-read sees every
-new event (including a context inject written by another process between turns).
+own-process and cross-process appends advance `.seq`, so the tail-read sees
+every new event (including a context inject written by another process between
+turns).
 
 On a cold start, a cache miss, or a tip that moved backward, the runner falls
 back to a full rebuild over the whole log and seeds the cache from it.
@@ -36,10 +37,10 @@ so an incremental fold is byte-identical to a full rebuild over the same events.
 
 ## The projection is the persisted prefix only
 
-The cache holds only what is durable on disk. The runner's non-persisted per-turn
-live-tail mutations — loop reminders, tool_result construction, tool-choice
-retries — are layered onto the per-turn provider messages and are never folded
-into the cached projection.
+The cache holds only what is durable on disk. The runner's non-persisted
+per-turn live-tail mutations — loop reminders, tool_result construction,
+tool-choice retries — are layered onto the per-turn provider messages and are
+never folded into the cached projection.
 
 ## Divergence canary
 

--- a/docs/design/2026-06-18-session-state-step3-index-and-seq-authority.md
+++ b/docs/design/2026-06-18-session-state-step3-index-and-seq-authority.md
@@ -1,48 +1,53 @@
 # Session-State Step 3 — Cross-Process Seq Authority + Recall Index (design, rev2)
 
-Status: design intent, hardened after a two-reviewer adversarial pass that found the
-rev1 (SQLite-counter) design corruption-prone. This is the linchpin the architecture
-spec flagged as "the part most likely to be wrong if rushed" — a mistake corrupts the
-durable log. Read the crash/concurrency analysis as the load-bearing section.
+Status: design intent, hardened after a two-reviewer adversarial pass that found
+the rev1 (SQLite-counter) design corruption-prone. This is the linchpin the
+architecture spec flagged as "the part most likely to be wrong if rushed" — a
+mistake corrupts the durable log. Read the crash/concurrency analysis as the
+load-bearing section.
 
 ## The one principle rev1 violated
 
 **Correctness decisions read the JSONL (the source of truth), serialized by a
-per-session file lock. The SQLite index is only a read/recall cache and is never on a
-correctness path.**
+per-session file lock. The SQLite index is only a read/recall cache and is never
+on a correctness path.**
 
 Rev1 tried to make a best-effort, lagging SQLite index the authority for seq
-assignment, turn_end dedup, idempotency, and the injects watermark. The reviewers
-showed every one of those is unsafe: the index lags the JSONL (write-through is
-best-effort, backfill runs *after* the RPC server is live), so the index can be behind
-the truth and produce a duplicate seq, a duplicate turn_end, a re-run prompt, or a
-**silently dropped cross-process inject**. Rev2 keeps every correctness decision on the
-JSONL under a real cross-process lock, and uses SQLite only for non-lossy recall (#22).
+assignment, turn*end dedup, idempotency, and the injects watermark. The
+reviewers showed every one of those is unsafe: the index lags the JSONL
+(write-through is best-effort, backfill runs \_after* the RPC server is live),
+so the index can be behind the truth and produce a duplicate seq, a duplicate
+turn_end, a re-run prompt, or a **silently dropped cross-process inject**. Rev2
+keeps every correctness decision on the JSONL under a real cross-process lock,
+and uses SQLite only for non-lossy recall (#22).
 
 ## The problem (unchanged)
 
 Per-turn cost is dominated by full-log scans:
-- `deriveNextEventSeqAcrossSessionFiles` — a full O(events) scan **on every append**
-  (5-8/turn) to compute the next `eventSeq`, run **outside any cross-process lock**.
-  Two processes appending to the same session concurrently (the inject path is
-  cross-process and live) can both derive the same seq and write a **duplicate** — a
-  latent corruption race that exists today.
-- `readImmediateInjectsSince` — a full scan **per loop iteration** (1-8/turn) for
-  cross-process injects.
-- `findLastTurnEndEventSeq`, `findTurnEndEventByTurnId` (dedup), `classifyPromptHandoff`
-  (idempotency) — full scans, but each runs **once per turn / per prompt**, not per
-  append, so they are not the per-append bottleneck.
+
+- `deriveNextEventSeqAcrossSessionFiles` — a full O(events) scan **on every
+  append** (5-8/turn) to compute the next `eventSeq`, run **outside any
+  cross-process lock**. Two processes appending to the same session concurrently
+  (the inject path is cross-process and live) can both derive the same seq and
+  write a **duplicate** — a latent corruption race that exists today.
+- `readImmediateInjectsSince` — a full scan **per loop iteration** (1-8/turn)
+  for cross-process injects.
+- `findLastTurnEndEventSeq`, `findTurnEndEventByTurnId` (dedup),
+  `classifyPromptHandoff` (idempotency) — full scans, but each runs **once per
+  turn / per prompt**, not per append, so they are not the per-append
+  bottleneck.
 
 ## The design (rev2)
 
 ### 1. Seq authority = per-session flock + monotonic head file
 
-A per-session **advisory file lock** (`<sessionDir>/.seq.lock`, via `proper-lockfile`
-or an equivalent battle-tested cross-process lock) and a per-session **head file**
-(`<sessionDir>/.seq` holding a single integer = the next-free seq).
+A per-session **advisory file lock** (`<sessionDir>/.seq.lock`, via
+`proper-lockfile` or an equivalent battle-tested cross-process lock) and a
+per-session **head file** (`<sessionDir>/.seq` holding a single integer = the
+next-free seq).
 
-`appendDurableEvent` becomes (the lock is held across the JSONL append — that is what
-makes seeding and assignment race-free):
+`appendDurableEvent` becomes (the lock is held across the JSONL append — that is
+what makes seeding and assignment race-free):
 
 ```
 acquire flock(sessionDir)            // cross-process serialization of ALL appenders
@@ -55,196 +60,220 @@ finally:
 writeThroughRecallIndex(event)       // best-effort, OUTSIDE the lock (not correctness)
 ```
 
-**Why reserve-before-append (head written before the JSONL append):** the head file
-and the JSONL are separate files; there is no transaction to roll back. A crash after
-`writeHead(H+1)` but before the JSONL append **burns H** (a gap) — the event was never
-durable, the caller never got success, losing it is correct, and the next append gets
-H+1, never H. A crash after the JSONL append is impossible to leave inconsistent
-because the head was already advanced first. **No interleaving yields a duplicate; the
-worst case is a gap, which every consumer tolerates** (the reducer sorts by seq;
-watermarks compare with `>`/`<=`, never `+1`; checkpoints match exact stored seqs;
-recall range reads tolerate missing neighbors — verified across the codebase by both
-reviewers).
+**Why reserve-before-append (head written before the JSONL append):** the head
+file and the JSONL are separate files; there is no transaction to roll back. A
+crash after `writeHead(H+1)` but before the JSONL append **burns H** (a gap) —
+the event was never durable, the caller never got success, losing it is correct,
+and the next append gets H+1, never H. A crash after the JSONL append is
+impossible to leave inconsistent because the head was already advanced first.
+**No interleaving yields a duplicate; the worst case is a gap, which every
+consumer tolerates** (the reducer sorts by seq; watermarks compare with
+`>`/`<=`, never `+1`; checkpoints match exact stored seqs; recall range reads
+tolerate missing neighbors — verified across the codebase by both reviewers).
 
-This is self-contained per session: **no SQLite, no DB-wide lock, no cross-session
-contention** (rev1 Finding A3 dissolved). The flock is also a genuine correctness fix
-for the dup race that exists today.
+This is self-contained per session: **no SQLite, no DB-wide lock, no
+cross-session contention** (rev1 Finding A3 dissolved). The flock is also a
+genuine correctness fix for the dup race that exists today.
 
 #### Head seeding and reconcile (exact semantics — rev1 was ambiguous here)
 
-The head file stores the **next-free** seq (not the last-consumed). Two rules, stated
-once and unambiguously:
+The head file stores the **next-free** seq (not the last-consumed). Two rules,
+stated once and unambiguously:
 
-- **Seed (head file missing):** done **inside the held flock** on the first append (or
-  at session open). `head = MAX(JSONL seq across all shards) + 1`. Reading `MAX(JSONL)`
-  under the flock is race-free because every appender holds the flock, so no concurrent
-  append can land between the scan and the first reserve. (`deriveNextEventSeqAcross
-  SessionFiles` already returns `MAX+1` across legacy + all persona/date shards — reuse
-  it for the seed.)
-- **Reconcile (head file present, on open):** `head = MAX(readHead(), MAX(JSONL)+1)`.
-  This is monotonic-merge — it can only move the head **up**, never down, so a stale or
-  lost head (e.g. an un-fsync'd write lost to a crash, or an index/state rebuild) can
-  never hand out a seq `≤` an existing JSONL seq. The `+1` is load-bearing (the head is
-  next-free; `MAX(JSONL)` is last-consumed).
+- **Seed (head file missing):** done **inside the held flock** on the first
+  append (or at session open). `head = MAX(JSONL seq across all shards) + 1`.
+  Reading `MAX(JSONL)` under the flock is race-free because every appender holds
+  the flock, so no concurrent append can land between the scan and the first
+  reserve. (`deriveNextEventSeqAcross SessionFiles` already returns `MAX+1`
+  across legacy + all persona/date shards — reuse it for the seed.)
+- **Reconcile (head file present, on open):**
+  `head = MAX(readHead(), MAX(JSONL)+1)`. This is monotonic-merge — it can only
+  move the head **up**, never down, so a stale or lost head (e.g. an un-fsync'd
+  write lost to a crash, or an index/state rebuild) can never hand out a seq `≤`
+  an existing JSONL seq. The `+1` is load-bearing (the head is next-free;
+  `MAX(JSONL)` is last-consumed).
 
-No per-append fsync of the head is required: the head is read fresh under the flock each
-append (so it reflects the last in-process write via the page cache), and a crash that
-loses an un-fsync'd head write is caught by the open-time reconcile against the JSONL.
+No per-append fsync of the head is required: the head is read fresh under the
+flock each append (so it reflects the last in-process write via the page cache),
+and a crash that loses an un-fsync'd head write is caught by the open-time
+reconcile against the JSONL.
 
 #### `session/fork` (rev1 Finding B7)
 
-Fork copies events with raw `appendFileSync`, preserving original seqs, and never calls
-`appendDurableEvent`. That is fine under rev2: the forked session has **no head file**,
-so the first real `appendDurableEvent` to it seeds the head from `MAX(copied JSONL)+1`
-under the flock. Because a fork creates a brand-new session that nothing else is
-appending to yet, there is no race. (We additionally write the head at fork time as an
-optimization, but correctness does not depend on it — the lazy seed covers it.)
+Fork copies events with raw `appendFileSync`, preserving original seqs, and
+never calls `appendDurableEvent`. That is fine under rev2: the forked session
+has **no head file**, so the first real `appendDurableEvent` to it seeds the
+head from `MAX(copied JSONL)+1` under the flock. Because a fork creates a
+brand-new session that nothing else is appending to yet, there is no race. (We
+additionally write the head at fork time as an optimization, but correctness
+does not depend on it — the lazy seed covers it.)
 
 #### `SessionState.nextEventSeq` (rev1 Finding A5/B5)
 
-The head file is the **sole** seq authority. `SessionState.nextEventSeq` is **retired
-as an authority**: nothing assigns a seq from it (today nothing does — assignment is
-`deriveNextEventSeqAcrossSessionFiles`). We stop `loadSession` from repairing/rewriting
-`state.nextEventSeq` from a JSONL scan (it would perpetually "mismatch" once gaps exist,
-rewriting state on every open). Either drop the field or mark it advisory/derived; the
-corruption guard that field once served (`readSessionState`) is replaced by the head
-reconcile. This must be explicit in the plan so two "next seq" sources cannot drift.
+The head file is the **sole** seq authority. `SessionState.nextEventSeq` is
+**retired as an authority**: nothing assigns a seq from it (today nothing does —
+assignment is `deriveNextEventSeqAcrossSessionFiles`). We stop `loadSession`
+from repairing/rewriting `state.nextEventSeq` from a JSONL scan (it would
+perpetually "mismatch" once gaps exist, rewriting state on every open). Either
+drop the field or mark it advisory/derived; the corruption guard that field once
+served (`readSessionState`) is replaced by the head reconcile. This must be
+explicit in the plan so two "next seq" sources cannot drift.
 
 ### 2. Injects = JSONL byte-offset tail-read (rev1 Finding B3 — the dangerous one)
 
-`readImmediateInjectsSince` must NOT read the lagging index (a cross-process inject in
-the JSONL but not yet journaled would be **silently dropped** — a lost notification,
-not a safe redo). Instead, read the JSONL **incrementally by byte offset**: track the
-last-read byte offset per shard file; each call reads only `[offset, EOF)`, parses the
-newly-appended lines, advances the offset. Append-only files mean cross-process injects
-land at the end and are seen immediately, with **O(new bytes)** work instead of
-O(all events). Handle the rare new-shard case (cross-midnight / persona change
-mid-turn) by detecting a new shard file and reading it whole from offset 0. This reads
-the truth, never lags, and removes the per-iteration full scan — the second bottleneck.
+`readImmediateInjectsSince` must NOT read the lagging index (a cross-process
+inject in the JSONL but not yet journaled would be **silently dropped** — a lost
+notification, not a safe redo). Instead, read the JSONL **incrementally by byte
+offset**: track the last-read byte offset per shard file; each call reads only
+`[offset, EOF)`, parses the newly-appended lines, advances the offset.
+Append-only files mean cross-process injects land at the end and are seen
+immediately, with **O(new bytes)** work instead of O(all events). Handle the
+rare new-shard case (cross-midnight / persona change mid-turn) by detecting a
+new shard file and reading it whole from offset 0. This reads the truth, never
+lags, and removes the per-iteration full scan — the second bottleneck.
 
 ### 3. dedup / idempotency / last-turn-end = stay on the JSONL
 
 These run **once per turn / per prompt**, not per append, so they are not the
 per-append bottleneck and do not need the index:
 
-- **turn_end dedup** (`findTurnEndEventByTurnId`): keep reading the JSONL, now **inside
-  the flock**, so the one-turn_end-per-turnId invariant is enforced against the truth
-  and is race-free (rev1 Findings A1/B9 dissolved — the flock serializes, and we read
-  the source of truth, not a lagging store). In practice turn_ends are written only by
-  the owning runner (in-process, already serialized by `runExclusive`), so the
-  cross-process case is rare regardless; reading the JSONL keeps it correct.
-- **idempotency** (`classifyPromptHandoff`): keep on the JSONL. It needs the matched
-  prompt's content deep-equal AND the later-same-turn-events check (rev1 Finding B4) —
-  both already work over the JSONL event set; no change, no regression. It runs once at
-  prompt handoff; the Step-2 parse-once already made the turn-entry read efficient.
-- **last-turn-end seq**: already served by `loadTurnEntryProjection` (Step 2) from the
-  single turn-entry parse. No per-append cost.
+- **turn_end dedup** (`findTurnEndEventByTurnId`): keep reading the JSONL, now
+  **inside the flock**, so the one-turn_end-per-turnId invariant is enforced
+  against the truth and is race-free (rev1 Findings A1/B9 dissolved — the flock
+  serializes, and we read the source of truth, not a lagging store). In practice
+  turn_ends are written only by the owning runner (in-process, already
+  serialized by `runExclusive`), so the cross-process case is rare regardless;
+  reading the JSONL keeps it correct.
+- **idempotency** (`classifyPromptHandoff`): keep on the JSONL. It needs the
+  matched prompt's content deep-equal AND the later-same-turn-events check (rev1
+  Finding B4) — both already work over the JSONL event set; no change, no
+  regression. It runs once at prompt handoff; the Step-2 parse-once already made
+  the turn-entry read efficient.
+- **last-turn-end seq**: already served by `loadTurnEntryProjection` (Step 2)
+  from the single turn-entry parse. No per-append cost.
 
-So Step 3 does **not** move dedup/idempotency to SQLite at all. That removes rev1
-Findings A1, A4, B4, B9 entirely.
+So Step 3 does **not** move dedup/idempotency to SQLite at all. That removes
+rev1 Findings A1, A4, B4, B9 entirely.
 
 ### 4. `event_journal` (SQLite) = recall non-lossy only (#22)
 
-A new `event_journal` table in the existing `recall/index.sqlite`: one row per event,
-`(session_id, event_seq, type, ts, line)` with `line` = the verbatim JSONL text, plus
-the FTS content for search. Purpose: `/recall` returns the **verbatim** event (no
-rendering loss, all event types), instead of today's lossy FTS-only rows. It is written
-by a **dedicated, unfiltered writer** (not `eventToRow`, which returns `null` for
-turn_end/system_prompt_set/etc — rev1 Finding B6), best-effort write-through + startup
-backfill (exactly today's recall robustness model). **Nothing correctness-critical reads
-it**, so its lag is harmless. This is the #22 deliverable and is independently shippable
-first (lowest risk).
+A new `event_journal` table in the existing `recall/index.sqlite`: one row per
+event, `(session_id, event_seq, type, ts, line)` with `line` = the verbatim
+JSONL text, plus the FTS content for search. Purpose: `/recall` returns the
+**verbatim** event (no rendering loss, all event types), instead of today's
+lossy FTS-only rows. It is written by a **dedicated, unfiltered writer** (not
+`eventToRow`, which returns `null` for turn_end/system_prompt_set/etc — rev1
+Finding B6), best-effort write-through + startup backfill (exactly today's
+recall robustness model). **Nothing correctness-critical reads it**, so its lag
+is harmless. This is the #22 deliverable and is independently shippable first
+(lowest risk).
 
 ## Invariants (rev2)
 
-1. JSONL is the source of truth. The head file is the seq authority (reconciled to the
-   JSONL on open). The SQLite index is a derived recall cache, rebuildable from the
-   JSONL, never on a correctness path.
-2. Seq is unique and monotonic across processes; **gaps are allowed** (a crash between
-   head-reserve and JSONL-append burns a seq). Nothing assumes gapless seqs.
-3. Every append holds the per-session flock across the JSONL write; seq assignment,
-   head seeding, and turn_end dedup happen under that lock, reading the JSONL.
-4. The head reconcile is monotonic: `head = MAX(readHead(), MAX(JSONL)+1)` on open;
-   it can never move down.
-5. The injects watermark reads the JSONL by byte offset (truth, no lag). It never reads
-   the SQLite index.
-6. `SessionState.nextEventSeq` is not a seq authority and is not repaired from a JSONL
-   scan on load.
-7. Recall index writes are best-effort + backfill-repaired; a recall write failure never
-   fails an append. (Seq assignment is a *file* operation under a *file* lock, not a DB
-   op — so DB unavailability cannot fail an append. Rev1 Finding A3 dissolved.)
+1. JSONL is the source of truth. The head file is the seq authority (reconciled
+   to the JSONL on open). The SQLite index is a derived recall cache,
+   rebuildable from the JSONL, never on a correctness path.
+2. Seq is unique and monotonic across processes; **gaps are allowed** (a crash
+   between head-reserve and JSONL-append burns a seq). Nothing assumes gapless
+   seqs.
+3. Every append holds the per-session flock across the JSONL write; seq
+   assignment, head seeding, and turn_end dedup happen under that lock, reading
+   the JSONL.
+4. The head reconcile is monotonic: `head = MAX(readHead(), MAX(JSONL)+1)` on
+   open; it can never move down.
+5. The injects watermark reads the JSONL by byte offset (truth, no lag). It
+   never reads the SQLite index.
+6. `SessionState.nextEventSeq` is not a seq authority and is not repaired from a
+   JSONL scan on load.
+7. Recall index writes are best-effort + backfill-repaired; a recall write
+   failure never fails an append. (Seq assignment is a _file_ operation under a
+   _file_ lock, not a DB op — so DB unavailability cannot fail an append. Rev1
+   Finding A3 dissolved.)
 
 ## Crash & concurrency analysis (load-bearing)
 
-- **Crash after head-reserve (H+1 written), before JSONL append:** H burned → gap.
-  Event lost (never durable; caller didn't get success). Next append H+1. No dup. ✔
+- **Crash after head-reserve (H+1 written), before JSONL append:** H burned →
+  gap. Event lost (never durable; caller didn't get success). Next append H+1.
+  No dup. ✔
 - **Crash after JSONL append:** head was already advanced first → consistent. ✔
-- **Two processes append concurrently:** the flock serializes them; A reserves H and
-  appends, releases; B reserves H+1 and appends. No dup. ✔ (the race today's code loses)
-- **Head file lost / un-fsync'd write lost to a crash:** open-time reconcile sets
-  `head = MAX(readHead()|0, MAX(JSONL)+1)` → never ≤ an existing JSONL seq. ✔
-- **Fork:** new session, lazy seed under the flock from `MAX(copied JSONL)+1`, no race. ✔
-- **Stale flock (process died holding it):** `proper-lockfile` reclaims a stale lock by
-  mtime/staleness; the plan must set a sane staleness and verify reclaim. (Open item.)
-- **Recall index unavailable/locked/disk-full:** swallowed (best-effort); append still
-  succeeds (seq + JSONL are file ops). Backfill repairs the index later. ✔
+- **Two processes append concurrently:** the flock serializes them; A reserves H
+  and appends, releases; B reserves H+1 and appends. No dup. ✔ (the race
+  today's code loses)
+- **Head file lost / un-fsync'd write lost to a crash:** open-time reconcile
+  sets `head = MAX(readHead()|0, MAX(JSONL)+1)` → never ≤ an existing JSONL seq.
+  ✔
+- **Fork:** new session, lazy seed under the flock from `MAX(copied JSONL)+1`,
+  no race. ✔
+- **Stale flock (process died holding it):** `proper-lockfile` reclaims a stale
+  lock by mtime/staleness; the plan must set a sane staleness and verify
+  reclaim. (Open item.)
+- **Recall index unavailable/locked/disk-full:** swallowed (best-effort); append
+  still succeeds (seq + JSONL are file ops). Backfill repairs the index later.
+  ✔
 
 ## Build order (each independently shippable + measured; safest first)
 
-1. **`event_journal` recall non-lossy (#22)** — lowest risk, no correctness path. Add
-   the table + unfiltered write-through + backfill; point `/recall` at the verbatim
-   line. Ship + verify recall fidelity on Ada. This proves the index plumbing with zero
-   risk to the log.
-2. **Injects byte-offset tail-read** — replace `readImmediateInjectsSince`'s full scan
-   with the incremental offset reader. Pure read change, reads the truth. Differential
-   test vs the full-scan over fixtures incl. cross-process injects + cross-shard. Ship +
-   measure (removes one bottleneck).
-3. **Seq = flock + head file — THE DANGEROUS ONE.** Add the per-session flock + head
-   file; reserve-before-append; seed + reconcile per the exact semantics above; retire
-   `SessionState.nextEventSeq` as authority and stop the `loadSession` repair-rewrite.
-   Tests: two real concurrent processes appending (assert unique, monotonic, no dup);
-   crash-injection between head-reserve and JSONL-append (assert gap, not dup); fork
-   seed; stale-lock reclaim; reconcile after a lost head. Keep
-   `deriveNextEventSeqAcrossSessionFiles` only for the seed/reconcile scan and a
-   debug/validate path. Deploy to Ada and watch for any seq anomaly (a tail-read over
-   her live log asserting strictly-increasing-with-gaps, no dups).
+1. **`event_journal` recall non-lossy (#22)** — lowest risk, no correctness
+   path. Add the table + unfiltered write-through + backfill; point `/recall` at
+   the verbatim line. Ship + verify recall fidelity on Ada. This proves the
+   index plumbing with zero risk to the log.
+2. **Injects byte-offset tail-read** — replace `readImmediateInjectsSince`'s
+   full scan with the incremental offset reader. Pure read change, reads the
+   truth. Differential test vs the full-scan over fixtures incl. cross-process
+   injects + cross-shard. Ship + measure (removes one bottleneck).
+3. **Seq = flock + head file — THE DANGEROUS ONE.** Add the per-session flock +
+   head file; reserve-before-append; seed + reconcile per the exact semantics
+   above; retire `SessionState.nextEventSeq` as authority and stop the
+   `loadSession` repair-rewrite. Tests: two real concurrent processes appending
+   (assert unique, monotonic, no dup); crash-injection between head-reserve and
+   JSONL-append (assert gap, not dup); fork seed; stale-lock reclaim; reconcile
+   after a lost head. Keep `deriveNextEventSeqAcrossSessionFiles` only for the
+   seed/reconcile scan and a debug/validate path. Deploy to Ada and watch for
+   any seq anomaly (a tail-read over her live log asserting
+   strictly-increasing-with-gaps, no dups).
 
 ## What stays put
 
-- The on-disk JSONL format is unchanged. Old sessions seed their head from `MAX(JSONL)`
-  on first open; nothing to migrate.
-- `runExclusive` (in-process) stays; the per-session flock adds the cross-process
-  serialization the append path lacked.
-- The recall FTS table stays for search; `event_journal` adds the verbatim store.
+- The on-disk JSONL format is unchanged. Old sessions seed their head from
+  `MAX(JSONL)` on first open; nothing to migrate.
+- `runExclusive` (in-process) stays; the per-session flock adds the
+  cross-process serialization the append path lacked.
+- The recall FTS table stays for search; `event_journal` adds the verbatim
+  store.
 
 ## What review changed (rev1 → rev2)
 
-A two-reviewer competitive pass found rev1 (SQLite-counter as seq authority + index for
-dedup/idempotency/injects) corruption-prone. Every fix below traces to a finding:
-- **Seq authority moved from a shared-SQLite counter to a per-session flock + head
-  file.** Dissolves: DB-wide contention + seq-on-critical-path append failure (A3); the
-  seeding TOCTOU because DB-lock ≠ JSONL-lock (A2) — now the flock is held across the
-  JSONL append; the ambiguous off-by-one reconcile (B1) — now stated once as
-  `MAX(stored, MAX(JSONL)+1)`, head = next-free; the backfill-clobbers-counter race
-  (B2) — no counter, head is per-session under the flock; the fork-with-no-seed dup
-  (B7) — lazy seed under the flock.
-- **Injects keep reading the JSONL (now by byte offset), never the index** (B3 — the
-  silently-dropped cross-process inject).
-- **dedup + idempotency stay on the JSONL** (A1, A4, B4, B9) — never moved to the index;
-  idempotency keeps its later-same-turn check intact.
-- **`event_journal` gets a dedicated unfiltered writer** (B6) and is recall-only.
-- **`SessionState.nextEventSeq` retired as authority + no load-time repair** (A5, B5).
-- **The canary is no longer load-bearing for seq** (A6, B8): seq correctness comes from
-  the flock + reserve-before-append + reconcile, which *prevent* dups, rather than a
-  sampled canary that could only *detect* an unrecoverable dup after the fact.
+A two-reviewer competitive pass found rev1 (SQLite-counter as seq authority +
+index for dedup/idempotency/injects) corruption-prone. Every fix below traces to
+a finding:
+
+- **Seq authority moved from a shared-SQLite counter to a per-session flock +
+  head file.** Dissolves: DB-wide contention + seq-on-critical-path append
+  failure (A3); the seeding TOCTOU because DB-lock ≠ JSONL-lock (A2) — now the
+  flock is held across the JSONL append; the ambiguous off-by-one reconcile (B1)
+  — now stated once as `MAX(stored, MAX(JSONL)+1)`, head = next-free; the
+  backfill-clobbers-counter race (B2) — no counter, head is per-session under
+  the flock; the fork-with-no-seed dup (B7) — lazy seed under the flock.
+- **Injects keep reading the JSONL (now by byte offset), never the index** (B3 —
+  the silently-dropped cross-process inject).
+- **dedup + idempotency stay on the JSONL** (A1, A4, B4, B9) — never moved to
+  the index; idempotency keeps its later-same-turn check intact.
+- **`event_journal` gets a dedicated unfiltered writer** (B6) and is
+  recall-only.
+- **`SessionState.nextEventSeq` retired as authority + no load-time repair**
+  (A5, B5).
+- **The canary is no longer load-bearing for seq** (A6, B8): seq correctness
+  comes from the flock + reserve-before-append + reconcile, which _prevent_
+  dups, rather than a sampled canary that could only _detect_ an unrecoverable
+  dup after the fact.
 
 ## Open items for the plan
 
-- Pick + verify the cross-process lock library (`proper-lockfile` vs a native flock);
-  confirm stale-lock reclaim semantics and a staleness threshold that can't falsely
-  reclaim a slow-but-live append.
-- The byte-offset inject reader's shard/rotation handling (cross-midnight, persona
-  change) — enumerate and test.
-- Confirm every `appendDurableEvent` caller goes through the locked path (the inject
-  path at `session-operations.ts`, the runner's `writeAndAdvance`, fork) — no raw
-  `appendFileSync` to a live session outside fork.
+- Pick + verify the cross-process lock library (`proper-lockfile` vs a native
+  flock); confirm stale-lock reclaim semantics and a staleness threshold that
+  can't falsely reclaim a slow-but-live append.
+- The byte-offset inject reader's shard/rotation handling (cross-midnight,
+  persona change) — enumerate and test.
+- Confirm every `appendDurableEvent` caller goes through the locked path (the
+  inject path at `session-operations.ts`, the runner's `writeAndAdvance`, fork)
+  — no raw `appendFileSync` to a live session outside fork.

--- a/docs/design/session-state-architecture.md
+++ b/docs/design/session-state-architecture.md
@@ -4,17 +4,17 @@ Author: architect (jesse-claude). Status: design intent, to build against.
 Revision 2 — corrected after adversarial review (see "What review changed").
 
 This is the mental model and the build plan. It is not a patch list. Read it to
-understand *why* the pieces exist and what must never break.
+understand _why_ the pieces exist and what must never break.
 
 ## The problem
 
 A lace session is an append-only event log. Today every per-turn operation
-rebuilds what it needs by reading and parsing the **entire** log from disk —
-5-8 times per turn (message rebuild, idempotency, last-turn-end, next-seq,
-inject scans), plus a full scan on **every** durable write to compute the next
-event seq (`event-log.ts` `deriveNextEventSeqAcrossSessionFiles`). Measured on a
-real coworker: 11k events, ~368k tokens, ~2.8s per read, 9-18s of dead time
-between turns.
+rebuilds what it needs by reading and parsing the **entire** log from disk — 5-8
+times per turn (message rebuild, idempotency, last-turn-end, next-seq, inject
+scans), plus a full scan on **every** durable write to compute the next event
+seq (`event-log.ts` `deriveNextEventSeqAcrossSessionFiles`). Measured on a real
+coworker: 11k events, ~368k tokens, ~2.8s per read, 9-18s of dead time between
+turns.
 
 Two consequences make this a foundation problem, not a slow-day:
 
@@ -25,7 +25,7 @@ Two consequences make this a foundation problem, not a slow-day:
 2. **The cache is held together by luck.** We rely on the Anthropic prompt cache
    (a real session shows ~364k cached tokens/turn, ~5× cost saved). That works
    only because the serialized request prefix is byte-for-byte identical across
-   turns — and today that identity is an *emergent property* of several
+   turns — and today that identity is an _emergent property_ of several
    unenforced facts. One stray byte in a tool description re-bills 364k tokens
    every turn, silently, with nothing watching.
 
@@ -33,7 +33,7 @@ Two consequences make this a foundation problem, not a slow-day:
 
 Stop reading the log on the hot path. The log is the durable write model; what a
 turn needs are **derived read models** kept current as events are appended. And
-make the byte-identity of the cached prefix a thing we *enforce and watch*,
+make the byte-identity of the cached prefix a thing we _enforce and watch_,
 rather than a thing we hope holds.
 
 Be precise about what byte-identity is and isn't, because a reviewer rightly
@@ -41,72 +41,75 @@ caught me overstating it: the Anthropic SDK serializes the whole request object
 with `JSON.stringify`. We do **not** own the serializer and we are **not** going
 to freeze wire bytes and splice them. Byte-identity is therefore
 `JSON.stringify(stableObject) === JSON.stringify(stableObject)`. Our job is to
-make that object's prefix *provably stable and cheap to produce*, and to put a
-test and a runtime guard on the bytes. The win is killing the O(events) work, not
-inventing a byte-splicer.
+make that object's prefix _provably stable and cheap to produce_, and to put a
+test and a runtime guard on the bytes. The win is killing the O(events) work,
+not inventing a byte-splicer.
 
 The architecture is three layers plus one rule about compaction.
 
 ### Layer 1 — The log (write model)
 
-Append-only, immutable, one writer per session (the per-session lock). The single
-durable source of truth. It exists for durability, audit, and rebuilding the
-layers above. **It is never read in full on the hot path.** That sentence is the
-point; everything else serves it. (One narrow, deliberate exception survives —
-see the cross-process tip-check in Layer 2.)
+Append-only, immutable, one writer per session (the per-session lock). The
+single durable source of truth. It exists for durability, audit, and rebuilding
+the layers above. **It is never read in full on the hot path.** That sentence is
+the point; everything else serves it. (One narrow, deliberate exception survives
+— see the cross-process tip-check in Layer 2.)
 
 ### Layer 2 — Projections (read models)
 
 Every derived view is produced by one reducer, `apply(state, event)`, folded
 forward as events are appended — never rebuilt by rescanning. We have three:
 
-- **Conversation projection** → the `ProviderMessage[]` *prefix* derived from the
-  persisted events. This is the keystone. Two things matter:
+- **Conversation projection** → the `ProviderMessage[]` _prefix_ derived from
+  the persisted events. This is the keystone. Two things matter:
   - **It is the persisted prefix, not the sent array.** Per turn the runner adds
-    live-tail content that is *never persisted* (loop reminders, tool-choice
+    live-tail content that is _never persisted_ (loop reminders, tool-choice
     retry placeholders, pause_turn merges). Those are applied on top, per turn,
     and live only at the tail — never in the cached prefix, never in the
     projection, never in a snapshot. The projection models exactly what the log
     can reproduce.
-  - **There must be exactly one reducer.** Today there are *three* event→message
-    coalescers (`message-builder.ts`, `compaction/toolkit.ts buildPreservedTail`,
-    and the runner's inline `tool_result` construction). Step 1 *unifies* them.
-    Until they're unified, "the batch rebuild and the incremental update are the
-    same function" is not yet true — that's work, not a given.
+  - **There must be exactly one reducer.** Today there are _three_ event→message
+    coalescers (`message-builder.ts`,
+    `compaction/toolkit.ts buildPreservedTail`, and the runner's inline
+    `tool_result` construction). Step 1 _unifies_ them. Until they're unified,
+    "the batch rebuild and the incremental update are the same function" is not
+    yet true — that's work, not a given.
 - **Index projection** → discriminators + the verbatim event line. The
   discriminators (next seq, last `turn_end` seq, idempotency keys, pending
-  immediate injects, turn_end dedup) answer most queries with a column lookup —
-  but idempotency compares the full prompt *content* (`classifyPromptHandoff`
+  immediate injects, turn*end dedup) answer most queries with a column lookup —
+  but idempotency compares the full prompt \_content* (`classifyPromptHandoff`
   does a deep-equal on the prompt body), so the index must also carry the
   verbatim event line, not just columns. **Full history, not windowed** — dedup
-  and idempotency must see turnIds and content from *before* the last compaction,
-  even though the conversation projection is windowed to the current era. Stored
-  cross-process (SQLite/WAL).
+  and idempotency must see turnIds and content from _before_ the last
+  compaction, even though the conversation projection is windowed to the current
+  era. Stored cross-process (SQLite/WAL).
 - **Recall projection** → full-text search. Already exists; stays separate;
   allowed to be lossy/redacted because it is not on the context path.
 
 Each projection is authoritative **in memory** during a live session for the
 process that holds the lock; saved to a durable **snapshot**; and **rebuildable
 from the log**. Every projection is advisory — on divergence it is thrown away
-and rebuilt. But "advisory" only helps if divergence is *detected*; see the two
-detectors below, because a wrong-but-well-formed projection is the dangerous case.
+and rebuilt. But "advisory" only helps if divergence is _detected_; see the two
+detectors below, because a wrong-but-well-formed projection is the dangerous
+case.
 
 **Cross-process coherence.** The in-memory projection is valid only while this
-process both holds the lock *and* the log tip hasn't advanced under it. Subagents
-and peers append to the same log from other processes (injects are a live path).
-So the read path keeps **one cheap check**: read the session's current max event
-seq, and if it's beyond what the projection has applied, rebuild.
+process both holds the lock _and_ the log tip hasn't advanced under it.
+Subagents and peers append to the same log from other processes (injects are a
+live path). So the read path keeps **one cheap check**: read the session's
+current max event seq, and if it's beyond what the projection has applied,
+rebuild.
 
 Getting that check actually cheap is an unsolved detail today, not a settled
-property — and the spec should say so. Events are sharded across
-`persona/date/` files with filesystem-dependent ordering, so "read the tail of
-the newest shard" is wrong (a cross-midnight or other-persona append lands the
-max seq elsewhere), and no seek-from-end reader exists yet, so today's derive is
-O(events). The fix is a design decision to make explicitly, not hand-wave: a
-per-session **monotonic head** (a tiny pointer holding the max seq, updated and
-fsync'd with every append, read O(1)), or the lock-consistent index's `MAX(seq)`,
-or de-sharding to one append log per session. Whatever we pick must be
-cross-process authoritative for *assigning* the next seq (the current
+property — and the spec should say so. Events are sharded across `persona/date/`
+files with filesystem-dependent ordering, so "read the tail of the newest shard"
+is wrong (a cross-midnight or other-persona append lands the max seq elsewhere),
+and no seek-from-end reader exists yet, so today's derive is O(events). The fix
+is a design decision to make explicitly, not hand-wave: a per-session
+**monotonic head** (a tiny pointer holding the max seq, updated and fsync'd with
+every append, read O(1)), or the lock-consistent index's `MAX(seq)`, or
+de-sharding to one append log per session. Whatever we pick must be
+cross-process authoritative for _assigning_ the next seq (the current
 disk-derive is correct precisely because it sees every process's appends; a
 per-process in-memory counter or a best-effort index is not — it can hand out a
 duplicate/low seq and corrupt the log). Resolve this before building Step 3/6;
@@ -119,29 +122,30 @@ The conversation projection is **provider-neutral**: it produces lace's internal
 `ProviderMessage[]` prefix, which feeds every provider's converter
 (`convertToAnthropicFormat`, `convertToOpenAIFormat`, `convertToGeminiFormat`,
 text-only). A turn's request object is `[converted prefix] + [live tail]`. The
-*neutral* prefix is stable across turns because the events that produce it are
+_neutral_ prefix is stable across turns because the events that produce it are
 immutable and the reducer is deterministic — and that stability is what every
 provider's caching wants, even though the mechanism differs:
 
 - **Anthropic / Bedrock**: explicit `cache_control` markers
-  (`attachMessageCacheBreakpoints` places a rolling-tail + anchor each turn). The
-  markers move; that's fine — the cache matches on content, not markers. Drift in
-  the prefix is the worst case: an explicit ~5× re-bill of the cached tokens.
+  (`attachMessageCacheBreakpoints` places a rolling-tail + anchor each turn).
+  The markers move; that's fine — the cache matches on content, not markers.
+  Drift in the prefix is the worst case: an explicit ~5× re-bill of the cached
+  tokens.
 - **OpenAI**: automatic server-side prefix caching; lace places no markers. A
-  stable prefix earns the automatic discount; drift just *loses* the discount —
+  stable prefix earns the automatic discount; drift just _loses_ the discount —
   gentler than Anthropic, same principle.
 - **Gemini / local (ollama, lmstudio)**: lace manages no explicit cache today; a
-  stable prefix still helps wherever the backend reuses prefix/KV state. We do not
-  assume a mechanism lace doesn't have.
+  stable prefix still helps wherever the backend reuses prefix/KV state. We do
+  not assume a mechanism lace doesn't have.
 
 So the architecture's job is the **stable neutral prefix + a deterministic
-per-provider conversion**; the cache *mechanism* lives in each provider adapter.
+per-provider conversion**; the cache _mechanism_ lives in each provider adapter.
 A session that switches providers (`modelId`/`connectionId` change) keeps its
 **projection** but loses its **cache**: each provider serializes a different
 prefix shape (Anthropic uses a `system` field, OpenAI prepends a `system` chat
 message, Gemini uses `systemInstruction`; tool schemas differ too) into a
 different cache namespace, so a switch cold-starts caching. The projection
-surviving is what makes the switch cheap to *assemble*; it does not preserve the
+surviving is what makes the switch cheap to _assemble_; it does not preserve the
 cache.
 
 What we add is not a byte-splicer; it is:
@@ -149,61 +153,61 @@ What we add is not a byte-splicer; it is:
 - **A determinism invariant (below)** on the inputs (and on each converter), so
   the prefix really is stable.
 - **Two golden-bytes gates, per provider** — because "byte-identical" means two
-  different things and the literal body legitimately changes turn-to-turn for the
-  marker providers:
-  - *refactor-equivalence*: the old full-scan path and the new projection path
+  different things and the literal body legitimately changes turn-to-turn for
+  the marker providers:
+  - _refactor-equivalence_: the old full-scan path and the new projection path
     produce the **same** serialized body for the same inputs — full
     `Buffer.equals`, markers and all. This is the gate that proves the refactor
     is safe.
-  - *cross-turn cache-stability*: turn N and turn N+1 with an unchanged prefix
+  - _cross-turn cache-stability_: turn N and turn N+1 with an unchanged prefix
     produce the same prefix bytes **after stripping `cache_control` markers**.
-    For Anthropic/Bedrock the roving anchor marker moves *inside* the prefix every
-    turn (so a raw `Buffer.equals` over the literal body would fail every turn,
-    falsely); the existing `cache-control-byte-stable` test already strips markers
-    for exactly this reason. OpenAI has no markers, so its prefix compares whole.
-    Drift here — after stripping — is the real cache regression.
-- **A runtime cache-health signal** (provider-reported cache read/write per turn,
-  for providers that report it) so drift in prod is visible immediately.
+    For Anthropic/Bedrock the roving anchor marker moves _inside_ the prefix
+    every turn (so a raw `Buffer.equals` over the literal body would fail every
+    turn, falsely); the existing `cache-control-byte-stable` test already strips
+    markers for exactly this reason. OpenAI has no markers, so its prefix
+    compares whole. Drift here — after stripping — is the real cache regression.
+- **A runtime cache-health signal** (provider-reported cache read/write per
+  turn, for providers that report it) so drift in prod is visible immediately.
 
-So byte-identity is *enforced and watched, per provider* — not *constructed by
-freezing bytes*. This is the honest correction to revision 1.
+So byte-identity is _enforced and watched, per provider_ — not _constructed by
+freezing bytes_. This is the honest correction to revision 1.
 
 ### The rule — compaction seals the message era
 
 Compaction is a state transition, not just a summarizer. It seals the message
-history so far into the conversation projection's immutable prefix and resets the
-live tail to near-empty. After compaction the conversation projection is built
-from `[sealed era] + [small tail]`, so the per-turn *rebuild* work is
+history so far into the conversation projection's immutable prefix and resets
+the live tail to near-empty. After compaction the conversation projection is
+built from `[sealed era] + [small tail]`, so the per-turn _rebuild_ work is
 O(tail-since-compaction), not O(events-ever). Be precise about the win:
 
 - Per-turn cost is **O(tail-since-compaction)**, reset at each compaction — not
   "flat." The tail grows between compactions; compaction is what bounds it. The
   asymptotic improvement over today's O(events-ever) is the real, large win.
 - Compaction must run `dropOrphanedToolBlocks` (the orphan-pair guard that has
-  bricked Ada before) and freeze the *post-pass* result; the reducer/pass must be
-  deterministic and order-independent so the sealed era's bytes are stable.
-- A post-compaction persona re-render appends a fresh `system_prompt_set` only if
-  the rendered prompt actually changed (the skip-if-unchanged guard). The system
-  segment is therefore stable across compactions *as long as rendering is
-  deterministic* — which is why the determinism invariant below is load-bearing.
+  bricked Ada before) and freeze the _post-pass_ result; the reducer/pass must
+  be deterministic and order-independent so the sealed era's bytes are stable.
+- A post-compaction persona re-render appends a fresh `system_prompt_set` only
+  if the rendered prompt actually changed (the skip-if-unchanged guard). The
+  system segment is therefore stable across compactions _as long as rendering is
+  deterministic_ — which is why the determinism invariant below is load-bearing.
 
 ## Invariants (these must always hold)
 
 1. The log is the only durable truth. Projections, snapshots, and indexes are
    derived and rebuildable.
-2. Nothing reads the full log on the hot path. The only per-turn log touch is the
-   cheap max-seq tip-check for cross-process coherence (see Layer 2 — making it
-   actually cheap is an open design item). Full scans (the O(events) re-derive)
-   are for cold rebuild, the sampled canary (Invariant 6), and the test oracle —
-   never per turn.
+2. Nothing reads the full log on the hot path. The only per-turn log touch is
+   the cheap max-seq tip-check for cross-process coherence (see Layer 2 — making
+   it actually cheap is an open design item). Full scans (the O(events)
+   re-derive) are for cold rebuild, the sampled canary (Invariant 6), and the
+   test oracle — never per turn.
 3. One reducer for events → the message prefix. The batch rebuild and the
    incremental update are the same function. The conversation projection models
    the persisted prefix only; the runner's non-persisted live-tail mutations are
    outside it.
 4. Byte-identity of the cached prefix is enforced **per provider** by a golden-
    bytes test and watched by a prod cache-health signal — not asserted "by
-   construction." The reducer guarantees the neutral message *array*; each
-   provider's golden test guarantees *that provider's* serialized bytes. The win
+   construction." The reducer guarantees the neutral message _array_; each
+   provider's golden test guarantees _that provider's_ serialized bytes. The win
    (a stable, cheaply-produced prefix) is provider-neutral; the stakes of drift
    differ (Anthropic/Bedrock ~5× re-bill; OpenAI loses an automatic discount;
    local loses KV reuse).
@@ -211,27 +215,29 @@ O(tail-since-compaction), not O(events-ever). Be precise about the win:
    message converter** — are **byte-deterministic** (no timestamps, no
    nondeterministic ordering, stable cwd handling). This is load-bearing — every
    provider's cache rests on it — and it must be tested directly, per converter.
-   One known landmine: the Gemini converter decodes a tool name from an id minted
-   with `Date.now()/Math.random()`; it is deterministic *only* because that id is
-   persisted verbatim in the event and never regenerated. Any path that re-mints
-   it breaks the prefix. The per-converter determinism test must cover this.
+   One known landmine: the Gemini converter decodes a tool name from an id
+   minted with `Date.now()/Math.random()`; it is deterministic _only_ because
+   that id is persisted verbatim in the event and never regenerated. Any path
+   that re-mints it breaks the prefix. The per-converter determinism test must
+   cover this.
 6. Any derived store can be bypassed. There are **two distinct detectors**, and
-   conflating them is a mistake: (a) *cross-process staleness* — the cheap max-seq
-   tip-check; if the tip advanced past what the projection applied, rebuild. This
-   is the frequent case (every cross-process inject) and must stay cheap. (b)
-   *reducer divergence* — the rare bug where the incremental fold disagrees with
-   the batch fold; caught by a **sampled canary** that does a full re-derive and
-   compares, infrequently (a timer or 1-in-N turns), accepting its O(events) cost
-   precisely because it is rare. Do **not** trigger the full re-derive on every
-   tip-change — that reintroduces the O(events) cost on the hot path. A wrong-but-
-   well-formed projection must not reach the wire silently; the canary plus the
-   prod cache-health signal are what catch it where fixtures can't.
+   conflating them is a mistake: (a) _cross-process staleness_ — the cheap
+   max-seq tip-check; if the tip advanced past what the projection applied,
+   rebuild. This is the frequent case (every cross-process inject) and must stay
+   cheap. (b) _reducer divergence_ — the rare bug where the incremental fold
+   disagrees with the batch fold; caught by a **sampled canary** that does a
+   full re-derive and compares, infrequently (a timer or 1-in-N turns),
+   accepting its O(events) cost precisely because it is rare. Do **not** trigger
+   the full re-derive on every tip-change — that reintroduces the O(events) cost
+   on the hot path. A wrong-but- well-formed projection must not reach the wire
+   silently; the canary plus the prod cache-health signal are what catch it
+   where fixtures can't.
 7. Seq derivation is disk-authoritative (tail-read), never a best-effort index.
 8. Snapshots are written under the per-session lock, consistent with the log
-   append. Crash recovery may *append* synthesized `turn_end` events
+   append. Crash recovery may _append_ synthesized `turn_end` events
    (`repairOrphanTurnStarts`), so "snapshot == log" is defined against the
    post-recovery log — and recovery must run to completion within the cold-open
-   lock *before* any snapshot is trusted or compared. This matters for the
+   lock _before_ any snapshot is trusted or compared. This matters for the
    **index** projection (turn_end dedup/watermark change when a turn_end is
    appended); the conversation projection happens to be unaffected only because
    it has no `turn_end` case — don't rely on that coincidence for the index.
@@ -245,91 +251,97 @@ Build the safety net before touching a byte. Each step is independently correct,
 shippable, and measured before the next. Do not skip and do not reorder.
 
 **Step 0 — Guardrail and instrumentation.** Before any change:
+
 - The **golden-bytes test**: capture the literal HTTP request body (after
   `sanitizeLoneSurrogates` and the SDK serializer) for a corpus of real fixtures
   — thinking blocks, tool calls with multi-key/numeric arguments, images, a
   compaction era with `preserved`, a post-compaction persona re-render, unicode,
   an orphaned tool block. Compare with `Buffer.equals`.
 - A **render-determinism test**: render the system prompt + tools twice (varying
-  wall-clock, cwd echo, skill enumeration) and assert byte-equality (Invariant 5).
+  wall-clock, cwd echo, skill enumeration) and assert byte-equality (Invariant
+  5).
 - **Prod cache-health signal**: log actual cache read/write tokens per turn on
-  Ada, so a prefix regression is visible immediately instead of three weeks later.
-  (Correction to rev2: `countTokensExplicit` is **not** dead — it is live on the
-  OpenAI no-usage fallback path (`openai-provider.ts` calls `_countTokensImpl`
-  directly), where it independently re-serializes the wire shape. So it *is* in
-  the determinism net for OpenAI-compatible providers and the per-converter
-  golden test must cover it; it is unused for Anthropic. The earlier "dead code"
-  claim was an Anthropic-only fact wrongly generalized — twice now; don't.)
-This step is the gate every later step passes through.
+  Ada, so a prefix regression is visible immediately instead of three weeks
+  later. (Correction to rev2: `countTokensExplicit` is **not** dead — it is live
+  on the OpenAI no-usage fallback path (`openai-provider.ts` calls
+  `_countTokensImpl` directly), where it independently re-serializes the wire
+  shape. So it _is_ in the determinism net for OpenAI-compatible providers and
+  the per-converter golden test must cover it; it is unused for Anthropic. The
+  earlier "dead code" claim was an Anthropic-only fact wrongly generalized —
+  twice now; don't.) This step is the gate every later step passes through.
 
 **Step 1 — One reducer.** Unify the three event→message coalescers
 (`message-builder.ts`, `compaction/toolkit.ts buildPreservedTail`, and the
-runner's inline `tool_result` construction) into a single pure `foldEvent`. Prove
-`fold-incremental == fold-batch` with a differential test and a fuzz harness.
+runner's inline `tool_result` construction) into a single pure `foldEvent`.
+Prove `fold-incremental == fold-batch` with a differential test and a fuzz
+harness.
 
 This is **not** a zero-behavior-change refactor, and the spec was wrong to call
-it one: today the runner emits *one user message per tool result* on a
-parallel-tool turn, while the batch rebuild *coalesces* them into one user
+it one: today the runner emits _one user message per tool result_ on a
+parallel-tool turn, while the batch rebuild _coalesces_ them into one user
 message with N `tool_result` blocks — a genuinely different wire shape. Unifying
 picks one canonical shape, which changes the live-tail bytes for those turns
 (it's in the tail, not the cached prefix, so it doesn't bust the prefix cache —
-but it *is* a wire change, gated by the refactor-equivalence golden test as a
+but it _is_ a wire change, gated by the refactor-equivalence golden test as a
 deliberate change). Worth flagging the deeper smell this exposes: because sent
 shape (N) and rebuilt shape (1) already differ today, the prefix a later turn
-rebuilds may not match what was actually sent on the parallel-tool turn —
-i.e. there may already be a latent cache break at those boundaries. Investigate
-that while unifying.
+rebuilds may not match what was actually sent on the parallel-tool turn — i.e.
+there may already be a latent cache break at those boundaries. Investigate that
+while unifying.
 
-**Step 2 — Buy time (surgical).** Not the architecture — the thing that makes Ada
-usable in days. Replace the per-write full-scan seq derive with a tail-read (the
-max seq is the last line of the newest shard). Parse the log once instead of
-twice. Coalesce the runner-entry reads into one. Stop `loadSession` re-deriving
-and rewriting state on every mid-turn refresh. Honest caveat a reviewer caught:
-the runner-entry reads are append-free *with respect to this process*, but another
-process can append a `context_injected` during the turn — so keep the mid-loop
-inject re-read (or fold it into the tip-check). Zero byte risk. Measure.
+**Step 2 — Buy time (surgical).** Not the architecture — the thing that makes
+Ada usable in days. Replace the per-write full-scan seq derive with a tail-read
+(the max seq is the last line of the newest shard). Parse the log once instead
+of twice. Coalesce the runner-entry reads into one. Stop `loadSession`
+re-deriving and rewriting state on every mid-turn refresh. Honest caveat a
+reviewer caught: the runner-entry reads are append-free _with respect to this
+process_, but another process can append a `context_injected` during the turn —
+so keep the mid-loop inject re-read (or fold it into the tip-check). Zero byte
+risk. Measure.
 
-**Step 3 — Index projection (full-history, durable, cross-process).** One row per
-event with discriminator columns **and the verbatim JSONL line**, written under
-the same per-session lock as the JSONL append (not best-effort, since dedup and
-the tip-check depend on it). Watermark, idempotency, dedup, and inject queries
-become indexed lookups over full history. Replaying the stored line feeds the
-*same reducer* the same input as a JSONL read — so the message output is
-identical because the reducer is identical, not because storage is "byte-safe" on
-its own. Rebuildable from the log; the seq authority stays the disk tail-read.
+**Step 3 — Index projection (full-history, durable, cross-process).** One row
+per event with discriminator columns **and the verbatim JSONL line**, written
+under the same per-session lock as the JSONL append (not best-effort, since
+dedup and the tip-check depend on it). Watermark, idempotency, dedup, and inject
+queries become indexed lookups over full history. Replaying the stored line
+feeds the _same reducer_ the same input as a JSONL read — so the message output
+is identical because the reducer is identical, not because storage is
+"byte-safe" on its own. Rebuildable from the log; the seq authority stays the
+disk tail-read.
 
 **Step 4 — Conversation projection + snapshots.** Hold the persisted-prefix
 `ProviderMessage[]` in memory, maintained by `foldEvent`, checkpointed to a
-durable snapshot under the lock at each compaction and periodically, rebuilt from
-snapshot + tail on cold start. The live hot path becomes O(tail). Guard with the
-golden test, a snapshot round-trip test (rebuild-from-snapshot == rebuild-from-
-post-recovery-log, byte-for-byte), and a **prod divergence guard**: cheaply (on a
-tip-change, or sampled) re-derive and compare to the in-memory projection; on
-mismatch, alarm and rebuild. The invariant check is not dev/CI-only — a real
-session's state never appears in fixtures, so the guard must run where the
-divergence actually happens.
+durable snapshot under the lock at each compaction and periodically, rebuilt
+from snapshot + tail on cold start. The live hot path becomes O(tail). Guard
+with the golden test, a snapshot round-trip test (rebuild-from-snapshot ==
+rebuild-from- post-recovery-log, byte-for-byte), and a **prod divergence
+guard**: cheaply (on a tip-change, or sampled) re-derive and compare to the
+in-memory projection; on mismatch, alarm and rebuild. The invariant check is not
+dev/CI-only — a real session's state never appears in fixtures, so the guard
+must run where the divergence actually happens.
 
-**Step 5 — Delete the old hot path.** Full-scan rebuild survives only as the test
-oracle and the recovery primitive. No per-turn path scans the log (the O(1)
+**Step 5 — Delete the old hot path.** Full-scan rebuild survives only as the
+test oracle and the recovery primitive. No per-turn path scans the log (the O(1)
 tip-check stays).
 
 (Revision 1 had a sixth step — "seal pre-serialized prefix bytes." It's removed:
-the SDK owns serialization and the cache markers move every turn, so freezing and
-splicing wire bytes isn't buildable without reimplementing the SDK body
+the SDK owns serialization and the cache markers move every turn, so freezing
+and splicing wire bytes isn't buildable without reimplementing the SDK body
 serializer. Byte stability comes from stable inputs + the gate, per Layer 3.)
 
 ## How we know it's right (the test contract)
 
-- **Golden-bytes, per provider, two gates** (Step 0): for each converter,
-  (a) refactor-equivalence — old path vs new path, same inputs, full
-  `Buffer.equals`; and (b) cross-turn cache-stability — turn N vs N+1,
-  markers stripped (Anthropic/Bedrock) or whole (OpenAI). The non-negotiable gate.
+- **Golden-bytes, per provider, two gates** (Step 0): for each converter, (a)
+  refactor-equivalence — old path vs new path, same inputs, full
+  `Buffer.equals`; and (b) cross-turn cache-stability — turn N vs N+1, markers
+  stripped (Anthropic/Bedrock) or whole (OpenAI). The non-negotiable gate.
 - **Render-determinism** (Step 0): system + tools + each provider's converter
-  render to identical bytes regardless of wall-clock/cwd/enumeration (Invariant 5).
+  render to identical bytes regardless of wall-clock/cwd/enumeration (Invariant
+  5).
 - **Reducer equivalence** (Step 1): incremental fold equals batch fold, fuzzed.
 - **Snapshot round-trip** (Step 4): rebuild-from-snapshot equals rebuild-from-
   post-recovery-log, byte-for-byte.
-- **Sampled canary** (Step 4): a *rare* full re-derive vs. the in-memory
+- **Sampled canary** (Step 4): a _rare_ full re-derive vs. the in-memory
   projection, in production, alarm on mismatch — catches a reducer bug a fixture
   can't. Rare on purpose (it's O(events)); it is **not** the cross-process
   staleness check (that's the cheap tip-check, run every turn).
@@ -340,10 +352,12 @@ serializer. Byte stability comes from stable inputs + the gate, per Layer 3.)
 
 - The on-disk log format does not change. Old sessions cold-build their
   projections on first load; nothing to migrate, no backward-compat shims.
-- The recall FTS index is not touched. It serves search; it stays lossy/separate.
+- The recall FTS index is not touched. It serves search; it stays
+  lossy/separate.
 - We do **not** take over body serialization from any provider SDK (Anthropic,
-  OpenAI, Gemini, …). We control the request *object* and make its prefix stable;
-  each SDK still serializes and owns transport, auth, retries, and streaming.
+  OpenAI, Gemini, …). We control the request _object_ and make its prefix
+  stable; each SDK still serializes and owns transport, auth, retries, and
+  streaming.
 - The log, projections, compaction, and the O(N²) fix are **provider-neutral** —
   they operate on neutral events and the neutral `ProviderMessage[]`. Only the
   converters and per-provider cache mechanisms are provider-specific, and they
@@ -351,47 +365,49 @@ serializer. Byte stability comes from stable inputs + the gate, per Layer 3.)
 
 ## What review changed
 
-**Revision 2 → 3** (second adversarial round, on the rev2 changes): the recurring
-fault was over-claiming, and the reviewers caught it every time. Fixed: the
-"O(1) tip-check / tail of the newest shard" was wrong (events are sharded across
-persona/date with filesystem-dependent order; no seek-from-end reader exists) —
-now framed as an explicit open design item (a per-session monotonic head, or the
-lock-consistent index max, or de-sharding). The `Buffer.equals` golden gate over
-"the literal body" is unimplementable for the marker providers (the anchor marker
-moves inside the prefix every turn) — split into *refactor-equivalence* (full
-bytes) and *cross-turn stability* (markers stripped). `countTokensExplicit` is
-**live** on the OpenAI no-usage path — the rev2 "dead code" claim was wrong
-(an Anthropic-only fact generalized; the second time that bit, now logged). Step 1
-is **not** a zero-wire-change refactor — unifying the three coalescers changes the
-parallel-tool-turn shape (N user messages vs 1) and may expose a pre-existing
-sent-vs-rebuilt cache break. The divergence guard split into a cheap per-turn
-staleness tip-check vs a rare sampled reducer-bug canary (re-deriving on every
-tip-change reintroduced O(events)). Plus: provider switch keeps the projection
-but loses the cache; the index carries the verbatim line (idempotency deep-equals
-content); recovery must finish before any snapshot compare (matters for the index);
-and the Gemini converter's `Date.now()/Math.random()` tool-id is a named
-determinism landmine.
+**Revision 2 → 3** (second adversarial round, on the rev2 changes): the
+recurring fault was over-claiming, and the reviewers caught it every time.
+Fixed: the "O(1) tip-check / tail of the newest shard" was wrong (events are
+sharded across persona/date with filesystem-dependent order; no seek-from-end
+reader exists) — now framed as an explicit open design item (a per-session
+monotonic head, or the lock-consistent index max, or de-sharding). The
+`Buffer.equals` golden gate over "the literal body" is unimplementable for the
+marker providers (the anchor marker moves inside the prefix every turn) — split
+into _refactor-equivalence_ (full bytes) and _cross-turn stability_ (markers
+stripped). `countTokensExplicit` is **live** on the OpenAI no-usage path — the
+rev2 "dead code" claim was wrong (an Anthropic-only fact generalized; the second
+time that bit, now logged). Step 1 is **not** a zero-wire-change refactor —
+unifying the three coalescers changes the parallel-tool-turn shape (N user
+messages vs 1) and may expose a pre-existing sent-vs-rebuilt cache break. The
+divergence guard split into a cheap per-turn staleness tip-check vs a rare
+sampled reducer-bug canary (re-deriving on every tip-change reintroduced
+O(events)). Plus: provider switch keeps the projection but loses the cache; the
+index carries the verbatim line (idempotency deep-equals content); recovery must
+finish before any snapshot compare (matters for the index); and the Gemini
+converter's `Date.now()/Math.random()` tool-id is a named determinism landmine.
 
 **Revision 1 → 2** (first adversarial round)
 
 Two competing adversarial reviews found, and the code confirmed: (1) the old
-Step 5 "seal pre-serialized prefix bytes + concatenate" is unbuildable against an
-SDK-owned `JSON.stringify` with cache markers that move every turn — removed;
+Step 5 "seal pre-serialized prefix bytes + concatenate" is unbuildable against
+an SDK-owned `JSON.stringify` with cache markers that move every turn — removed;
 byte-identity is now "stable inputs + golden gate + prod signal." (2) The
-conversation projection is the *persisted prefix*, not the sent array — the
-runner's non-persisted live-tail mutations are explicitly outside it. (3) Added a
-*production* divergence guard and an O(1) cross-process tip-check, because the
+conversation projection is the _persisted prefix_, not the sent array — the
+runner's non-persisted live-tail mutations are explicitly outside it. (3) Added
+a _production_ divergence guard and an O(1) cross-process tip-check, because the
 old dev/CI-only invariant check couldn't catch a wrong-but-well-formed prefix or
-a stale-after-cross-process-append projection. (4) Precision fixes: O(tail-since-
-compaction) not "flat"; system/tools are separate stable segments; seq stays
-disk-authoritative; the index is full-history for discriminators; render
-determinism is now an explicit, tested invariant; Step 1 *unifies* three
-coalescers; and `countTokensExplicit` is dead code, dropped from the threat model.
+a stale-after-cross-process-append projection. (4) Precision fixes:
+O(tail-since- compaction) not "flat"; system/tools are separate stable segments;
+seq stays disk-authoritative; the index is full-history for discriminators;
+render determinism is now an explicit, tested invariant; Step 1 _unifies_ three
+coalescers; and `countTokensExplicit` is dead code, dropped from the threat
+model.
 
 ## The one-line summary
 
 The log is the truth and is read on the hot path only as a cheap max-seq
-tip-check; everything a turn needs is a projection kept current as events append; compaction
-seals the message era so per-turn rebuild cost is O(tail-since-compaction) and
-resets; and byte-identity of the cached prefix is held by deterministic inputs, a
-golden test, and a production cache-health guard — not by freezing bytes.
+tip-check; everything a turn needs is a projection kept current as events
+append; compaction seals the message era so per-turn rebuild cost is
+O(tail-since-compaction) and resets; and byte-identity of the cached prefix is
+held by deterministic inputs, a golden test, and a production cache-health guard
+— not by freezing bytes.

--- a/docs/design/threads.md
+++ b/docs/design/threads.md
@@ -99,13 +99,14 @@ events (id, thread_id, type, data, created_at)
 
 #### Compaction System (`src/threads/compaction/`)
 
-> **OUTDATED (2026-06).** Predates the event-sourced rewrite and the plugin system.
-> Compaction is no longer a `src/threads/` `ThreadManager` registry; it is a
-> `LACE_PLUGINS` registry: `api.compaction.register(name, strategy)`, where a
-> strategy is `compact(events, ctx): Promise<CompactResult>`, selected per-persona
-> by name (default `track-based`). `registerCompactionStrategy` /
-> `TrimToolResultsStrategy` below no longer exist. See `docs/reference/plugins.md`
-> and `docs/superpowers/specs/2026-06-03-pluggable-compaction-design.md`.
+> **OUTDATED (2026-06).** Predates the event-sourced rewrite and the plugin
+> system. Compaction is no longer a `src/threads/` `ThreadManager` registry; it
+> is a `LACE_PLUGINS` registry: `api.compaction.register(name, strategy)`, where
+> a strategy is `compact(events, ctx): Promise<CompactResult>`, selected
+> per-persona by name (default `track-based`). `registerCompactionStrategy` /
+> `TrimToolResultsStrategy` below no longer exist. See
+> `docs/reference/plugins.md` and
+> `docs/superpowers/specs/2026-06-03-pluggable-compaction-design.md`.
 
 Event-based strategy for managing context window limits:
 
@@ -175,8 +176,8 @@ parent_thread_id
 
 ## Compaction Strategy
 
-> **OUTDATED** — see the note under "Compaction System" above. Compaction is now a
-> plugin registry (`api.compaction`); the strategy types below are historical.
+> **OUTDATED** — see the note under "Compaction System" above. Compaction is now
+> a plugin registry (`api.compaction`); the strategy types below are historical.
 
 ### Event-Based Compaction
 

--- a/docs/external-tools.md
+++ b/docs/external-tools.md
@@ -43,12 +43,12 @@ and exit 0:
 
 - `name` (required) — the entry name for this tool. The final registered name
   depends on how the binary is loaded:
-  - **Plugin global exec dir** (`api.tools.registerExecDir`): the kernel prepends
-    `<namespace>:` automatically, so `"name": "widget"` in a plugin with
-    `namespace: 'acme'` becomes `acme:widget`.
-  - **Per-persona exec dir** (`<persona>/tools/`): the descriptor name is used as-is
-    (no namespace prefix). The name must be globally unique among tools visible to
-    that persona but can shadow a same-named plugin/core global.
+  - **Plugin global exec dir** (`api.tools.registerExecDir`): the kernel
+    prepends `<namespace>:` automatically, so `"name": "widget"` in a plugin
+    with `namespace: 'acme'` becomes `acme:widget`.
+  - **Per-persona exec dir** (`<persona>/tools/`): the descriptor name is used
+    as-is (no namespace prefix). The name must be globally unique among tools
+    visible to that persona but can shadow a same-named plugin/core global.
   - **Core exec tools**: the descriptor name is used as-is (no prefix).
 - `description` (required) — shown to the model.
 - `inputSchema` (required) — a JSON Schema **object** (`type: "object"`);
@@ -118,12 +118,13 @@ When lace invokes your tool (`run-once.ts` / `exec-tool-adapter.ts`):
 
 ### Discovery and registration
 
-`discoverExecToolsSync(dir, namePrefix?)` (from `@lace/agent/tools/exec/discover`)
-synchronously scans a single directory, runs each **executable** file (mode
-`+x`) with `lace-tool-schema` (5 s budget per binary, 30 s total budget, max 64
-binaries), and returns an `ExecToolAdapter[]`. Files that aren't executable, exit
-non-zero, or print an invalid descriptor are **skipped with a warning, never
-fatal** — one bad binary can't break discovery of the rest.
+`discoverExecToolsSync(dir, namePrefix?)` (from
+`@lace/agent/tools/exec/discover`) synchronously scans a single directory, runs
+each **executable** file (mode `+x`) with `lace-tool-schema` (5 s budget per
+binary, 30 s total budget, max 64 binaries), and returns an `ExecToolAdapter[]`.
+Files that aren't executable, exit non-zero, or print an invalid descriptor are
+**skipped with a warning, never fatal** — one bad binary can't break discovery
+of the rest.
 
 Discovery runs **synchronously at boot** through three wiring points:
 

--- a/docs/plans/2026-06-17-tool-result-capping.md
+++ b/docs/plans/2026-06-17-tool-result-capping.md
@@ -1,31 +1,48 @@
 # Tool-Result Capping Implementation Plan
 
-> **For agentic workers:** Use superpowers:subagent-driven-development or executing-plans. Steps use checkbox (`- [ ]`) syntax.
+> **For agentic workers:** Use superpowers:subagent-driven-development or
+> executing-plans. Steps use checkbox (`- [ ]`) syntax.
 
-**Goal:** Cap how much a single tool result contributes to the live context AND the durable transcript, so an oversized MCP/exec/tool result can no longer balloon the session toward the context window.
+**Goal:** Cap how much a single tool result contributes to the live context AND
+the durable transcript, so an oversized MCP/exec/tool result can no longer
+balloon the session toward the context window.
 
-**Architecture:** A single chokepoint in the conversation runner, where every tool result already converges (`executeToolCall` → `coreResult`). Results at or below a ride-whole budget pass through untouched. Larger results are spilled in full to a per-session sidecar file and replaced — in both the live provider message and the durable `tool_use` event — with a small head+tail digest plus an exact-byte elision marker. A new `read_tool_result` tool pages the spilled remainder by head/tail/grep. Numbers mirror serf (`agent/job_shell.go`, `agent/job_output_digest.go`): ride-whole 8 KB, ~2 KB digest.
+**Architecture:** A single chokepoint in the conversation runner, where every
+tool result already converges (`executeToolCall` → `coreResult`). Results at or
+below a ride-whole budget pass through untouched. Larger results are spilled in
+full to a per-session sidecar file and replaced — in both the live provider
+message and the durable `tool_use` event — with a small head+tail digest plus an
+exact-byte elision marker. A new `read_tool_result` tool pages the spilled
+remainder by head/tail/grep. Numbers mirror serf (`agent/job_shell.go`,
+`agent/job_output_digest.go`): ride-whole 8 KB, ~2 KB digest.
 
 **Tech Stack:** TypeScript, vitest, zod. All work in `packages/agent`.
 
-**Conventions:** Files start with `// ABOUTME:`. Strict TS, no `any`. Real fs in tests (tempdir). TDD: failing test first. Run `npx vitest run <file>` from `packages/agent`.
+**Conventions:** Files start with `// ABOUTME:`. Strict TS, no `any`. Real fs in
+tests (tempdir). TDD: failing test first. Run `npx vitest run <file>` from
+`packages/agent`.
 
 ---
 
 ## Constants (shared)
 
-- `TOOL_RESULT_RIDE_WHOLE_BYTES = 8 * 1024` — a result whose text content is ≤ this rides back whole; no spill, no digest.
-- `TOOL_RESULT_DIGEST_HALF_BYTES = 1024` — when over the ride-whole budget, keep this many bytes from the head and from the tail (≈ 2 KB digest), each trimmed to a line boundary.
+- `TOOL_RESULT_RIDE_WHOLE_BYTES = 8 * 1024` — a result whose text content is ≤
+  this rides back whole; no spill, no digest.
+- `TOOL_RESULT_DIGEST_HALF_BYTES = 1024` — when over the ride-whole budget, keep
+  this many bytes from the head and from the tail (≈ 2 KB digest), each trimmed
+  to a line boundary.
 
 ---
 
 ### Task 1: Tool-result digest (pure function)
 
 **Files:**
+
 - Create: `packages/agent/src/tools/result-digest.ts`
 - Test: `packages/agent/src/tools/__tests__/result-digest.test.ts`
 
-The function digests a single string. Line-align the head/tail cuts (don't split mid-line). The marker must state the exact elided byte count and how to recover.
+The function digests a single string. Line-align the head/tail cuts (don't split
+mid-line). The marker must state the exact elided byte count and how to recover.
 
 ```ts
 // ABOUTME: Pure head+tail digest for oversized tool-result text. Keeps the result
@@ -35,9 +52,9 @@ export const TOOL_RESULT_RIDE_WHOLE_BYTES = 8 * 1024;
 export const TOOL_RESULT_DIGEST_HALF_BYTES = 1024;
 
 export interface ToolResultDigest {
-  text: string;        // either the whole input (ride-whole) or head+marker+tail
+  text: string; // either the whole input (ride-whole) or head+marker+tail
   elidedBytes: number; // 0 when ridden whole
-  totalBytes: number;  // byte length of the full input
+  totalBytes: number; // byte length of the full input
 }
 
 export function digestToolResultText(
@@ -48,7 +65,8 @@ export function digestToolResultText(
   const rideWhole = opts?.rideWholeBytes ?? TOOL_RESULT_RIDE_WHOLE_BYTES;
   const half = opts?.digestHalfBytes ?? TOOL_RESULT_DIGEST_HALF_BYTES;
   const totalBytes = Buffer.byteLength(full, 'utf8');
-  if (totalBytes <= rideWhole) return { text: full, elidedBytes: 0, totalBytes };
+  if (totalBytes <= rideWhole)
+    return { text: full, elidedBytes: 0, totalBytes };
 
   const buf = Buffer.from(full, 'utf8');
   // Head: first `half` bytes, trimmed back to the last newline so we don't cut a line.
@@ -58,11 +76,15 @@ export function digestToolResultText(
   // Tail: last `half` bytes, trimmed forward to the first newline.
   let tailStart = Math.max(buf.length - half, headEnd);
   const firstNlInTail = buf.indexOf(0x0a, tailStart);
-  if (firstNlInTail >= 0 && firstNlInTail + 1 < buf.length) tailStart = firstNlInTail + 1;
+  if (firstNlInTail >= 0 && firstNlInTail + 1 < buf.length)
+    tailStart = firstNlInTail + 1;
 
   const head = buf.subarray(0, headEnd).toString('utf8');
   const tail = buf.subarray(tailStart).toString('utf8');
-  const elidedBytes = totalBytes - Buffer.byteLength(head, 'utf8') - Buffer.byteLength(tail, 'utf8');
+  const elidedBytes =
+    totalBytes -
+    Buffer.byteLength(head, 'utf8') -
+    Buffer.byteLength(tail, 'utf8');
   const marker =
     `\n…[${elidedBytes} bytes elided of ${totalBytes} total — recover with ` +
     `read_tool_result(tool_call_id="${toolCallId}", head_lines=…, tail_lines=…, grep="…")]…\n`;
@@ -70,8 +92,16 @@ export function digestToolResultText(
 }
 ```
 
-- [ ] **Step 1: Write failing tests.** Cover: (a) input ≤ 8 KB returns unchanged, `elidedBytes === 0`; (b) input > 8 KB returns head+marker+tail, `text` length far smaller than input, marker contains the exact `elidedBytes` and the `toolCallId`; (c) head/tail cuts land on line boundaries (no partial line at the head end or tail start); (d) multibyte UTF-8 near the cut does not produce broken output (use a string with `é`/emoji near the boundary; assert the result round-trips as valid UTF-8 — `Buffer.from(result.text,'utf8').toString('utf8')` equals itself). 
-- [ ] **Step 2:** Run `npx vitest run src/tools/__tests__/result-digest.test.ts` — fails (module missing).
+- [ ] **Step 1: Write failing tests.** Cover: (a) input ≤ 8 KB returns
+      unchanged, `elidedBytes === 0`; (b) input > 8 KB returns head+marker+tail,
+      `text` length far smaller than input, marker contains the exact
+      `elidedBytes` and the `toolCallId`; (c) head/tail cuts land on line
+      boundaries (no partial line at the head end or tail start); (d) multibyte
+      UTF-8 near the cut does not produce broken output (use a string with
+      `é`/emoji near the boundary; assert the result round-trips as valid UTF-8
+      — `Buffer.from(result.text,'utf8').toString('utf8')` equals itself).
+- [ ] **Step 2:** Run `npx vitest run src/tools/__tests__/result-digest.test.ts`
+      — fails (module missing).
 - [ ] **Step 3:** Implement `result-digest.ts` as above.
 - [ ] **Step 4:** Run the test — passes.
 - [ ] **Step 5:** Commit.
@@ -81,27 +111,47 @@ export function digestToolResultText(
 ### Task 2: Tool-result sidecar store
 
 **Files:**
+
 - Create: `packages/agent/src/storage/tool-result-store.ts`
 - Test: `packages/agent/src/storage/__tests__/tool-result-store.test.ts`
 
-Stores the full result under `<sessionDir>/tool-results/<toolCallId>.txt` and reads it back with head/tail/grep slicing. Use `getSessionDir(sessionId)` from `session-store.ts` to resolve the dir. Sanitize `toolCallId` to a safe filename (allow `[A-Za-z0-9_-]`, reject/replace others) to prevent path traversal.
+Stores the full result under `<sessionDir>/tool-results/<toolCallId>.txt` and
+reads it back with head/tail/grep slicing. Use `getSessionDir(sessionId)` from
+`session-store.ts` to resolve the dir. Sanitize `toolCallId` to a safe filename
+(allow `[A-Za-z0-9_-]`, reject/replace others) to prevent path traversal.
 
 ```ts
 // ABOUTME: Per-session sidecar for full tool-result payloads that were digested
 // ABOUTME: out of the live context; read back by head/tail/grep via read_tool_result.
 
-export function writeToolResultSidecar(sessionId: string, toolCallId: string, full: string): void
-export interface SidecarSlice { content: string; totalBytes: number; lineCount: number; matchedLines?: number }
+export function writeToolResultSidecar(
+  sessionId: string,
+  toolCallId: string,
+  full: string
+): void;
+export interface SidecarSlice {
+  content: string;
+  totalBytes: number;
+  lineCount: number;
+  matchedLines?: number;
+}
 export function readToolResultSidecar(
   sessionId: string,
   toolCallId: string,
   opts: { headLines?: number; tailLines?: number; grep?: string }
-): SidecarSlice  // throws a clear Error if the sidecar is absent
+): SidecarSlice; // throws a clear Error if the sidecar is absent
 ```
 
-Slicing semantics: if `grep` is set, return only matching lines (plain substring match, capped at a sane max e.g. 500 lines, note when capped); otherwise return the first `headLines` and/or last `tailLines` (default to a modest head, e.g. 200 lines, when none given). Always report `totalBytes` and `lineCount` of the full file.
+Slicing semantics: if `grep` is set, return only matching lines (plain substring
+match, capped at a sane max e.g. 500 lines, note when capped); otherwise return
+the first `headLines` and/or last `tailLines` (default to a modest head, e.g.
+200 lines, when none given). Always report `totalBytes` and `lineCount` of the
+full file.
 
-- [ ] **Step 1:** Write failing tests (tempdir + `LACE_DIR`): write a 50 KB multi-line payload, then read back head-only, tail-only, grep, and the absent-sidecar error path. Assert filename sanitization (a `toolCallId` with `../` does not escape the dir).
+- [ ] **Step 1:** Write failing tests (tempdir + `LACE_DIR`): write a 50 KB
+      multi-line payload, then read back head-only, tail-only, grep, and the
+      absent-sidecar error path. Assert filename sanitization (a `toolCallId`
+      with `../` does not escape the dir).
 - [ ] **Step 2:** Run — fails.
 - [ ] **Step 3:** Implement.
 - [ ] **Step 4:** Run — passes.
@@ -112,16 +162,31 @@ Slicing semantics: if `grep` is set, return only matching lines (plain substring
 ### Task 3: `read_tool_result` tool
 
 **Files:**
+
 - Create: `packages/agent/src/tools/implementations/read_tool_result.ts`
-- Modify: `packages/agent/src/tools/builtins.ts` (register the tool in `registerBuiltinTools`)
+- Modify: `packages/agent/src/tools/builtins.ts` (register the tool in
+  `registerBuiltinTools`)
 - Test: `packages/agent/src/tools/__tests__/read-tool-result.test.ts`
 
-Model on `JobOutputTool` (`implementations/job_output.ts`). zod schema `{ tool_call_id: NonEmptyString, head_lines?: int>=0, tail_lines?: int>=0, grep?: string }` `.strict()`. Resolve the session from `context.activeSessionId` (fail with a clear message if absent). Call `readToolResultSidecar`. Return the slice as a text `ToolResult`, prefixed with a one-line header stating total bytes/lines and what slice was returned. Mark `readOnlySafe: true`, `safeInternal: true`. Write a description that tells the model this fetches the full output of a previously-digested tool result, and to prefer `grep` for large outputs.
+Model on `JobOutputTool` (`implementations/job_output.ts`). zod schema
+`{ tool_call_id: NonEmptyString, head_lines?: int>=0, tail_lines?: int>=0, grep?: string }`
+`.strict()`. Resolve the session from `context.activeSessionId` (fail with a
+clear message if absent). Call `readToolResultSidecar`. Return the slice as a
+text `ToolResult`, prefixed with a one-line header stating total bytes/lines and
+what slice was returned. Mark `readOnlySafe: true`, `safeInternal: true`. Write
+a description that tells the model this fetches the full output of a
+previously-digested tool result, and to prefer `grep` for large outputs.
 
-- [ ] **Step 1:** Write failing tests: seed a sidecar via Task 2, build a `ToolContext` with `activeSessionId`, call the tool with head/tail/grep, assert the returned content; assert the missing-`activeSessionId` and missing-sidecar failure paths return `status:'failed'` with a clear message (not a throw).
+- [ ] **Step 1:** Write failing tests: seed a sidecar via Task 2, build a
+      `ToolContext` with `activeSessionId`, call the tool with head/tail/grep,
+      assert the returned content; assert the missing-`activeSessionId` and
+      missing-sidecar failure paths return `status:'failed'` with a clear
+      message (not a throw).
 - [ ] **Step 2:** Run — fails.
 - [ ] **Step 3:** Implement + register in `builtins.ts`.
-- [ ] **Step 4:** Run — passes. Also run `src/tools/builtins.test.ts` to confirm registration didn't break the builtin set (update its expected-tool list/count if it pins one).
+- [ ] **Step 4:** Run — passes. Also run `src/tools/builtins.test.ts` to confirm
+      registration didn't break the builtin set (update its expected-tool
+      list/count if it pins one).
 - [ ] **Step 5:** Commit.
 
 ---
@@ -129,37 +194,71 @@ Model on `JobOutputTool` (`implementations/job_output.ts`). zod schema `{ tool_c
 ### Task 4: Runner integration (the chokepoint)
 
 **Files:**
-- Modify: `packages/agent/src/core/conversation/runner.ts` (in `executeToolCall`, right after `executeToolByName` returns `coreResult` at ~line 1619, before `protocolResult` is built and before the return)
-- Test: `packages/agent/src/core/conversation/__tests__/` — add `runner-tool-result-cap.test.ts` (match the dir convention used by existing runner tests; if runner tests live elsewhere, co-locate there)
 
-Apply capping to `coreResult` so BOTH downstream consumers — the durable `tool_use` event (built from `protocolToolResultFromCore(coreResult)`) and the `providerMessages` append (`{ role:'user', content:'', toolResults:[result.coreResult] }`) — carry the digested content. Do NOT digest the `read_tool_result` tool's own output (it is already bounded by its args; digesting it would defeat paging) — skip by tool name.
+- Modify: `packages/agent/src/core/conversation/runner.ts` (in
+  `executeToolCall`, right after `executeToolByName` returns `coreResult` at
+  ~line 1619, before `protocolResult` is built and before the return)
+- Test: `packages/agent/src/core/conversation/__tests__/` — add
+  `runner-tool-result-cap.test.ts` (match the dir convention used by existing
+  runner tests; if runner tests live elsewhere, co-locate there)
+
+Apply capping to `coreResult` so BOTH downstream consumers — the durable
+`tool_use` event (built from `protocolToolResultFromCore(coreResult)`) and the
+`providerMessages` append
+(`{ role:'user', content:'', toolResults:[result.coreResult] }`) — carry the
+digested content. Do NOT digest the `read_tool_result` tool's own output (it is
+already bounded by its args; digesting it would defeat paging) — skip by tool
+name.
 
 Logic:
-1. Concatenate the text of `coreResult.content` text blocks → `fullText`. (Leave non-text blocks, e.g. images, untouched and unmeasured.)
+
+1. Concatenate the text of `coreResult.content` text blocks → `fullText`. (Leave
+   non-text blocks, e.g. images, untouched and unmeasured.)
 2. `const digest = digestToolResultText(fullText, toolCallId)`.
-3. If `digest.elidedBytes > 0`: `writeToolResultSidecar(sessionId, toolCallId, fullText)` and replace `coreResult.content`'s text blocks with a single `{ type:'text', text: digest.text }` (preserving any non-text blocks). Leave `status` unchanged.
+3. If `digest.elidedBytes > 0`:
+   `writeToolResultSidecar(sessionId, toolCallId, fullText)` and replace
+   `coreResult.content`'s text blocks with a single
+   `{ type:'text', text: digest.text }` (preserving any non-text blocks). Leave
+   `status` unchanged.
 4. If `elidedBytes === 0`: leave `coreResult` untouched.
 
-`sessionId` is in scope in `executeToolCall` (it is a param). Guard: if `sessionId` is missing/empty, skip the spill and just inline-truncate (don't lose the cap, but don't write a stray file) — or assert it's present; pick the safe option and note it.
+`sessionId` is in scope in `executeToolCall` (it is a param). Guard: if
+`sessionId` is missing/empty, skip the spill and just inline-truncate (don't
+lose the cap, but don't write a stray file) — or assert it's present; pick the
+safe option and note it.
 
-- [ ] **Step 1:** Write a failing test that drives `executeToolCall` (or the smallest runner seam that exercises this branch) with a stubbed `toolExecutor.execute` returning a >8 KB text result, and asserts: (a) the `coreResult.content` text returned/appended is the digest (small, contains the marker), (b) a sidecar file exists with the full text, (c) a ≤8 KB result is passed through unchanged. If `executeToolCall` is private/hard to call directly, test through the existing runner test harness used by other runner tests, or temporarily expose a thin internal seam — prefer reusing an existing harness.
+- [ ] **Step 1:** Write a failing test that drives `executeToolCall` (or the
+      smallest runner seam that exercises this branch) with a stubbed
+      `toolExecutor.execute` returning a >8 KB text result, and asserts: (a) the
+      `coreResult.content` text returned/appended is the digest (small, contains
+      the marker), (b) a sidecar file exists with the full text, (c) a ≤8 KB
+      result is passed through unchanged. If `executeToolCall` is private/hard
+      to call directly, test through the existing runner test harness used by
+      other runner tests, or temporarily expose a thin internal seam — prefer
+      reusing an existing harness.
 - [ ] **Step 2:** Run — fails.
 - [ ] **Step 3:** Implement the capping block.
 - [ ] **Step 4:** Run — passes.
-- [ ] **Step 5:** Run the broader suites: `npx vitest run src/core src/tools src/storage` — all green. Then `npm run typecheck` and `npm run lint`.
+- [ ] **Step 5:** Run the broader suites:
+      `npx vitest run src/core src/tools src/storage` — all green. Then
+      `npm run typecheck` and `npm run lint`.
 - [ ] **Step 6:** Commit.
 
 ---
 
 ## Out of scope (note as follow-ups, do not build)
 
-- Sidecar retention/eviction (serf drops the middle past a retention cap). v1 keeps the full spill; disk is cheaper than context. Revisit if session dirs grow unbounded.
+- Sidecar retention/eviction (serf drops the middle past a retention cap). v1
+  keeps the full spill; disk is cheaper than context. Revisit if session dirs
+  grow unbounded.
 - Digesting non-text content blocks (images).
-- A separate, larger inline budget for bounded delegate *reports* (serf's `shellInlineOutputBytes = 64 KB`); not needed for the general raw-result cap.
+- A separate, larger inline budget for bounded delegate _reports_ (serf's
+  `shellInlineOutputBytes = 64 KB`); not needed for the general raw-result cap.
 
 ## Self-review checklist (run before final commit)
 
-- Every oversized result path writes the sidecar AND digests both the live message and the durable event.
+- Every oversized result path writes the sidecar AND digests both the live
+  message and the durable event.
 - `read_tool_result` is excluded from re-digestion.
 - No placeholder text, no `any`, line-aligned cuts, UTF-8 safe.
 - Builtin registration test updated if it pins the tool set.

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -130,14 +130,15 @@ incompatible kernel fails loudly at load rather than misbehaving later.
 
 Four typed registries, each a `Registry<T>` — a select-one-by-name table.
 Personas and skills are **not** registries; they are contributed via directories
-(see [Personas and Skills via directories](#personas-and-skills-via-directories)).
+(see
+[Personas and Skills via directories](#personas-and-skills-via-directories)).
 
-| `api` field  | Value type                 | Import the type from           | Consumed at                                                                                               |
-| ------------ | -------------------------- | ------------------------------ | --------------------------------------------------------------------------------------------------------- |
-| `tools`      | `Tool`                     | `@lace/agent/tools/tool`       | `ToolExecutor.registerAllAvailableTools()` draws every registered tool into each session executor.        |
-| `compaction` | `CompactionStrategy`       | `@lace/agent/compaction/types` | `resolveCompactionStrategy(name)` selects a strategy by name (persona-configured, default `track-based`). |
-| `recall`     | `RecallMembershipExtractor`| `@lace/agent/plugins/api`      | `recall(action:"thread", groupKey)` calls the registered extractor with an **opaque** key to select a conversation's events from the verbatim journal. The kernel never parses the key. |
-| `runtimes`   | `ContainerRuntime`         | `@lace/agent/containers/types` | `createDefaultContainerManager(platform, name)` selects a runtime by name.                                |
+| `api` field  | Value type                  | Import the type from           | Consumed at                                                                                                                                                                             |
+| ------------ | --------------------------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tools`      | `Tool`                      | `@lace/agent/tools/tool`       | `ToolExecutor.registerAllAvailableTools()` draws every registered tool into each session executor.                                                                                      |
+| `compaction` | `CompactionStrategy`        | `@lace/agent/compaction/types` | `resolveCompactionStrategy(name)` selects a strategy by name (persona-configured, default `track-based`).                                                                               |
+| `recall`     | `RecallMembershipExtractor` | `@lace/agent/plugins/api`      | `recall(action:"thread", groupKey)` calls the registered extractor with an **opaque** key to select a conversation's events from the verbatim journal. The kernel never parses the key. |
+| `runtimes`   | `ContainerRuntime`          | `@lace/agent/containers/types` | `createDefaultContainerManager(platform, name)` selects a runtime by name.                                                                                                              |
 
 ### Ownership and duplicates
 
@@ -165,8 +166,8 @@ class Registry<T> {
 
 The exported `registries` object exposes one of these per kind —
 `registries.tools`, `registries.compaction`, `registries.recall`,
-`registries.runtimes` — each with the full surface above. In a test you can assert ownership (e.g.
-`registries.compaction.owner('acme:strat')`).
+`registries.runtimes` — each with the full surface above. In a test you can
+assert ownership (e.g. `registries.compaction.owner('acme:strat')`).
 
 ## Personas and Skills via directories
 
@@ -179,8 +180,8 @@ names them at boot.
 Registers a directory of flat `<entry>.md` persona files. Each `.md` file
 becomes a persona named `<namespace>:<entry>`, where `namespace` is
 `meta.namespace` from the plugin's `meta`. For example, a plugin with
-`namespace: 'acme'` and a file `personas/researcher.md` produces a persona
-named `acme:researcher`.
+`namespace: 'acme'` and a file `personas/researcher.md` produces a persona named
+`acme:researcher`.
 
 Precedence order: user-disk personas override plugin personas override bundled
 personas. A user who drops `~/.lace/agent-personas/researcher.md` silences the
@@ -199,7 +200,8 @@ the name is bare (e.g. `researcher`, not `acme:researcher`). All skill sources
 (plugins, user-disk, bundled) share a single flat namespace; collisions are
 resolved first-wins and emit a `warn`. Choose collision-safe skill names.
 
-(Contrast: tools and personas ARE `<namespace>:<entry>`-namespaced; skills are not.)
+(Contrast: tools and personas ARE `<namespace>:<entry>`-namespaced; skills are
+not.)
 
 ### Per-persona tools and skills (`<persona>/tools/` and `<persona>/skills/`)
 
@@ -422,7 +424,10 @@ interface CompactionContext {
   // (converts {prompt}->messages; defaults `model` to the session modelId).
   // Absent when no connection/model is available; deterministic strategies ignore it.
   query?: (opts: {
-    messages?: ProviderMessage[]; prompt?: string; model?: string; signal?: AbortSignal;
+    messages?: ProviderMessage[];
+    prompt?: string;
+    model?: string;
+    signal?: AbortSignal;
   }) => Promise<{ text: string; usage?: ProviderResponse['usage'] }>;
   // Free-text steering from the compact caller (compact_session / ent.session.compact
   // `guidance`, or /compact's command tail). Absent when auto-fired; built-ins ignore it.
@@ -431,11 +436,12 @@ interface CompactionContext {
 ```
 
 **Compaction is triggered three ways**, all routing through the persona-selected
-strategy and `validatePreserved`: automatically in the runner's post-turn hook at
-the persona's `compaction.breakpoints` (`{ at, action: 'notify' | 'compact' }`);
-by the agent calling the built-in **`compact_session`** tool (optional `guidance`;
-it schedules a post-turn compaction and asks the model to end its turn); or via the
-`ent/session/compact` RPC / the `/compact` command.
+strategy and `validatePreserved`: automatically in the runner's post-turn hook
+at the persona's `compaction.breakpoints`
+(`{ at, action: 'notify' | 'compact' }`); by the agent calling the built-in
+**`compact_session`** tool (optional `guidance`; it schedules a post-turn
+compaction and asks the model to end its turn); or via the `ent/session/compact`
+RPC / the `/compact` command.
 
 Return `{ noop: true }` when there is nothing to compact — do **not** return a
 `compactionEvent` with an empty `preserved`. `ContextCompactedEventData` (from
@@ -462,19 +468,19 @@ result). When building test fixtures, a minimal `turn_end` data payload is
 `{ stopReason: 'end_turn', usage: { costUsd: 0 } }`; a `prompt`/`message`
 payload carries `{ content: string | ContentBlock[] }`.
 
-**The toolkit:** `@lace/agent/compaction/toolkit` exports the
-domain-neutral compaction primitives (promoted out of the kernel `track-based`
-strategy in the Slack de-leak): `splitAtTailBoundary` (events -> earlier/tail at a
-turn boundary), `demuxByTrack(events, attributeFn)` (group earlier events by a
+**The toolkit:** `@lace/agent/compaction/toolkit` exports the domain-neutral
+compaction primitives (promoted out of the kernel `track-based` strategy in the
+Slack de-leak): `splitAtTailBoundary` (events -> earlier/tail at a turn
+boundary), `demuxByTrack(events, attributeFn)` (group earlier events by a
 caller-supplied per-event track key — the de-interleave seam a custom strategy
-injects its own attributor into), `buildPreservedTail` / `buildPreservedWithPrefix`
-(build the verbatim-tail + prefix preserved stream), the generic non-Slack salience
-helpers `jobSalience` / `untrackedSalience` / `systemSalience` with
-`renderGenericSections`, and
-`mergePreservedAdjacent(entries: PreservedEntry[])` — apply the last to your preserved
-list so message replay stays legal (drops empties, merges consecutive same-role
-entries, ensures a leading user-role entry; returns `[]` when nothing remains →
-return `{ noop: true }`). A `PreservedEntry` is
+injects its own attributor into), `buildPreservedTail` /
+`buildPreservedWithPrefix` (build the verbatim-tail + prefix preserved stream),
+the generic non-Slack salience helpers `jobSalience` / `untrackedSalience` /
+`systemSalience` with `renderGenericSections`, and
+`mergePreservedAdjacent(entries: PreservedEntry[])` — apply the last to your
+preserved list so message replay stays legal (drops empties, merges consecutive
+same-role entries, ensures a leading user-role entry; returns `[]` when nothing
+remains → return `{ noop: true }`). A `PreservedEntry` is
 `{ role: string; content: string | Block[]; toolCalls?: unknown[]; toolResults?: unknown[] }`
 where `Block = { type: string; [k: string]: unknown }`. `PreservedEntry` **is**
 exported from `@lace/agent/compaction/toolkit` — import the type rather than

--- a/docs/superpowers/plans/2026-06-04-file-based-personas-and-exec-tools.md
+++ b/docs/superpowers/plans/2026-06-04-file-based-personas-and-exec-tools.md
@@ -1,14 +1,30 @@
 # File-based personas + per-persona/plugin tools & skills — Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make all personas file-based (`.md` dirs, `:`-namespaced by source) and wire one-shot-exec **tools** and **skills** into lace from three source tiers — core, plugin-global, and per-persona (`<persona>/tools/`, `<persona>/skills/`).
+**Goal:** Make all personas file-based (`.md` dirs, `:`-namespaced by source)
+and wire one-shot-exec **tools** and **skills** into lace from three source
+tiers — core, plugin-global, and per-persona (`<persona>/tools/`,
+`<persona>/skills/`).
 
-**Architecture:** Personas stop being in-memory plugin objects; plugins contribute persona/skill/tool *directories*. Logical names are `<namespace>:<entry>` (namespace from the source; flat disk names). Global exec tools land in `registries.tools` at boot via **synchronous** discovery (so it runs inside `register(api)`); per-persona tools/skills are injected only when that persona is active. Skills flow through the existing per-session `SkillRegistry` via one `composeSkillDirs` resolver.
+**Architecture:** Personas stop being in-memory plugin objects; plugins
+contribute persona/skill/tool _directories_. Logical names are
+`<namespace>:<entry>` (namespace from the source; flat disk names). Global exec
+tools land in `registries.tools` at boot via **synchronous** discovery (so it
+runs inside `register(api)`); per-persona tools/skills are injected only when
+that persona is active. Skills flow through the existing per-session
+`SkillRegistry` via one `composeSkillDirs` resolver.
 
-**Tech Stack:** TypeScript (ESM), Node `child_process.spawnSync`, vitest, Zod, the lace plugin system (`registries`, `loadPlugins`), `PersonaRegistry`, `SkillRegistry`, `TemplateEngine`.
+**Tech Stack:** TypeScript (ESM), Node `child_process.spawnSync`, vitest, Zod,
+the lace plugin system (`registries`, `loadPlugins`), `PersonaRegistry`,
+`SkillRegistry`, `TemplateEngine`.
 
-**Design of record:** `docs/superpowers/specs/2026-06-04-file-based-personas-and-exec-tools-design.md` (read it; this plan implements it). Reviewed by three opus panels.
+**Design of record:**
+`docs/superpowers/specs/2026-06-04-file-based-personas-and-exec-tools-design.md`
+(read it; this plan implements it). Reviewed by three opus panels.
 
 **Branch:** `exec-tools-and-file-personas` (already created off `main`).
 
@@ -16,40 +32,60 @@
 
 ## Conventions for the implementer
 
-- Run all commands from `packages/agent` (the repo root vitest config excludes `packages/**`):
-  `cd packages/agent && npx vitest run <path>`.
-- Typecheck: `cd packages/agent && npx tsc --noEmit -p .`. Lint: `npx eslint <files> --fix`.
-- This is a **shared repo with concurrent writers** — commit with explicit pathspecs (`git commit <files> -m …`), never `git add -A`, never push.
-- No backward-compat shims (pre-prod). End commit messages with the Co-Authored-By trailer.
-- Exec tests use **real subprocesses** (no mocks), mirroring `src/tools/exec/__tests__/workspace-stats.e2e.test.ts`.
+- Run all commands from `packages/agent` (the repo root vitest config excludes
+  `packages/**`): `cd packages/agent && npx vitest run <path>`.
+- Typecheck: `cd packages/agent && npx tsc --noEmit -p .`. Lint:
+  `npx eslint <files> --fix`.
+- This is a **shared repo with concurrent writers** — commit with explicit
+  pathspecs (`git commit <files> -m …`), never `git add -A`, never push.
+- No backward-compat shims (pre-prod). End commit messages with the
+  Co-Authored-By trailer.
+- Exec tests use **real subprocesses** (no mocks), mirroring
+  `src/tools/exec/__tests__/workspace-stats.e2e.test.ts`.
 
 ## File structure (what changes)
 
 **Phase 0 — file-based personas + naming + TemplateEngine**
-- Modify `src/config/template-engine.ts` — make the embedded-files lookup opt-in per engine.
-- Modify `src/config/persona-registry.ts` — `FileDirSource` for user+plugin dirs; delete in-memory `PluginSource`; source-scoped rendering; `:`-namespacing; `personaToolsDir`/`personaSkillsDir`; plugin-dir list.
-- Modify `src/plugins/api.ts`, `src/plugins/index.ts` — remove `personas` registry/`PersonaDef`; add `api.personas.addDir` + `api.skills.addDir` (skills dir list used in Phase 5) + the plugin-dir module state.
+
+- Modify `src/config/template-engine.ts` — make the embedded-files lookup opt-in
+  per engine.
+- Modify `src/config/persona-registry.ts` — `FileDirSource` for user+plugin
+  dirs; delete in-memory `PluginSource`; source-scoped rendering;
+  `:`-namespacing; `personaToolsDir`/`personaSkillsDir`; plugin-dir list.
+- Modify `src/plugins/api.ts`, `src/plugins/index.ts` — remove `personas`
+  registry/`PersonaDef`; add `api.personas.addDir` + `api.skills.addDir` (skills
+  dir list used in Phase 5) + the plugin-dir module state.
 - Modify `src/config/prompt-manager.ts` — source-scoped render call.
 - Update examples/fixtures/tests (full inventory in tasks).
 
 **Phase 1 — sync exec discovery**
-- Modify `src/tools/exec/run-once.ts` — export `minimalEnv`; add `runExecToolSchemaSync`.
-- Modify `src/tools/exec/discover.ts` — `discoverExecToolsSync`; remove async `discoverExecTools`.
+
+- Modify `src/tools/exec/run-once.ts` — export `minimalEnv`; add
+  `runExecToolSchemaSync`.
+- Modify `src/tools/exec/discover.ts` — `discoverExecToolsSync`; remove async
+  `discoverExecTools`.
 - Modify `src/tools/exec/exec-tool-adapter.ts` — add `nameOverride` ctor param.
-- Migrate `src/tools/exec/__tests__/discover.test.ts`, `workspace-stats.e2e.test.ts`.
+- Migrate `src/tools/exec/__tests__/discover.test.ts`,
+  `workspace-stats.e2e.test.ts`.
 
 **Phase 2 — global tier**
-- Create `src/tools/exec/register-exec.ts` — `registerCoreExecTools`, `registerExecDirInto`.
+
+- Create `src/tools/exec/register-exec.ts` — `registerCoreExecTools`,
+  `registerExecDirInto`.
 - Modify `src/plugins/api.ts` — `api.tools.registerExecDir`.
 - Modify `src/main.ts` — `registerCoreExecTools()` in `boot()`.
 
 **Phase 3 — per-persona tools**
+
 - Modify `src/tools/executor.ts` — `injectPersonaTools` (override-guarded).
 
 **Phase 4 — wiring**
-- Modify `src/server.ts`, `src/server-types.ts`, the handlers (`tools.ts`, `session.ts`, `session-operations.ts`, `prompt.ts`).
+
+- Modify `src/server.ts`, `src/server-types.ts`, the handlers (`tools.ts`,
+  `session.ts`, `session-operations.ts`, `prompt.ts`).
 
 **Phase 5 — skills**
+
 - Create `src/skills/compose-skill-dirs.ts` — `composeSkillDirs`.
 - Modify `src/skills/registry.ts` — cross-source shadow `warn`.
 - Modify the four producers + plugin skill-dir state.
@@ -60,13 +96,19 @@
 
 # Phase 0 — File-based personas + naming + TemplateEngine
 
-> Phase 0 is the hard dependency for Phases 3 and 5. Land it green before proceeding.
+> Phase 0 is the hard dependency for Phases 3 and 5. Land it green before
+> proceeding.
 
 ### Task 0.1: `TemplateEngine` — make the embedded lookup opt-in
 
-**Why:** `loadTemplate` checks `Bun.embeddedFiles` unconditionally before the FS dirs (`template-engine.ts:62-115`), and `processIncludes` does the same for `@path` includes. For source-scoped persona rendering, only the *bundled* source may use embedded-first; user/plugin sources must resolve against their own FS dir.
+**Why:** `loadTemplate` checks `Bun.embeddedFiles` unconditionally before the FS
+dirs (`template-engine.ts:62-115`), and `processIncludes` does the same for
+`@path` includes. For source-scoped persona rendering, only the _bundled_ source
+may use embedded-first; user/plugin sources must resolve against their own FS
+dir.
 
 **Files:**
+
 - Modify: `src/config/template-engine.ts`
 - Test: `src/config/__tests__/template-engine-embedded-optin.test.ts` (create)
 
@@ -105,12 +147,14 @@ describe('TemplateEngine embedded opt-in', () => {
 
 - [ ] **Step 2: Run it, verify it fails**
 
-Run: `cd packages/agent && npx vitest run src/config/__tests__/template-engine-embedded-optin.test.ts`
+Run:
+`cd packages/agent && npx vitest run src/config/__tests__/template-engine-embedded-optin.test.ts`
 Expected: FAIL (`usesEmbedded` undefined; constructor takes no options).
 
 - [ ] **Step 3: Implement the opt-in**
 
 In `src/config/template-engine.ts`:
+
 - Change the constructor to accept options and store a flag:
 
 ```ts
@@ -133,20 +177,29 @@ In `src/config/template-engine.ts`:
   as `if (this.useEmbedded && typeof Bun !== 'undefined' && …)`.
 - In `processIncludes`, find the equivalent embedded-files check (the include
   resolution that reads `Bun.embeddedFiles`) and gate it the same way:
-  `if (this.useEmbedded && …)`. The FS include resolution (relative to the include
-  base dir) is the path that must run for non-embedded engines.
+  `if (this.useEmbedded && …)`. The FS include resolution (relative to the
+  include base dir) is the path that must run for non-embedded engines.
 
 > NOTE: read `processIncludes` to place the guard exactly; there is one embedded
-> branch and one FS branch — gate only the embedded branch on `this.useEmbedded`.
+> branch and one FS branch — gate only the embedded branch on
+> `this.useEmbedded`.
 
 - [ ] **Step 4: Run test, verify pass**
 
-Run: `cd packages/agent && npx vitest run src/config/__tests__/template-engine-embedded-optin.test.ts`
+Run:
+`cd packages/agent && npx vitest run src/config/__tests__/template-engine-embedded-optin.test.ts`
 Expected: PASS.
 
-- [ ] **Step 5: Guard existing callers** — the bundled-persona render path must pass `{ useEmbedded: true }`. Find every `new TemplateEngine(` (grep) and set `useEmbedded: true` ONLY where bundled/embedded personas are rendered (the prompt-manager default engine — Task 0.7 revisits this). For now, default all existing `new TemplateEngine(dirs)` callers to `{ useEmbedded: true }` to preserve current behavior, so this task is behavior-preserving.
+- [ ] **Step 5: Guard existing callers** — the bundled-persona render path must
+      pass `{ useEmbedded: true }`. Find every `new TemplateEngine(` (grep) and
+      set `useEmbedded: true` ONLY where bundled/embedded personas are rendered
+      (the prompt-manager default engine — Task 0.7 revisits this). For now,
+      default all existing `new TemplateEngine(dirs)` callers to
+      `{ useEmbedded: true }` to preserve current behavior, so this task is
+      behavior-preserving.
 
-Run: `cd packages/agent && npx vitest run src/config/` — Expected: existing template/persona tests still PASS.
+Run: `cd packages/agent && npx vitest run src/config/` — Expected: existing
+template/persona tests still PASS.
 
 - [ ] **Step 6: Commit**
 
@@ -161,9 +214,12 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 
 ### Task 0.2: Plugin-dir module state + `api.personas.addDir` / `api.skills.addDir`
 
-**Why:** Plugins contribute persona/skill *directories* (not in-memory objects). The dirs accumulate in module-level lists populated during `loadPlugins`, read later by `PersonaRegistry` and `composeSkillDirs`.
+**Why:** Plugins contribute persona/skill _directories_ (not in-memory objects).
+The dirs accumulate in module-level lists populated during `loadPlugins`, read
+later by `PersonaRegistry` and `composeSkillDirs`.
 
 **Files:**
+
 - Create: `src/plugins/contributed-dirs.ts`
 - Modify: `src/plugins/api.ts`, `src/plugins/index.ts`
 - Test: `src/plugins/__tests__/contributed-dirs.test.ts` (create)
@@ -175,7 +231,11 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 // ABOUTME: Plugin-contributed persona/skill dirs accumulate by namespace and reset for tests.
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
-  addPersonaDir, personaDirs, addSkillDir, skillDirs, resetContributedDirsForTest,
+  addPersonaDir,
+  personaDirs,
+  addSkillDir,
+  skillDirs,
+  resetContributedDirsForTest,
 } from '../contributed-dirs';
 
 describe('contributed dirs', () => {
@@ -202,7 +262,9 @@ describe('contributed dirs', () => {
 
 - [ ] **Step 2: Run it, verify it fails**
 
-Run: `cd packages/agent && npx vitest run src/plugins/__tests__/contributed-dirs.test.ts` — Expected: FAIL (module missing).
+Run:
+`cd packages/agent && npx vitest run src/plugins/__tests__/contributed-dirs.test.ts`
+— Expected: FAIL (module missing).
 
 - [ ] **Step 3: Implement `contributed-dirs.ts`**
 
@@ -236,12 +298,19 @@ export function resetContributedDirsForTest(): void {
 }
 ```
 
-- [ ] **Step 4: Run test, verify pass.** `cd packages/agent && npx vitest run src/plugins/__tests__/contributed-dirs.test.ts` — Expected: PASS.
+- [ ] **Step 4: Run test, verify pass.**
+      `cd packages/agent && npx vitest run src/plugins/__tests__/contributed-dirs.test.ts`
+      — Expected: PASS.
 
-- [ ] **Step 5: Wire into `PluginApi`** (api.ts). Replace the `personas` registrar with a `personas.addDir` view and add `skills.addDir`, both injecting the plugin's `meta.namespace`:
+- [ ] **Step 5: Wire into `PluginApi`** (api.ts). Replace the `personas`
+      registrar with a `personas.addDir` view and add `skills.addDir`, both
+      injecting the plugin's `meta.namespace`:
 
 In `src/plugins/api.ts`:
-- Remove from `PluginRegistries`/`PluginApi`/`makeRegistries`/`createPluginApi`/`resetRegistriesForTest`: every `personas` line and the `PersonaDef` import/export.
+
+- Remove from
+  `PluginRegistries`/`PluginApi`/`makeRegistries`/`createPluginApi`/`resetRegistriesForTest`:
+  every `personas` line and the `PersonaDef` import/export.
 - Add to the `PluginApi` interface:
 
 ```ts
@@ -249,7 +318,8 @@ In `src/plugins/api.ts`:
   skills: { addDir(dir: string): void };
 ```
 
-- In `createPluginApi`, build them from `meta.namespace` (import from `./contributed-dirs`):
+- In `createPluginApi`, build them from `meta.namespace` (import from
+  `./contributed-dirs`):
 
 ```ts
     personas: { addDir: (dir) => addPersonaDir(meta.namespace, dir) },
@@ -258,9 +328,15 @@ In `src/plugins/api.ts`:
 
 - In `resetRegistriesForTest()`, add `resetContributedDirsForTest()`.
 
-- [ ] **Step 6: Update `src/plugins/index.ts`** — remove the `PersonaDef` re-export; export `addPersonaDir, personaDirs, addSkillDir, skillDirs, resetContributedDirsForTest, type ContributedDir` from `./contributed-dirs`.
+- [ ] **Step 6: Update `src/plugins/index.ts`** — remove the `PersonaDef`
+      re-export; export
+      `addPersonaDir, personaDirs, addSkillDir, skillDirs, resetContributedDirsForTest, type ContributedDir`
+      from `./contributed-dirs`.
 
-- [ ] **Step 7: Typecheck** — `cd packages/agent && npx tsc --noEmit -p .`. Expect errors in consumers of the removed `personas` registry / `PersonaDef` — those are fixed in Tasks 0.3–0.6 and 0.8. Do NOT fix unrelated files yet; proceed.
+- [ ] **Step 7: Typecheck** — `cd packages/agent && npx tsc --noEmit -p .`.
+      Expect errors in consumers of the removed `personas` registry /
+      `PersonaDef` — those are fixed in Tasks 0.3–0.6 and 0.8. Do NOT fix
+      unrelated files yet; proceed.
 
 - [ ] **Step 8: Commit**
 
@@ -275,16 +351,19 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 
 ### Task 0.3: `PersonaRegistry` — `FileDirSource`, plugin dirs, `:`-namespacing, source-scoped render
 
-**Why:** Personas become file-only. Plugin dirs (namespaced) join the search path between user and bundled. Rendering is source-scoped (the source owns an FS-only `TemplateEngine` rooted at its dir; bundled keeps `useEmbedded:true`).
+**Why:** Personas become file-only. Plugin dirs (namespaced) join the search
+path between user and bundled. Rendering is source-scoped (the source owns an
+FS-only `TemplateEngine` rooted at its dir; bundled keeps `useEmbedded:true`).
 
 **Files:**
+
 - Modify: `src/config/persona-registry.ts`
 - Test: `src/config/__tests__/persona-registry-filedir.test.ts` (create)
 
 > Read `persona-registry.ts` fully first. You are replacing the `PersonaSource`
-> implementations. Preserve: `PersonaInfo`, `ParsedPersona`, `parsePersona` parse
-> logic (gray-matter + `personaConfigSchema` + `resolveMcpPaths`), the kata-#55
-> user-dir TTL/`anyPathScanned` rescan guard, `PersonaNotFoundError`,
+> implementations. Preserve: `PersonaInfo`, `ParsedPersona`, `parsePersona`
+> parse logic (gray-matter + `personaConfigSchema` + `resolveMcpPaths`), the
+> kata-#55 user-dir TTL/`anyPathScanned` rescan guard, `PersonaNotFoundError`,
 > `listAvailablePersonas`, `hasPersona`.
 
 - [ ] **Step 1: Write the failing test**
@@ -298,7 +377,10 @@ import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { PersonaRegistry } from '../persona-registry';
-import { addPersonaDir, resetContributedDirsForTest } from '@lace/agent/plugins';
+import {
+  addPersonaDir,
+  resetContributedDirsForTest,
+} from '@lace/agent/plugins';
 
 function pluginPersonaDir(ns: string, name: string, body: string): string {
   const root = mkdtempSync(join(tmpdir(), `pp-${ns}-`));
@@ -310,13 +392,22 @@ describe('PersonaRegistry file-dir sources', () => {
   beforeEach(() => resetContributedDirsForTest());
 
   it('resolves a plugin persona as <ns>:<entry> with a real path', () => {
-    const dir = pluginPersonaDir('acme', 'scout', 'You are Scout. {{system.os}}');
+    const dir = pluginPersonaDir(
+      'acme',
+      'scout',
+      'You are Scout. {{system.os}}'
+    );
     addPersonaDir('acme', dir);
-    const reg = new PersonaRegistry({ bundledPersonasPath: '/nonexistent', userPersonasPaths: [] });
+    const reg = new PersonaRegistry({
+      bundledPersonasPath: '/nonexistent',
+      userPersonasPaths: [],
+    });
     expect(reg.hasPersona('acme:scout')).toBe(true);
     const parsed = reg.parsePersona('acme:scout');
     expect(parsed.body).toContain('Scout');
-    const info = reg.listAvailablePersonas().find((p) => p.name === 'acme:scout');
+    const info = reg
+      .listAvailablePersonas()
+      .find((p) => p.name === 'acme:scout');
     expect(info?.path).toBe(join(dir, 'scout.md')); // real path, not a sentinel
   });
 
@@ -326,13 +417,18 @@ describe('PersonaRegistry file-dir sources', () => {
     writeFileSync(join(root, 'sections', 'role.md'), 'ROLE-FROM-PLUGIN');
     writeFileSync(join(root, 'docs.md'), 'persona @sections/role.md');
     addPersonaDir('acme', root);
-    const reg = new PersonaRegistry({ bundledPersonasPath: '/nonexistent', userPersonasPaths: [] });
+    const reg = new PersonaRegistry({
+      bundledPersonasPath: '/nonexistent',
+      userPersonasPaths: [],
+    });
     expect(reg.renderPersona('acme:docs', {})).toContain('ROLE-FROM-PLUGIN');
   });
 });
 ```
 
-- [ ] **Step 2: Run it, verify it fails.** `cd packages/agent && npx vitest run src/config/__tests__/persona-registry-filedir.test.ts` — Expected: FAIL (`renderPersona` missing; `acme:scout` not found).
+- [ ] **Step 2: Run it, verify it fails.**
+      `cd packages/agent && npx vitest run src/config/__tests__/persona-registry-filedir.test.ts`
+      — Expected: FAIL (`renderPersona` missing; `acme:scout` not found).
 
 - [ ] **Step 3: Implement the source model.** Replace the source classes with:
 
@@ -340,44 +436,51 @@ describe('PersonaRegistry file-dir sources', () => {
 interface PersonaSource {
   readonly kind: 'user' | 'plugin' | 'bundled';
   readonly isUserDefined: boolean;
-  has(name: string): boolean;          // name is the LOGICAL name (ns:entry for plugin)
+  has(name: string): boolean; // name is the LOGICAL name (ns:entry for plugin)
   names(): string[];
   parse(name: string): ParsedPersona;
   render(name: string, context: TemplateContext): string;
-  displayPath(name: string): string;   // real disk path
+  displayPath(name: string): string; // real disk path
   resourceDir(name: string, kind: 'tools' | 'skills'): string | null;
 }
 ```
 
 - `FileDirSource` (used for user and plugin dirs): constructed with
-  `{ dir, namespace?: string, isUserDefined, kind }`. `namespace` undefined ⇒ bare
-  names (user); set ⇒ logical name `${namespace}:${entry}` mapping to file
+  `{ dir, namespace?: string, isUserDefined, kind }`. `namespace` undefined ⇒
+  bare names (user); set ⇒ logical name `${namespace}:${entry}` mapping to file
   `<dir>/<entry>.md`. It owns an **FS-only** `new TemplateEngine([dir])`
   (`useEmbedded:false`). `render(name)` = `engine.render('<entry>.md', context)`
   (source-scoped → its own `@sections`). `parse` reads `<dir>/<entry>.md` + the
-  shared `parseFileContent` helper (extract the existing matter+schema+resolveMcpPaths
-  into a module function if not already). `resourceDir(name,kind)` =
-  `<dir>/<entry>/<kind>` if it exists else `null`. `displayPath` = `<dir>/<entry>.md`.
+  shared `parseFileContent` helper (extract the existing
+  matter+schema+resolveMcpPaths into a module function if not already).
+  `resourceDir(name,kind)` = `<dir>/<entry>/<kind>` if it exists else `null`.
+  `displayPath` = `<dir>/<entry>.md`.
 - `BundledSource`: keep the existing embedded/bundled loader, but its
-  `TemplateEngine` is `new TemplateEngine([bundledPersonasPath], { useEmbedded: true })`.
-  `resourceDir` returns `null` (embedded ⇒ no real FS dir) unless the bundled path
-  is a real dir on disk; return the real path when it exists, else `null`.
+  `TemplateEngine` is
+  `new TemplateEngine([bundledPersonasPath], { useEmbedded: true })`.
+  `resourceDir` returns `null` (embedded ⇒ no real FS dir) unless the bundled
+  path is a real dir on disk; return the real path when it exists, else `null`.
 - Delete the in-memory `PluginSource` entirely.
 
 - [ ] **Step 4: Wire sources + plugin dirs in `PersonaRegistry`.**
-  - Build `sources` in order: user `FileDirSource`s (from `userPersonasPaths`, no
-    namespace) → plugin `FileDirSource`s (from `personaDirs()` in `@lace/agent/plugins`,
-    each with its `namespace`) → `BundledSource`. Preserve the kata-#55 rescan guard
-    for the USER dirs only (plugin dirs are static — scan once).
-  - `parsePersona`/`hasPersona`/`listAvailablePersonas`: iterate sources first-match,
-    same as today (precedence by order).
+  - Build `sources` in order: user `FileDirSource`s (from `userPersonasPaths`,
+    no namespace) → plugin `FileDirSource`s (from `personaDirs()` in
+    `@lace/agent/plugins`, each with its `namespace`) → `BundledSource`.
+    Preserve the kata-#55 rescan guard for the USER dirs only (plugin dirs are
+    static — scan once).
+  - `parsePersona`/`hasPersona`/`listAvailablePersonas`: iterate sources
+    first-match, same as today (precedence by order).
   - Add `renderPersona(name, context)`: first source with `has(name)` →
     `source.render(name, context)`; else throw `PersonaNotFoundError`.
-  - Add `personaToolsDir(name)` = first matching source's `resourceDir(name,'tools')`;
-    `personaSkillsDir(name)` likewise for `'skills'`.
-  - `PersonaInfo.path` = `source.displayPath(name)` (real path; no `plugin:` sentinel).
+  - Add `personaToolsDir(name)` = first matching source's
+    `resourceDir(name,'tools')`; `personaSkillsDir(name)` likewise for
+    `'skills'`.
+  - `PersonaInfo.path` = `source.displayPath(name)` (real path; no `plugin:`
+    sentinel).
 
-- [ ] **Step 5: Run test, verify pass.** `cd packages/agent && npx vitest run src/config/__tests__/persona-registry-filedir.test.ts` — Expected: PASS.
+- [ ] **Step 5: Run test, verify pass.**
+      `cd packages/agent && npx vitest run src/config/__tests__/persona-registry-filedir.test.ts`
+      — Expected: PASS.
 
 - [ ] **Step 6: Commit**
 
@@ -393,46 +496,58 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 ### Task 0.4: `PromptManager` renders via `renderPersona`
 
 **Files:**
-- Modify: `src/config/prompt-manager.ts`
-- Test: `src/config/__tests__/persona-rendering-characterization.test.ts` (rewrite — see Task 0.6)
 
-- [ ] **Step 1:** In `prompt-manager.ts:generateSystemPrompt`, replace the current
-  `getPersonaPath` + `plugin:` sniff + `render`/`renderString` branch with:
+- Modify: `src/config/prompt-manager.ts`
+- Test: `src/config/__tests__/persona-rendering-characterization.test.ts`
+  (rewrite — see Task 0.6)
+
+- [ ] **Step 1:** In `prompt-manager.ts:generateSystemPrompt`, replace the
+      current `getPersonaPath` + `plugin:` sniff + `render`/`renderString`
+      branch with:
 
 ```ts
-      this.personaRegistry.validatePersona(persona);
-      const context = await this.variableManager.getTemplateContext();
-      const prompt = this.personaRegistry.renderPersona(persona, context);
+this.personaRegistry.validatePersona(persona);
+const context = await this.variableManager.getTemplateContext();
+const prompt = this.personaRegistry.renderPersona(persona, context);
 ```
 
-  Remove the now-unused `getPersonaPath` call and the `isPluginPersona` branch.
-  (The PromptManager no longer owns persona rendering; the registry does, source-scoped.)
+Remove the now-unused `getPersonaPath` call and the `isPluginPersona` branch.
+(The PromptManager no longer owns persona rendering; the registry does,
+source-scoped.)
 
-- [ ] **Step 2: Run** `cd packages/agent && npx vitest run src/config/prompt-manager.test.ts` — fix any breaks from the signature change (the persona-plugin in-memory cases are rewritten in Task 0.6).
+- [ ] **Step 2: Run**
+      `cd packages/agent && npx vitest run src/config/prompt-manager.test.ts` —
+      fix any breaks from the signature change (the persona-plugin in-memory
+      cases are rewritten in Task 0.6).
 
-- [ ] **Step 3: Commit** `git commit src/config/prompt-manager.ts -m "refactor(prompt-manager): render personas via PersonaRegistry.renderPersona  \n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"`
+- [ ] **Step 3: Commit**
+      `git commit src/config/prompt-manager.ts -m "refactor(prompt-manager): render personas via PersonaRegistry.renderPersona  \n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"`
 
 ---
 
 ### Task 0.5: Convert example plugins to dir contributions
 
 **Files:**
-- Modify: `src/plugins/__examples__/reference-plugin.ts`, `persona-plugin.ts`, `incident-responder-plugin.ts`
-- Create: persona `.md` dirs under `src/plugins/__examples__/<plugin>-personas/`
-- Modify: the `:`-tool-name change in `reference-plugin.ts` (`reference/greet`→`reference:greet`, etc.)
 
-- [ ] **Step 1:** For each example that registered an in-memory persona, create a
-  sibling dir with `<entry>.md` and call `api.personas.addDir(<absdir>)` in
-  `register`. E.g. `reference-plugin.ts`: create
-  `src/plugins/__examples__/reference-personas/scout.md` containing the old
-  `scoutPersona.body` (+ frontmatter for its config), and replace
-  `api.personas.register('reference/scout', …)` with
-  `api.personas.addDir(path.join(__dirname, 'reference-personas'))`. Drop the
-  `PersonaDef` import.
-- [ ] **Step 2:** Change `/`→`:` in all registered tool/strategy/runtime names in
-  these examples (`reference:greet`, `reference:quiet`, `reference:mem`) and the
-  packaging comment (`<namespace>:<entry>`).
-- [ ] **Step 3: Typecheck** `cd packages/agent && npx tsc --noEmit -p .` — these files clean.
+- Modify: `src/plugins/__examples__/reference-plugin.ts`, `persona-plugin.ts`,
+  `incident-responder-plugin.ts`
+- Create: persona `.md` dirs under `src/plugins/__examples__/<plugin>-personas/`
+- Modify: the `:`-tool-name change in `reference-plugin.ts`
+  (`reference/greet`→`reference:greet`, etc.)
+
+- [ ] **Step 1:** For each example that registered an in-memory persona, create
+      a sibling dir with `<entry>.md` and call `api.personas.addDir(<absdir>)`
+      in `register`. E.g. `reference-plugin.ts`: create
+      `src/plugins/__examples__/reference-personas/scout.md` containing the old
+      `scoutPersona.body` (+ frontmatter for its config), and replace
+      `api.personas.register('reference/scout', …)` with
+      `api.personas.addDir(path.join(__dirname, 'reference-personas'))`. Drop
+      the `PersonaDef` import.
+- [ ] **Step 2:** Change `/`→`:` in all registered tool/strategy/runtime names
+      in these examples (`reference:greet`, `reference:quiet`, `reference:mem`)
+      and the packaging comment (`<namespace>:<entry>`).
+- [ ] **Step 3: Typecheck** `cd packages/agent && npx tsc --noEmit -p .` — these
+      files clean.
 - [ ] **Step 4: Commit** the examples.
 
 ---
@@ -440,6 +555,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 ### Task 0.6: Fix all remaining consumers (fixtures + tests)
 
 **Files (the full inventory — verify each by grep):**
+
 - `src/plugins/__fixtures__/{good-plugin,reach-plugin,dup-persona-plugin,loader-probe}.ts`
 - `src/plugins/api.test.ts`, `src/plugins/loader.test.ts`
 - `src/config/__tests__/persona-registry-plugins.test.ts`
@@ -447,21 +563,25 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 - `src/config/__tests__/persona-rendering-characterization.test.ts`
 - `src/plugins/__tests__/whole-system.integration.test.ts`
 
-- [ ] **Step 1: Grep to confirm the set:** `grep -rln "registries.personas\|api.personas.register\|PersonaDef\|personas\.register" src` — every hit not already handled is in this task.
-- [ ] **Step 2:** Convert each fixture/test that registered an in-memory persona to
-  either (a) a fixture persona `.md` dir + `api.personas.addDir`, or (b) drop the
-  persona assertion where it only tested the removed registry. For
-  `whole-system.integration.test.ts`, its premise **inverts** — it currently
-  asserts `parsePersona('reference/scout')` resolves with
-  `bundledPersonasPath:'/nonexistent', userPersonasPaths:[]`. Repoint it at a real
-  fixture persona dir via `addPersonaDir('reference', <fixtureDir>)` and assert
-  `reference:scout`.
+- [ ] **Step 1: Grep to confirm the set:**
+      `grep -rln "registries.personas\|api.personas.register\|PersonaDef\|personas\.register" src`
+      — every hit not already handled is in this task.
+- [ ] **Step 2:** Convert each fixture/test that registered an in-memory persona
+      to either (a) a fixture persona `.md` dir + `api.personas.addDir`, or (b)
+      drop the persona assertion where it only tested the removed registry. For
+      `whole-system.integration.test.ts`, its premise **inverts** — it currently
+      asserts `parsePersona('reference/scout')` resolves with
+      `bundledPersonasPath:'/nonexistent', userPersonasPaths:[]`. Repoint it at
+      a real fixture persona dir via `addPersonaDir('reference', <fixtureDir>)`
+      and assert `reference:scout`.
 - [ ] **Step 3:** Rewrite `persona-rendering-characterization.test.ts` to assert
-  source-scoped rendering through `renderPersona` (user + plugin + bundled), not the
-  deleted `renderString`/`getPersonaPath` path.
+      source-scoped rendering through `renderPersona` (user + plugin + bundled),
+      not the deleted `renderString`/`getPersonaPath` path.
 - [ ] **Step 4: Run the whole config + plugins suites**
-  `cd packages/agent && npx vitest run src/config/ src/plugins/` — Expected: all PASS.
-- [ ] **Step 5: Full typecheck** `cd packages/agent && npx tsc --noEmit -p .` — Expected: clean.
+      `cd packages/agent && npx vitest run src/config/ src/plugins/` — Expected:
+      all PASS.
+- [ ] **Step 5: Full typecheck** `cd packages/agent && npx tsc --noEmit -p .` —
+      Expected: clean.
 - [ ] **Step 6: Commit** all fixtures/tests.
 
 ---
@@ -471,6 +591,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 ### Task 1.1: Export `minimalEnv`; add a sync schema probe
 
 **Files:**
+
 - Modify: `src/tools/exec/run-once.ts`
 - Test: `src/tools/exec/__tests__/run-once-sync.test.ts` (create)
 
@@ -486,14 +607,19 @@ import { join } from 'node:path';
 import { runExecToolSchemaSync, minimalEnv } from '../run-once';
 
 it('minimalEnv exposes a minimal allowlist', () => {
-  expect(Object.keys(minimalEnv())).toEqual(expect.arrayContaining(['PATH', 'HOME']));
+  expect(Object.keys(minimalEnv())).toEqual(
+    expect.arrayContaining(['PATH', 'HOME'])
+  );
 });
 
 it('runs lace-tool-schema synchronously and captures stdout', () => {
   const dir = mkdtempSync(join(tmpdir(), 'exec-'));
   const bin = join(dir, 't.mjs');
-  writeFileSync(bin, `#!/usr/bin/env node
-if (process.argv[2] === 'lace-tool-schema') { process.stdout.write('{"ok":true}'); }`);
+  writeFileSync(
+    bin,
+    `#!/usr/bin/env node
+if (process.argv[2] === 'lace-tool-schema') { process.stdout.write('{"ok":true}'); }`
+  );
   chmodSync(bin, 0o755);
   const res = runExecToolSchemaSync(bin, dir, 5000);
   expect(res.exitCode).toBe(0);
@@ -501,26 +627,42 @@ if (process.argv[2] === 'lace-tool-schema') { process.stdout.write('{"ok":true}'
 });
 ```
 
-- [ ] **Step 2: Run it, verify it fails.** `cd packages/agent && npx vitest run src/tools/exec/__tests__/run-once-sync.test.ts` — Expected: FAIL (exports missing).
+- [ ] **Step 2: Run it, verify it fails.**
+      `cd packages/agent && npx vitest run src/tools/exec/__tests__/run-once-sync.test.ts`
+      — Expected: FAIL (exports missing).
 
-- [ ] **Step 3: Implement.** In `run-once.ts`: change `function minimalEnv` → `export function minimalEnv`. Add:
+- [ ] **Step 3: Implement.** In `run-once.ts`: change `function minimalEnv` →
+      `export function minimalEnv`. Add:
 
 ```ts
 import { spawnSync } from 'node:child_process';
 
-export interface SchemaProbeResult { stdout: string; stderr: string; exitCode: number | null; }
+export interface SchemaProbeResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
 
-export function runExecToolSchemaSync(bin: string, cwd: string, timeoutMs: number): SchemaProbeResult {
+export function runExecToolSchemaSync(
+  bin: string,
+  cwd: string,
+  timeoutMs: number
+): SchemaProbeResult {
   const r = spawnSync(bin, ['lace-tool-schema'], {
-    cwd, env: minimalEnv(), input: '', timeout: timeoutMs, encoding: 'utf-8', killSignal: 'SIGKILL',
+    cwd,
+    env: minimalEnv(),
+    input: '',
+    timeout: timeoutMs,
+    encoding: 'utf-8',
+    killSignal: 'SIGKILL',
   });
   return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', exitCode: r.status };
 }
 ```
 
-> Caveat (document in a comment): `spawnSync` timeout kills only the direct child,
-> not the process group (unlike the async `runExecToolProcess`). Acceptable for
-> trusted one-shot schema probes.
+> Caveat (document in a comment): `spawnSync` timeout kills only the direct
+> child, not the process group (unlike the async `runExecToolProcess`).
+> Acceptable for trusted one-shot schema probes.
 
 - [ ] **Step 4: Run, verify pass.** Expected: PASS.
 - [ ] **Step 5: Commit** `run-once.ts` + the test.
@@ -530,10 +672,15 @@ export function runExecToolSchemaSync(bin: string, cwd: string, timeoutMs: numbe
 ### Task 1.2: `discoverExecToolsSync` (+ aggregate budget); remove async `discoverExecTools`
 
 **Files:**
-- Modify: `src/tools/exec/discover.ts`, `src/tools/exec/exec-tool-adapter.ts`
-- Migrate: `src/tools/exec/__tests__/discover.test.ts`, `workspace-stats.e2e.test.ts`
 
-- [ ] **Step 1: Add a `nameOverride` ctor param to `ExecToolAdapter`** (`exec-tool-adapter.ts`): change the constructor to accept `nameOverride?: string` and set `this.name = nameOverride ?? descriptor.name;` (keep everything else).
+- Modify: `src/tools/exec/discover.ts`, `src/tools/exec/exec-tool-adapter.ts`
+- Migrate: `src/tools/exec/__tests__/discover.test.ts`,
+  `workspace-stats.e2e.test.ts`
+
+- [ ] **Step 1: Add a `nameOverride` ctor param to `ExecToolAdapter`**
+      (`exec-tool-adapter.ts`): change the constructor to accept
+      `nameOverride?: string` and set
+      `this.name = nameOverride ?? descriptor.name;` (keep everything else).
 
 - [ ] **Step 2: Write the failing test** for sync discovery:
 
@@ -549,12 +696,18 @@ import { discoverExecToolsSync } from '../discover';
 it('discovers a valid exec tool and skips a bad one', () => {
   const dir = mkdtempSync(join(tmpdir(), 'disc-'));
   const good = join(dir, 'good.mjs');
-  writeFileSync(good, `#!/usr/bin/env node
-if (process.argv[2]==='lace-tool-schema') process.stdout.write('{"name":"good","description":"d","inputSchema":{"type":"object"}}');`);
+  writeFileSync(
+    good,
+    `#!/usr/bin/env node
+if (process.argv[2]==='lace-tool-schema') process.stdout.write('{"name":"good","description":"d","inputSchema":{"type":"object"}}');`
+  );
   chmodSync(good, 0o755);
   const bad = join(dir, 'bad.mjs');
-  writeFileSync(bad, `#!/usr/bin/env node
-process.exit(3);`);
+  writeFileSync(
+    bad,
+    `#!/usr/bin/env node
+process.exit(3);`
+  );
   chmodSync(bad, 0o755);
 
   const tools = discoverExecToolsSync(dir);
@@ -562,9 +715,12 @@ process.exit(3);`);
 });
 ```
 
-- [ ] **Step 3: Run it, verify it fails.** Expected: FAIL (`discoverExecToolsSync` missing).
+- [ ] **Step 3: Run it, verify it fails.** Expected: FAIL
+      (`discoverExecToolsSync` missing).
 
-- [ ] **Step 4: Implement `discoverExecToolsSync`** in `discover.ts` (mirror the async one's skip-bad logic, using `runExecToolSchemaSync`, with an aggregate budget):
+- [ ] **Step 4: Implement `discoverExecToolsSync`** in `discover.ts` (mirror the
+      async one's skip-bad logic, using `runExecToolSchemaSync`, with an
+      aggregate budget):
 
 ```ts
 import { readdirSync, statSync } from 'node:fs';
@@ -578,41 +734,66 @@ const PER_BINARY_MS = 5000;
 const TOTAL_BUDGET_MS = 30000;
 const MAX_BINARIES = 64;
 
-export function discoverExecToolsSync(dir: string, namePrefix = ''): ExecToolAdapter[] {
+export function discoverExecToolsSync(
+  dir: string,
+  namePrefix = ''
+): ExecToolAdapter[] {
   let entries: string[];
-  try { entries = readdirSync(dir); } catch { return []; }
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
   const out: ExecToolAdapter[] = [];
   const startedAt = Date.now();
   let count = 0;
   for (const entry of entries) {
-    if (count >= MAX_BINARIES) { logger.warn('exectool.discover.cap', { dir, cap: MAX_BINARIES }); break; }
-    if (Date.now() - startedAt > TOTAL_BUDGET_MS) { logger.warn('exectool.discover.budget', { dir }); break; }
+    if (count >= MAX_BINARIES) {
+      logger.warn('exectool.discover.cap', { dir, cap: MAX_BINARIES });
+      break;
+    }
+    if (Date.now() - startedAt > TOTAL_BUDGET_MS) {
+      logger.warn('exectool.discover.budget', { dir });
+      break;
+    }
     const bin = join(dir, entry);
     try {
       const st = statSync(bin);
       if (!st.isFile() || (st.mode & 0o111) === 0) continue;
       count++;
-      const { stdout, exitCode } = runExecToolSchemaSync(bin, dir, PER_BINARY_MS);
-      if (exitCode !== 0) { logger.warn('exectool.schema.nonzero', { bin, exitCode }); continue; }
+      const { stdout, exitCode } = runExecToolSchemaSync(
+        bin,
+        dir,
+        PER_BINARY_MS
+      );
+      if (exitCode !== 0) {
+        logger.warn('exectool.schema.nonzero', { bin, exitCode });
+        continue;
+      }
       const desc = parseExecToolDescriptor(stdout);
       const name = namePrefix ? `${namePrefix}${desc.name}` : desc.name;
       out.push(new ExecToolAdapter(bin, desc, name));
     } catch (err) {
-      logger.warn('exectool.discover.skipped', { bin, error: err instanceof Error ? err.message : String(err) });
+      logger.warn('exectool.discover.skipped', {
+        bin,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
   return out;
 }
 ```
 
-  `namePrefix` is `''` for core/per-persona (bare names) and `'<ns>:'` for plugin-global (Phase 2).
+`namePrefix` is `''` for core/per-persona (bare names) and `'<ns>:'` for
+plugin-global (Phase 2).
 
 - [ ] **Step 5: Remove the async `discoverExecTools`** and migrate its two tests
-  (`discover.test.ts` → use `discoverExecToolsSync` without `await`;
-  `workspace-stats.e2e.test.ts` → drop the `await`, call sync). Keep the e2e as the
-  real-subprocess exemplar.
+      (`discover.test.ts` → use `discoverExecToolsSync` without `await`;
+      `workspace-stats.e2e.test.ts` → drop the `await`, call sync). Keep the e2e
+      as the real-subprocess exemplar.
 
-- [ ] **Step 6: Run** `cd packages/agent && npx vitest run src/tools/exec/` — Expected: all PASS. Typecheck clean.
+- [ ] **Step 6: Run** `cd packages/agent && npx vitest run src/tools/exec/` —
+      Expected: all PASS. Typecheck clean.
 - [ ] **Step 7: Commit** the exec dir changes + migrated tests.
 
 ---
@@ -622,6 +803,7 @@ export function discoverExecToolsSync(dir: string, namePrefix = ''): ExecToolAda
 ### Task 2.1: `registerCoreExecTools` + `registerExecDirInto` + `api.tools.registerExecDir`
 
 **Files:**
+
 - Create: `src/tools/exec/register-exec.ts`
 - Modify: `src/plugins/api.ts`
 - Test: `src/tools/exec/__tests__/register-exec.test.ts` (create)
@@ -641,8 +823,11 @@ import { registerExecDirInto, registerCoreExecTools } from '../register-exec';
 function toolDir(name: string): string {
   const dir = mkdtempSync(join(tmpdir(), 'xt-'));
   const bin = join(dir, `${name}.mjs`);
-  writeFileSync(bin, `#!/usr/bin/env node
-if (process.argv[2]==='lace-tool-schema') process.stdout.write('{"name":"${name}","description":"d","inputSchema":{"type":"object"}}');`);
+  writeFileSync(
+    bin,
+    `#!/usr/bin/env node
+if (process.argv[2]==='lace-tool-schema') process.stdout.write('{"name":"${name}","description":"d","inputSchema":{"type":"object"}}');`
+  );
   chmodSync(bin, 0o755);
   return dir;
 }
@@ -657,7 +842,9 @@ describe('register-exec', () => {
   });
 
   it('registerCoreExecTools no-ops when the core dir is absent', () => {
-    expect(() => registerCoreExecTools('/nonexistent/agent-exec-tools')).not.toThrow();
+    expect(() =>
+      registerCoreExecTools('/nonexistent/agent-exec-tools')
+    ).not.toThrow();
   });
 });
 ```
@@ -674,7 +861,10 @@ import { registries } from '@lace/agent/plugins';
 import { logger } from '@lace/agent/utils/logger';
 import { discoverExecToolsSync } from './discover';
 
-export function registerExecDirInto(dir: string, opts: { namespace?: string; owner: string }): void {
+export function registerExecDirInto(
+  dir: string,
+  opts: { namespace?: string; owner: string }
+): void {
   if (!existsSync(dir)) return; // FS-only; absent → no-op
   const prefix = opts.namespace ? `${opts.namespace}:` : '';
   for (const tool of discoverExecToolsSync(dir, prefix)) {
@@ -692,7 +882,8 @@ export function registerCoreExecTools(coreDir: string): void {
 ```
 
 - [ ] **Step 4: Add `api.tools.registerExecDir`** in `api.ts` — extend the tools
-  registrar object so a plugin can call it, injecting `meta.namespace`/`meta.name`:
+      registrar object so a plugin can call it, injecting
+      `meta.namespace`/`meta.name`:
 
 ```ts
     tools: {
@@ -701,11 +892,13 @@ export function registerCoreExecTools(coreDir: string): void {
     },
 ```
 
-  (Update the `PluginRegistrar`/`PluginApi` tool type to include
-  `registerExecDir(dir: string): void`. Import `registerExecDirInto` from
-  `@lace/agent/tools/exec/register-exec`.)
+(Update the `PluginRegistrar`/`PluginApi` tool type to include
+`registerExecDir(dir: string): void`. Import `registerExecDirInto` from
+`@lace/agent/tools/exec/register-exec`.)
 
-- [ ] **Step 5: Run, verify pass.** `cd packages/agent && npx vitest run src/tools/exec/__tests__/register-exec.test.ts` — Expected: PASS.
+- [ ] **Step 5: Run, verify pass.**
+      `cd packages/agent && npx vitest run src/tools/exec/__tests__/register-exec.test.ts`
+      — Expected: PASS.
 - [ ] **Step 6: Commit.**
 
 ---
@@ -713,12 +906,21 @@ export function registerCoreExecTools(coreDir: string): void {
 ### Task 2.2: Boot wiring
 
 **Files:**
+
 - Modify: `src/main.ts`
 - Test: extend `src/plugins/__tests__/whole-system.integration.test.ts`
 
-- [ ] **Step 1:** In `main.ts boot()`, add `registerCoreExecTools(<coreDir>)` immediately after `registerBuiltinTools()` and before `loadPlugins(...)`. Resolve the core dir as the FS path `packages/agent/config/agent-exec-tools` via the existing resource-path helper for dev, falling back to no-op when absent. (Create an empty `config/agent-exec-tools/.gitkeep` so the dir exists.)
-- [ ] **Step 2:** Extend the whole-system integration test: a fixture plugin calls `api.tools.registerExecDir(<dir>)`; after `loadPlugins`, assert `registries.tools.has('<ns>:<tool>')` and a `ToolExecutor` surfaces it.
-- [ ] **Step 3: Run** the integration test + `src/main` smoke if present. Commit.
+- [ ] **Step 1:** In `main.ts boot()`, add `registerCoreExecTools(<coreDir>)`
+      immediately after `registerBuiltinTools()` and before `loadPlugins(...)`.
+      Resolve the core dir as the FS path
+      `packages/agent/config/agent-exec-tools` via the existing resource-path
+      helper for dev, falling back to no-op when absent. (Create an empty
+      `config/agent-exec-tools/.gitkeep` so the dir exists.)
+- [ ] **Step 2:** Extend the whole-system integration test: a fixture plugin
+      calls `api.tools.registerExecDir(<dir>)`; after `loadPlugins`, assert
+      `registries.tools.has('<ns>:<tool>')` and a `ToolExecutor` surfaces it.
+- [ ] **Step 3: Run** the integration test + `src/main` smoke if present.
+      Commit.
 
 ---
 
@@ -727,6 +929,7 @@ export function registerCoreExecTools(coreDir: string): void {
 ### Task 3.1: `injectPersonaTools` with override guard
 
 **Files:**
+
 - Modify: `src/tools/executor.ts`
 - Test: `src/tools/executor.persona-tools.test.ts` (create)
 
@@ -745,16 +948,23 @@ import { registerBuiltinTools } from './builtins';
 
 function personaToolsDir(name: string): string {
   const root = mkdtempSync(join(tmpdir(), 'pt-'));
-  const td = join(root, 'tools'); mkdirSync(td, { recursive: true });
+  const td = join(root, 'tools');
+  mkdirSync(td, { recursive: true });
   const bin = join(td, `${name}.mjs`);
-  writeFileSync(bin, `#!/usr/bin/env node
-if (process.argv[2]==='lace-tool-schema') process.stdout.write('{"name":"${name}","description":"d","inputSchema":{"type":"object"}}');`);
+  writeFileSync(
+    bin,
+    `#!/usr/bin/env node
+if (process.argv[2]==='lace-tool-schema') process.stdout.write('{"name":"${name}","description":"d","inputSchema":{"type":"object"}}');`
+  );
   chmodSync(bin, 0o755);
   return td;
 }
 
 describe('injectPersonaTools', () => {
-  beforeEach(() => { resetRegistriesForTest(); registerBuiltinTools(); });
+  beforeEach(() => {
+    resetRegistriesForTest();
+    registerBuiltinTools();
+  });
 
   it('injects a per-persona tool and refuses to override a builtin', () => {
     const ex = new ToolExecutor();
@@ -770,7 +980,8 @@ describe('injectPersonaTools', () => {
 });
 ```
 
-- [ ] **Step 2: Run, verify fail.** Expected: FAIL (`injectPersonaTools` missing).
+- [ ] **Step 2: Run, verify fail.** Expected: FAIL (`injectPersonaTools`
+      missing).
 
 - [ ] **Step 3: Implement `injectPersonaTools`** on `ToolExecutor`:
 
@@ -792,8 +1003,8 @@ import { LACE_BUILTIN_TOOL_NAMES } from './builtins'; // verify exact export loc
   }
 ```
 
-> `registerTool` is a bare `Map.set` (override is automatic). The guard is the only
-> new logic. Confirm the exact name/location of `LACE_BUILTIN_TOOL_NAMES`.
+> `registerTool` is a bare `Map.set` (override is automatic). The guard is the
+> only new logic. Confirm the exact name/location of `LACE_BUILTIN_TOOL_NAMES`.
 
 - [ ] **Step 4: Run, verify pass.** Commit.
 
@@ -804,31 +1015,41 @@ import { LACE_BUILTIN_TOOL_NAMES } from './builtins'; // verify exact export loc
 ### Task 4.1: Thread persona into `createToolExecutorForMode`
 
 **Files:**
+
 - Modify: `src/server.ts`, `src/server-types.ts`
-- Modify handlers: `src/rpc/handlers/tools.ts`, `session.ts`, `session-operations.ts`, `prompt.ts`
+- Modify handlers: `src/rpc/handlers/tools.ts`, `session.ts`,
+  `session-operations.ts`, `prompt.ts`
 - Test: `src/server.persona-executor.test.ts` (create)
 
 > Read each call site. **Source of truth per site:**
-> - `composeAndWriteSystemPromptSet` callers (session/new `session.ts`~557, fork `session.ts`~781, `/clear` `slash-commands.ts`~229): pass the **existing `persona` param** through; do NOT read `state.activeSession`.
-> - `tools.ts`, `session-operations.ts` (two builds): `state.activeSession.meta.persona ?? 'lace'`.
-> - `prompt.ts` cached wrapper: `state.activeSession.meta.persona ?? 'lace'` (closure).
+>
+> - `composeAndWriteSystemPromptSet` callers (session/new `session.ts`~557, fork
+>   `session.ts`~781, `/clear` `slash-commands.ts`~229): pass the **existing
+>   `persona` param** through; do NOT read `state.activeSession`.
+> - `tools.ts`, `session-operations.ts` (two builds):
+>   `state.activeSession.meta.persona ?? 'lace'`.
+> - `prompt.ts` cached wrapper: `state.activeSession.meta.persona ?? 'lace'`
+>   (closure).
 > - `initialize.ts`: none.
 
-- [ ] **Step 1:** Add `activePersona?: string` (or `personaToolsDir?: string`) to
-  `createToolExecutorForMode` (`server.ts`) and `CreateToolExecutorFn`
-  (`server-types.ts`). Inside `createToolExecutorForMode`, after
-  `executor.registerAllAvailableTools(...)` and **before** `toolsForProvider` is
-  computed, call `executor.injectPersonaTools(personaRegistry.personaToolsDir(activePersona))`
-  when `activePersona` is set. Do NOT change the runner's separate 5-param
-  `createToolExecutor` type; the runtime path injects via the `prompt.ts` wrapper.
+- [ ] **Step 1:** Add `activePersona?: string` (or `personaToolsDir?: string`)
+      to `createToolExecutorForMode` (`server.ts`) and `CreateToolExecutorFn`
+      (`server-types.ts`). Inside `createToolExecutorForMode`, after
+      `executor.registerAllAvailableTools(...)` and **before**
+      `toolsForProvider` is computed, call
+      `executor.injectPersonaTools(personaRegistry.personaToolsDir(activePersona))`
+      when `activePersona` is set. Do NOT change the runner's separate 5-param
+      `createToolExecutor` type; the runtime path injects via the `prompt.ts`
+      wrapper.
 
-- [ ] **Step 2: Write a test** asserting `createToolExecutorForMode(..., { activePersona })`
-  surfaces the persona's `<persona>/tools/` tool in `toolsForProvider`, and that the
-  advertised list equals the executor's tools.
+- [ ] **Step 2: Write a test** asserting
+      `createToolExecutorForMode(..., { activePersona })` surfaces the persona's
+      `<persona>/tools/` tool in `toolsForProvider`, and that the advertised
+      list equals the executor's tools.
 
-- [ ] **Step 3:** Update each call site to pass the persona per the source-of-truth
-  table above. `composeAndWriteSystemPromptSet` gains an executor build that uses its
-  `persona` param.
+- [ ] **Step 3:** Update each call site to pass the persona per the
+      source-of-truth table above. `composeAndWriteSystemPromptSet` gains an
+      executor build that uses its `persona` param.
 
 - [ ] **Step 4: Run** the rpc-handler tests + the new test. Typecheck. Commit.
 
@@ -839,6 +1060,7 @@ import { LACE_BUILTIN_TOOL_NAMES } from './builtins'; // verify exact export loc
 ### Task 5.1: `composeSkillDirs`
 
 **Files:**
+
 - Create: `src/skills/compose-skill-dirs.ts`
 - Test: `src/skills/__tests__/compose-skill-dirs.test.ts` (create)
 
@@ -859,9 +1081,14 @@ describe('composeSkillDirs', () => {
     const dirs = composeSkillDirs(
       { skillDirs: ['/embedder/skills'] },
       '/persona/skills', // resolved per-persona skills dir
-      { coreDir: '/core/skills' },
+      { coreDir: '/core/skills' }
     );
-    expect(dirs).toEqual(['/persona/skills', '/plugin/skills', '/core/skills', '/embedder/skills']);
+    expect(dirs).toEqual([
+      '/persona/skills',
+      '/plugin/skills',
+      '/core/skills',
+      '/embedder/skills',
+    ]);
   });
 
   it('omits a null persona dir and an absent core dir', () => {
@@ -884,7 +1111,7 @@ import { skillDirs as pluginSkillDirs } from '@lace/agent/plugins';
 export function composeSkillDirs(
   source: { skillDirs?: string[]; workDirSkillDirs?: string[] },
   personaSkillsDir: string | null,
-  opts: { coreDir?: string },
+  opts: { coreDir?: string }
 ): string[] {
   const out: string[] = [];
   if (personaSkillsDir) out.push(personaSkillsDir);
@@ -896,9 +1123,10 @@ export function composeSkillDirs(
 }
 ```
 
-> At the call sites, the embedder tier is `state.skillDirs ?? getSkillDirectories(workDir)`
-> — pass the resolved array in as `source.skillDirs`. `coreDir` is the FS
-> `agent-skills/` path when present, else omitted.
+> At the call sites, the embedder tier is
+> `state.skillDirs ?? getSkillDirectories(workDir)` — pass the resolved array in
+> as `source.skillDirs`. `coreDir` is the FS `agent-skills/` path when present,
+> else omitted.
 
 - [ ] **Step 4: Run, verify pass.** Commit.
 
@@ -906,12 +1134,16 @@ export function composeSkillDirs(
 
 ### Task 5.2: Cross-source shadow `warn` in `SkillRegistry`
 
-**Files:** Modify `src/skills/registry.ts`; test `src/skills/registry.shadow.test.ts`.
+**Files:** Modify `src/skills/registry.ts`; test
+`src/skills/registry.shadow.test.ts`.
 
-- [ ] **Step 1: Test** that registering two dirs with a same-named skill keeps the first and emits a `warn` (capture the logger). The skill-name == dir-name rule means the dir name collides; assert first-wins + a warn-level log.
+- [ ] **Step 1: Test** that registering two dirs with a same-named skill keeps
+      the first and emits a `warn` (capture the logger). The skill-name ==
+      dir-name rule means the dir name collides; assert first-wins + a
+      warn-level log.
 - [ ] **Step 2:** In `loadSkillFromDirectory`, where it currently skips an
-  already-registered name at `debug`, change the shadow log to `logger.warn` with
-  both `skillDir`s. (Keep first-wins behavior.)
+      already-registered name at `debug`, change the shadow log to `logger.warn`
+      with both `skillDir`s. (Keep first-wins behavior.)
 - [ ] **Step 3: Run, commit.**
 
 ---
@@ -920,8 +1152,9 @@ export function composeSkillDirs(
 
 **Files:** Modify `src/rpc/handlers/{session,prompt,tools}.ts`.
 
-- [ ] **Step 1:** At each of the three sites that build `new SkillRegistry({ skillDirs })`,
-  replace the `skillDirs` computation with:
+- [ ] **Step 1:** At each of the three sites that build
+      `new SkillRegistry({ skillDirs })`, replace the `skillDirs` computation
+      with:
 
 ```ts
 const personaSkillsDir = personaRegistry.personaSkillsDir(<activePersona>);
@@ -932,17 +1165,18 @@ const skillDirs = composeSkillDirs(
 );
 ```
 
-  `<activePersona>` per the Phase-4 source-of-truth table (the `persona` param at
-  `composeAndWriteSystemPromptSet`; `state.activeSession.meta.persona ?? 'lace'` at
-  `tools.ts`).
+`<activePersona>` per the Phase-4 source-of-truth table (the `persona` param at
+`composeAndWriteSystemPromptSet`; `state.activeSession.meta.persona ?? 'lace'`
+at `tools.ts`).
 
-- [ ] **Step 2: Do NOT touch `getSubagentHostSkillDirs`** (`subagent-job.ts`) — it
-  keeps shipping the raw `state.skillDirs ?? getSkillDirectories(workDir)`; the child
-  re-composes. Add a one-line comment there stating this is intentional.
+- [ ] **Step 2: Do NOT touch `getSubagentHostSkillDirs`** (`subagent-job.ts`) —
+      it keeps shipping the raw
+      `state.skillDirs ?? getSkillDirectories(workDir)`; the child re-composes.
+      Add a one-line comment there stating this is intentional.
 - [ ] **Step 3: Test** (e2e-ish): a persona with a `<persona>/skills/` skill →
-  the per-session `SkillRegistry` (built via the handler path) lists it for that
-  persona and not for another; an embedder `state.skillDirs` still layers
-  plugin/persona skills on top.
+      the per-session `SkillRegistry` (built via the handler path) lists it for
+      that persona and not for another; an embedder `state.skillDirs` still
+      layers plugin/persona skills on top.
 - [ ] **Step 4: Run** the handler/skill tests. Typecheck. Commit.
 
 ---
@@ -951,12 +1185,23 @@ const skillDirs = composeSkillDirs(
 
 ### Task 6.1: Update plugin/persona docs
 
-**Files:** `docs/reference/plugins.md`, `docs/writing-plugins.md`, `docs/external-tools.md`, `docs/building-agents-on-lace.md`, `docs/agent-personas.md`.
+**Files:** `docs/reference/plugins.md`, `docs/writing-plugins.md`,
+`docs/external-tools.md`, `docs/building-agents-on-lace.md`,
+`docs/agent-personas.md`.
 
-- [ ] **Step 1:** `reference/plugins.md` — remove `api.personas.register`/`PersonaDef`/`registries.personas` and the `PersonaDef` section; document `api.personas.addDir` + `api.skills.addDir` + `api.tools.registerExecDir`; change the namespacing rule `<ns>/<entry>` → `<ns>:<entry>`.
-- [ ] **Step 2:** `writing-plugins.md` + `external-tools.md` — add skills, the `<persona>/tools|skills/` convention, `:`-namespacing; correct `/`→`:` in tool examples.
-- [ ] **Step 3:** `building-agents-on-lace.md` — update genuine plugin tool-name refs to `:`; **leave MCP `<server>/<tool>` slash names** (e.g. `knowledge/grep`).
-- [ ] **Step 4:** `agent-personas.md` — add the `api.personas.addDir` + `<persona>/tools|skills/` convention.
+- [ ] **Step 1:** `reference/plugins.md` — remove
+      `api.personas.register`/`PersonaDef`/`registries.personas` and the
+      `PersonaDef` section; document `api.personas.addDir` +
+      `api.skills.addDir` + `api.tools.registerExecDir`; change the namespacing
+      rule `<ns>/<entry>` → `<ns>:<entry>`.
+- [ ] **Step 2:** `writing-plugins.md` + `external-tools.md` — add skills, the
+      `<persona>/tools|skills/` convention, `:`-namespacing; correct `/`→`:` in
+      tool examples.
+- [ ] **Step 3:** `building-agents-on-lace.md` — update genuine plugin tool-name
+      refs to `:`; **leave MCP `<server>/<tool>` slash names** (e.g.
+      `knowledge/grep`).
+- [ ] **Step 4:** `agent-personas.md` — add the `api.personas.addDir` +
+      `<persona>/tools|skills/` convention.
 - [ ] **Step 5: Commit.**
 
 ---
@@ -965,16 +1210,32 @@ const skillDirs = composeSkillDirs(
 
 - [ ] `cd packages/agent && npx tsc --noEmit -p .` — clean.
 - [ ] `cd packages/agent && npx eslint src --ext .ts` — clean (or `--fix`).
-- [ ] `cd packages/agent && npm test` — full suite green (no regressions; was ~3330 tests).
-- [ ] Grep: no `registries.personas` / `api.personas.register` / `PersonaDef` / `renderString`-for-personas / `discoverExecTools(`-async remain.
-- [ ] Grep: no plugin `<ns>/<entry>` tool names remain (only MCP `<server>/<tool>` slash names).
+- [ ] `cd packages/agent && npm test` — full suite green (no regressions; was
+      ~3330 tests).
+- [ ] Grep: no `registries.personas` / `api.personas.register` / `PersonaDef` /
+      `renderString`-for-personas / `discoverExecTools(`-async remain.
+- [ ] Grep: no plugin `<ns>/<entry>` tool names remain (only MCP
+      `<server>/<tool>` slash names).
 
 # Self-review (author checklist — done)
 
-- **Spec coverage:** Part 0 → Tasks 0.1–0.6; Part 1 → 1.1–1.2; Part 2 → 2.1–2.2; Part 3 → 3.1; Part 4 → 4.1; Part 5 → 5.1–5.3; docs → 6.1. The TemplateEngine opt-in (the round-3 render fix) is Task 0.1; per-site persona source-of-truth (round-3 Part 4 fix) is Task 4.1's table; the subagent-stays-raw rule is Task 5.3 Step 2.
-- **Type consistency:** `personaToolsDir`/`personaSkillsDir`/`renderPersona`/`resourceDir` (Task 0.3) are used in 3.1/4.1/5.3; `discoverExecToolsSync(dir, namePrefix)` (1.2) is used in 2.1/3.1; `ExecToolAdapter` `nameOverride` (1.2) used by 1.2; `composeSkillDirs` signature (5.1) used in 5.3; `addPersonaDir/personaDirs/addSkillDir/skillDirs/resetContributedDirsForTest` (0.2) used across.
-- **Open (settle while implementing):** within-source duplicate exec-tool name → warn-and-skip (discovery already skips dup descriptor names per the bad-binary path; confirm). Built-ins stay bare.
+- **Spec coverage:** Part 0 → Tasks 0.1–0.6; Part 1 → 1.1–1.2; Part 2 → 2.1–2.2;
+  Part 3 → 3.1; Part 4 → 4.1; Part 5 → 5.1–5.3; docs → 6.1. The TemplateEngine
+  opt-in (the round-3 render fix) is Task 0.1; per-site persona source-of-truth
+  (round-3 Part 4 fix) is Task 4.1's table; the subagent-stays-raw rule is Task
+  5.3 Step 2.
+- **Type consistency:**
+  `personaToolsDir`/`personaSkillsDir`/`renderPersona`/`resourceDir` (Task 0.3)
+  are used in 3.1/4.1/5.3; `discoverExecToolsSync(dir, namePrefix)` (1.2) is
+  used in 2.1/3.1; `ExecToolAdapter` `nameOverride` (1.2) used by 1.2;
+  `composeSkillDirs` signature (5.1) used in 5.3;
+  `addPersonaDir/personaDirs/addSkillDir/skillDirs/resetContributedDirsForTest`
+  (0.2) used across.
+- **Open (settle while implementing):** within-source duplicate exec-tool name →
+  warn-and-skip (discovery already skips dup descriptor names per the bad-binary
+  path; confirm). Built-ins stay bare.
 
 # Execution handoff
 
-(See top banner.) Phases are ordered by dependency: **Phase 0 first** (blocks 3 & 5), then 1 → 2 → 3 → 4 → 5 → 6. Within a phase, tasks are sequential.
+(See top banner.) Phases are ordered by dependency: **Phase 0 first** (blocks 3
+& 5), then 1 → 2 → 3 → 4 → 5 → 6. Within a phase, tasks are sequential.

--- a/docs/superpowers/plans/2026-06-14-async-only-delegation-plan.md
+++ b/docs/superpowers/plans/2026-06-14-async-only-delegation-plan.md
@@ -1,56 +1,126 @@
 # Async-Only Delegation — Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax.
 
-**Goal:** Remove blocking subagent waits from lace — `delegate` async-only, `job_output` snapshot-only — and rewrite sen-core delegation guidance, so a human-facing agent never goes deaf to its human while a subagent runs.
+**Goal:** Remove blocking subagent waits from lace — `delegate` async-only,
+`job_output` snapshot-only — and rewrite sen-core delegation guidance, so a
+human-facing agent never goes deaf to its human while a subagent runs.
 
-**Architecture:** Delete the sync/blocking code paths (not make them interruptible). Completion is delivered by lace's existing durable notification + always-on fallback. Keep the `ent/job/output` RPC blocking path (no production caller). See spec: `docs/superpowers/specs/2026-06-14-async-only-delegation-design.md`.
+**Architecture:** Delete the sync/blocking code paths (not make them
+interruptible). Completion is delivered by lace's existing durable
+notification + always-on fallback. Keep the `ent/job/output` RPC blocking path
+(no production caller). See spec:
+`docs/superpowers/specs/2026-06-14-async-only-delegation-design.md`.
 
-**Tech Stack:** TypeScript, zod schemas, vitest. Repos: `lace` (`packages/agent`), `sen-core-v2` (`agent-runtime`).
+**Tech Stack:** TypeScript, zod schemas, vitest. Repos: `lace`
+(`packages/agent`), `sen-core-v2` (`agent-runtime`).
 
-**Invariant for every task:** the full suite (`npm test` in the repo) is green at each commit. `bash`'s own `background` param and the exec `run-once` tests are unrelated — do NOT touch them.
+**Invariant for every task:** the full suite (`npm test` in the repo) is green
+at each commit. `bash`'s own `background` param and the exec `run-once` tests
+are unrelated — do NOT touch them.
 
 ---
 
 ### Task 1: `job_output` → snapshot-only
 
 **Files:**
+
 - Modify: `packages/agent/src/tools/implementations/job_output.ts`
 - Test: `packages/agent/src/tools/__tests__/job_output.test.ts`,
   `packages/agent/src/tools/implementations/__tests__/job-tools.test.ts`,
   `packages/agent/src/tools/implementations/__tests__/job_output-clamp.test.ts`
 
-- [ ] **Step 1: Write the failing test** — in `tools/__tests__/job_output.test.ts`, replace the `block`/`timeoutMs` schema tests with: the schema parse of `{ jobId, block: true }` is rejected (unknown key) and `{ jobId }` succeeds; calling the tool on a running job returns immediately with `status:"running"` (no wait).
+- [ ] **Step 1: Write the failing test** — in
+      `tools/__tests__/job_output.test.ts`, replace the `block`/`timeoutMs`
+      schema tests with: the schema parse of `{ jobId, block: true }` is
+      rejected (unknown key) and `{ jobId }` succeeds; calling the tool on a
+      running job returns immediately with `status:"running"` (no wait).
 
 - [ ] **Step 2: Run to verify it fails** — `npm test -- job_output.test` → FAIL.
 
-- [ ] **Step 3: Implement** — in `job_output.ts`: delete `JOB_OUTPUT_MIN_BLOCKING_TIMEOUT_MS` (`:15`); change schema (`:17-22`) to `z.object({ jobId: NonEmptyString, byteOffset: z.number().int().min(0).default(0) }).strict()` (drop `block`, `timeoutMs`); in `executeValidated` delete the blocking branch (`:73-79`) and the `block`/`timeoutMs` destructure — read `jobManager.getJob`/`getJobOutput` directly and return the snapshot. Rewrite the description: snapshot-only, "to wait for completion, subscribe with `job_notify(jobId)` and return — you'll be woken on a later turn."
+- [ ] **Step 3: Implement** — in `job_output.ts`: delete
+      `JOB_OUTPUT_MIN_BLOCKING_TIMEOUT_MS` (`:15`); change schema (`:17-22`) to
+      `z.object({ jobId: NonEmptyString, byteOffset: z.number().int().min(0).default(0) }).strict()`
+      (drop `block`, `timeoutMs`); in `executeValidated` delete the blocking
+      branch (`:73-79`) and the `block`/`timeoutMs` destructure — read
+      `jobManager.getJob`/`getJobOutput` directly and return the snapshot.
+      Rewrite the description: snapshot-only, "to wait for completion, subscribe
+      with `job_notify(jobId)` and return — you'll be woken on a later turn."
 
-- [ ] **Step 4: Fix the now-broken tests** — `job_output-clamp.test.ts` is entirely about the clamp: delete the file. In `job-tools.test.ts`, remove the `block:true` "waits for completion" case (`~:48-86`); keep the `block:false`/snapshot cases (now just `{jobId}`).
+- [ ] **Step 4: Fix the now-broken tests** — `job_output-clamp.test.ts` is
+      entirely about the clamp: delete the file. In `job-tools.test.ts`, remove
+      the `block:true` "waits for completion" case (`~:48-86`); keep the
+      `block:false`/snapshot cases (now just `{jobId}`).
 
-- [ ] **Step 5: Run** — `npm test` → PASS (whole suite; the RPC e2e block tests are untouched and stay green).
+- [ ] **Step 5: Run** — `npm test` → PASS (whole suite; the RPC e2e block tests
+      are untouched and stay green).
 
-- [ ] **Step 6: Commit** — `feat(job_output): snapshot-only, remove blocking wait`.
+- [ ] **Step 6: Commit** —
+      `feat(job_output): snapshot-only, remove blocking wait`.
 
 ---
 
 ### Task 2: `delegate` → async-only (large — includes the full delegate test sweep)
 
 **Files:**
+
 - Modify: `packages/agent/src/tools/implementations/delegate.ts`
 - Modify (fixtures): `packages/agent/src/runtime/test-provider.ts`
-- Test (unit): `tools/implementations/__tests__/delegate.test.ts`, `tools/__tests__/delegate.test.ts`, `tools/__tests__/executor-persona-wiring.test.ts`, `tools/implementations/__tests__/delegate-workspace-lifecycle.test.ts`, `jobs/__tests__/persistent-box-never-reaped.test.ts`, `core/conversation/__tests__/runner.persona-registry.test.ts`, `__tests__/session-new.persona-config.test.ts`, `core/conversation/__tests__/runner.test.ts` (delegate cases only)
-- Test (e2e): `__tests__/agent-process.delegate.e2e.test.ts`, `.subagent.e2e.test.ts`, `.delegate-config.e2e.test.ts`, `.event-seq.e2e.test.ts`, `.jobs.e2e.test.ts`, `.subagent-early-stop.e2e.test.ts`, `.subagent-intent-text-stop.e2e.test.ts`, `credential-integration.e2e.test.ts`
+- Test (unit): `tools/implementations/__tests__/delegate.test.ts`,
+  `tools/__tests__/delegate.test.ts`,
+  `tools/__tests__/executor-persona-wiring.test.ts`,
+  `tools/implementations/__tests__/delegate-workspace-lifecycle.test.ts`,
+  `jobs/__tests__/persistent-box-never-reaped.test.ts`,
+  `core/conversation/__tests__/runner.persona-registry.test.ts`,
+  `__tests__/session-new.persona-config.test.ts`,
+  `core/conversation/__tests__/runner.test.ts` (delegate cases only)
+- Test (e2e): `__tests__/agent-process.delegate.e2e.test.ts`,
+  `.subagent.e2e.test.ts`, `.delegate-config.e2e.test.ts`,
+  `.event-seq.e2e.test.ts`, `.jobs.e2e.test.ts`,
+  `.subagent-early-stop.e2e.test.ts`, `.subagent-intent-text-stop.e2e.test.ts`,
+  `credential-integration.e2e.test.ts`
 
-- [ ] **Step 1: Write the failing test** — in `tools/implementations/__tests__/delegate.test.ts`, add: schema parse of `{ prompt, background: true }` is rejected (unknown key); a `delegate({prompt})` call returns immediately with a result whose JSON contains `"status":"started"` and a `jobId`, WITHOUT awaiting `job.completion` (assert the call resolves before the job's completion promise).
+- [ ] **Step 1: Write the failing test** — in
+      `tools/implementations/__tests__/delegate.test.ts`, add: schema parse of
+      `{ prompt, background: true }` is rejected (unknown key); a
+      `delegate({prompt})` call returns immediately with a result whose JSON
+      contains `"status":"started"` and a `jobId`, WITHOUT awaiting
+      `job.completion` (assert the call resolves before the job's completion
+      promise).
 
 - [ ] **Step 2: Run to verify it fails** — `npm test -- delegate.test` → FAIL.
 
-- [ ] **Step 3: Implement the schema + tool change** — in `delegate.ts`: remove `background: z.boolean().default(false)` from the schema (`:31`); remove `background` from the destructure (`:138`); delete the `if (background)` guard so the async path is unconditional (the existing background return at `~:375-390` becomes the sole return); delete the entire sync-mode block (`:393-428`) — the `abortPromise`, the `Promise.race`, the `delegate jobId=` preamble, and the sync output return. Keep the per_invocation workspace framing that the async return already carries. Rewrite the description (`:80-104`): present the async flow as the only flow; delete the "Sync mode" paragraph and the `background` param doc; fix the `resume` note; remove the `job_output(block=true)` anti-pattern line.
+- [ ] **Step 3: Implement the schema + tool change** — in `delegate.ts`: remove
+      `background: z.boolean().default(false)` from the schema (`:31`); remove
+      `background` from the destructure (`:138`); delete the `if (background)`
+      guard so the async path is unconditional (the existing background return
+      at `~:375-390` becomes the sole return); delete the entire sync-mode block
+      (`:393-428`) — the `abortPromise`, the `Promise.race`, the
+      `delegate jobId=` preamble, and the sync output return. Keep the
+      per_invocation workspace framing that the async return already carries.
+      Rewrite the description (`:80-104`): present the async flow as the only
+      flow; delete the "Sync mode" paragraph and the `background` param doc; fix
+      the `resume` note; remove the `job_output(block=true)` anti-pattern line.
 
-- [ ] **Step 4: Fix unit tests** — convert sync-mode cases in both `delegate.test.ts` files to assert the async started-shape; delete/replace `'accepts background parameter'` and `'defaults background to false'`. Grep `rg "background" packages/agent/src --glob "*.test.ts"` and update every DELEGATE call passing `background` (skip `bash-*`/`run-once`). For tests that relied on inline subagent output, await `job.completion` (or `jobManager.getJob(jobId).completion`) then assert via `getJobOutput`.
+- [ ] **Step 4: Fix unit tests** — convert sync-mode cases in both
+      `delegate.test.ts` files to assert the async started-shape; delete/replace
+      `'accepts background parameter'` and `'defaults background to false'`.
+      Grep `rg "background" packages/agent/src --glob "*.test.ts"` and update
+      every DELEGATE call passing `background` (skip `bash-*`/`run-once`). For
+      tests that relied on inline subagent output, await `job.completion` (or
+      `jobManager.getJob(jobId).completion`) then assert via `getJobOutput`.
 
-- [ ] **Step 5: Fix e2e tests + test-provider** — the test-provider (`runtime/test-provider.ts:~391`) emits `delegate` with no `background`; that's now async. For each e2e test asserting inline output (notably `agent-process.delegate.e2e.test.ts` `toContain("delegate jobId=")` + inline result): restructure to (a) assert the async started return, then (b) drive completion — await the job, or feed a follow-up turn whose fixture consumes the `job-completed` notification and calls `job_output(jobId)` — then assert on that output. Add the follow-up-turn fixtures to the test-provider as needed.
+- [ ] **Step 5: Fix e2e tests + test-provider** — the test-provider
+      (`runtime/test-provider.ts:~391`) emits `delegate` with no `background`;
+      that's now async. For each e2e test asserting inline output (notably
+      `agent-process.delegate.e2e.test.ts` `toContain("delegate jobId=")` +
+      inline result): restructure to (a) assert the async started return, then
+      (b) drive completion — await the job, or feed a follow-up turn whose
+      fixture consumes the `job-completed` notification and calls
+      `job_output(jobId)` — then assert on that output. Add the follow-up-turn
+      fixtures to the test-provider as needed.
 
 - [ ] **Step 6: Run** — `npm test` → PASS (entire suite, e2e included).
 
@@ -61,64 +131,100 @@
 ### Task 3: `job_notify` description + always-on fallback wake test
 
 **Files:**
+
 - Modify: `packages/agent/src/tools/implementations/job_notify.ts`
 - Test: new test near the jobs tests
 
-- [ ] **Step 1: Write the failing test** — assert that when a job finalizes with NO subscription, `fanoutToInject` still invokes the inject closure once (the always-on fallback wakes the parent). Use the existing job-manager test harness pattern (`jobs/__tests__`).
+- [ ] **Step 1: Write the failing test** — assert that when a job finalizes with
+      NO subscription, `fanoutToInject` still invokes the inject closure once
+      (the always-on fallback wakes the parent). Use the existing job-manager
+      test harness pattern (`jobs/__tests__`).
 
-- [ ] **Step 2: Run** — FAIL (or assert current behavior already passes; if it passes, keep it as a regression guard and note so).
+- [ ] **Step 2: Run** — FAIL (or assert current behavior already passes; if it
+      passes, keep it as a regression guard and note so).
 
-- [ ] **Step 3: Implement** — `job_notify.ts:34` references `delegate(..., background=true)`: reword to the async flow ("`delegate(prompt=...)` returns immediately; subscribe here to be woken on terminal/progress"). No behavior change to the fallback (it already works — this test locks it in).
+- [ ] **Step 3: Implement** — `job_notify.ts:34` references
+      `delegate(..., background=true)`: reword to the async flow
+      ("`delegate(prompt=...)` returns immediately; subscribe here to be woken
+      on terminal/progress"). No behavior change to the fallback (it already
+      works — this test locks it in).
 
 - [ ] **Step 4: Run** — `npm test -- job` → PASS.
 
-- [ ] **Step 5: Commit** — `docs(job_notify): async wording; test: lock in no-subscription fallback wake`.
+- [ ] **Step 5: Commit** —
+      `docs(job_notify): async wording; test: lock in no-subscription fallback wake`.
 
 ---
 
 ### Task 4: Hardening — drain pending immediate injects on all turn-exit paths
 
 **Files:**
-- Modify: the turn/prompt runner (`core/conversation/runner.ts` and/or the prompt orchestrator that owns turn exit — grep `hasPendingImmediateInjects` to find the existing success-path re-scan)
+
+- Modify: the turn/prompt runner (`core/conversation/runner.ts` and/or the
+  prompt orchestrator that owns turn exit — grep `hasPendingImmediateInjects` to
+  find the existing success-path re-scan)
 - Test: `core/conversation/__tests__/` (new case)
 
-**Context:** Today the post-turn re-scan that catches an immediate inject written during a turn runs only on the normal turn return. Abort, slash-command, and error exits clear the active turn without re-scanning. Under async-only the job notification is the sole delivery, so a job completing as such a turn ends could be stranded.
+**Context:** Today the post-turn re-scan that catches an immediate inject
+written during a turn runs only on the normal turn return. Abort, slash-command,
+and error exits clear the active turn without re-scanning. Under async-only the
+job notification is the sole delivery, so a job completing as such a turn ends
+could be stranded.
 
-- [ ] **Step 1: Write the failing test** — simulate a job-completion `context_injected` (priority `immediate`) landing while a turn ends via the ABORT/ERROR path; assert a follow-up internal turn is triggered to consume it. (Model the existing success-path re-scan test, e.g. `runner.context-inject.test.ts`.)
+- [ ] **Step 1: Write the failing test** — simulate a job-completion
+      `context_injected` (priority `immediate`) landing while a turn ends via
+      the ABORT/ERROR path; assert a follow-up internal turn is triggered to
+      consume it. (Model the existing success-path re-scan test, e.g.
+      `runner.context-inject.test.ts`.)
 
 - [ ] **Step 2: Run** — FAIL.
 
-- [ ] **Step 3: Implement** — locate the existing `hasPendingImmediateInjects` → internal-turn re-scan on the success return; extract it into a helper and invoke it on the abort, slash-command, and error/`finally` turn-exit paths (guarding against re-entrancy / double turns the same way the success path does).
+- [ ] **Step 3: Implement** — locate the existing `hasPendingImmediateInjects` →
+      internal-turn re-scan on the success return; extract it into a helper and
+      invoke it on the abort, slash-command, and error/`finally` turn-exit paths
+      (guarding against re-entrancy / double turns the same way the success path
+      does).
 
 - [ ] **Step 4: Run** — `npm test -- runner` then full `npm test` → PASS.
 
-- [ ] **Step 5: Commit** — `fix(runner): drain pending immediate injects on abort/error turn exits`.
+- [ ] **Step 5: Commit** —
+      `fix(runner): drain pending immediate injects on abort/error turn exits`.
 
 ---
 
 ### Task 5 (optional, include if cheap): Reconcile orphaned running jobs on session restore
 
 **Files:**
-- Modify: session restore path (grep where `applyRunningStatus` / session open runs)
+
+- Modify: session restore path (grep where `applyRunningStatus` / session open
+  runs)
 - Test: jobs/session restore test
 
-- [ ] **Step 1: Write the failing test** — a session whose event log has a `running` job with no live process, on restore, injects a `job-failed` notification for it.
+- [ ] **Step 1: Write the failing test** — a session whose event log has a
+      `running` job with no live process, on restore, injects a `job-failed`
+      notification for it.
 
 - [ ] **Step 2: Run** — FAIL.
 
-- [ ] **Step 3: Implement** — on session restore, for each event-log `running` job absent from the live map, finalize-as-failed and inject `job-failed` (reuse the notification composer). Idempotent.
+- [ ] **Step 3: Implement** — on session restore, for each event-log `running`
+      job absent from the live map, finalize-as-failed and inject `job-failed`
+      (reuse the notification composer). Idempotent.
 
 - [ ] **Step 4: Run** — PASS.
 
-- [ ] **Step 5: Commit** — `fix(jobs): wake parent for orphaned running jobs on restore`.
+- [ ] **Step 5: Commit** —
+      `fix(jobs): wake parent for orphaned running jobs on restore`.
 
-> If this proves more than ~1 task of work, SKIP it and instead ensure the guidance (Task 6) documents `jobs_list` recovery after a restart. Note the decision in the commit/PR.
+> If this proves more than ~1 task of work, SKIP it and instead ensure the
+> guidance (Task 6) documents `jobs_list` recovery after a restart. Note the
+> decision in the commit/PR.
 
 ---
 
 ### Task 6: sen-core delegation guidance rewrite
 
 **Files (sen-core-v2):**
+
 - `agent-runtime/user/core_identity/instructions/delegating-to-subagents.md`
 - `agent-runtime/system/sen-core/skills/innate/delegating-to-subagents/SKILL.md`
 - `agent-runtime/user/agent-personas/ephemeral-box-worker.md`
@@ -128,18 +234,34 @@
 - `docs/architecture/personas.md`
 - Test: `tests/automated/` (new guidance assertion test)
 
-- [ ] **Step 1: Write the failing test** — a test that greps the two primary guidance files and asserts they do NOT contain `background`, `block=true`, `expected_response`, or `delegate(subagent`, and DO contain the async vocabulary (`job_notify` / "returns immediately" / "single-turn"). (Model on `tests/automated/credential-skills.test.ts`.)
+- [ ] **Step 1: Write the failing test** — a test that greps the two primary
+      guidance files and asserts they do NOT contain `background`, `block=true`,
+      `expected_response`, or `delegate(subagent`, and DO contain the async
+      vocabulary (`job_notify` / "returns immediately" / "single-turn"). (Model
+      on `tests/automated/credential-skills.test.ts`.)
 
 - [ ] **Step 2: Run** — FAIL.
 
-- [ ] **Step 3: Implement** — rewrite the two primary surfaces to teach the async model (dispatch → return to human → woken by `job-completed/failed/cancelled` notification → `job_output(jobId)` snapshot → act), the "silence is not success" rule, and the "subagents are single-turn, cannot delegate-and-wait" constraint, using lace's real params (`prompt`, optional `persona`). In the 4 persona prompts + `personas.md`, replace the drifted `delegate(subagent, task, expected_response)` form with the real call shape and drop the "your turn pauses" framing.
+- [ ] **Step 3: Implement** — rewrite the two primary surfaces to teach the
+      async model (dispatch → return to human → woken by
+      `job-completed/failed/cancelled` notification → `job_output(jobId)`
+      snapshot → act), the "silence is not success" rule, and the "subagents are
+      single-turn, cannot delegate-and-wait" constraint, using lace's real
+      params (`prompt`, optional `persona`). In the 4 persona prompts +
+      `personas.md`, replace the drifted
+      `delegate(subagent, task, expected_response)` form with the real call
+      shape and drop the "your turn pauses" framing.
 
 - [ ] **Step 4: Run** — `npm test` (sen-core) → PASS.
 
-- [ ] **Step 5: Commit** — `docs(sen-core): rewrite delegation guidance for async-only, fix schema drift`.
+- [ ] **Step 5: Commit** —
+      `docs(sen-core): rewrite delegation guidance for async-only, fix schema drift`.
 
 ---
 
 ## Final review
 
-After all tasks: dispatch a final code-quality reviewer over the whole diff in both repos, then build + full test green in each (`npm run typecheck && npm test`), then proceed to deploy + live-verify per the spec's Rollout.
+After all tasks: dispatch a final code-quality reviewer over the whole diff in
+both repos, then build + full test green in each
+(`npm run typecheck && npm test`), then proceed to deploy + live-verify per the
+spec's Rollout.

--- a/docs/superpowers/plans/2026-06-16-thinking-block-round-tripping.md
+++ b/docs/superpowers/plans/2026-06-16-thinking-block-round-tripping.md
@@ -6,11 +6,11 @@ would 400 on tool-use continuations), and surface Ada's thinking in Slack as
 italics.
 
 **Architecture:** Thread a new `ThinkingBlock[]` through the full loop —
-provider response → `message` event → history rebuild → `convertToAnthropicFormat`
-— and emit thinking blocks first in the assistant content array. Enable
-`thinking:{type:'adaptive', display:'summarized'}` gated exactly like reasoning
-effort (so only the opus-4-8 main persona gets it; compaction haiku/sonnet and the
-opus-4-7 arbiter are untouched).
+provider response → `message` event → history rebuild →
+`convertToAnthropicFormat` — and emit thinking blocks first in the assistant
+content array. Enable `thinking:{type:'adaptive', display:'summarized'}` gated
+exactly like reasoning effort (so only the opus-4-8 main persona gets it;
+compaction haiku/sonnet and the opus-4-7 arbiter are untouched).
 
 **Branch:** `feat/opus-4-8-reasoning-effort` (builds on the effort commit; the
 deploy ships effort + thinking + opus-4-8 together).
@@ -20,6 +20,7 @@ deploy ships effort + thinking + opus-4-8 together).
 Anthropic requires thinking blocks (with their opaque `signature`) replayed
 **verbatim** on the assistant turn carrying `tool_use`, in wire order
 `[thinking…, text?, tool_use…]`. Modified thinking blocks 400. So:
+
 - Store thinking blocks exactly (text + signature), no redaction/truncation.
 - `sanitizeLoneSurrogates` must not touch thinking-block fields.
 - Support `redacted_thinking` (`{type, data}`) blocks too — replay verbatim.
@@ -39,51 +40,57 @@ export type ThinkingBlock =
    `ProviderMessage` (908-913).
 
 2. **Anthropic provider** (`anthropic-provider.ts`):
-   - Parse thinking + redacted_thinking from `response.content` / `finalMessage.content`
-     into `response.thinkingBlocks`, preserving order (non-stream ~376-389, stream ~564-576).
-   - Enable `thinking:{type:'adaptive', display:'summarized'}`, gated on the same
-     `reasoningEffort !== undefined` condition already computed for effort.
+   - Parse thinking + redacted_thinking from `response.content` /
+     `finalMessage.content` into `response.thinkingBlocks`, preserving order
+     (non-stream ~376-389, stream ~564-576).
+   - Enable `thinking:{type:'adaptive', display:'summarized'}`, gated on the
+     same `reasoningEffort !== undefined` condition already computed for effort.
    - Test: payload.thinking set for opus-4-8 (catalog effort), absent for haiku
-     (has_reasoning_effort:false); response.thinkingBlocks populated from content.
+     (has_reasoning_effort:false); response.thinkingBlocks populated from
+     content.
 
-3. **Format converter** (`format-converters.ts:122-161`): when `msg.thinkingBlocks`
-   present, unshift them (in order) before text/tool_use in BOTH the tool-call
-   branch and the pure-text branch. Test: thinking block emitted first, signature intact.
+3. **Format converter** (`format-converters.ts:122-161`): when
+   `msg.thinkingBlocks` present, unshift them (in order) before text/tool_use in
+   BOTH the tool-call branch and the pure-text branch. Test: thinking block
+   emitted first, signature intact.
 
 4. **Surrogate guard** (`anthropic/well-formed-json.ts`): confirm/ensure
-   `sanitizeLoneSurrogates` leaves thinking/redacted_thinking blocks byte-identical.
-   Test: a payload with a thinking block whose text has no surrogate is unchanged;
-   signature preserved.
+   `sanitizeLoneSurrogates` leaves thinking/redacted_thinking blocks
+   byte-identical. Test: a payload with a thinking block whose text has no
+   surrogate is unchanged; signature preserved.
 
-5. **Event schema + writer** (`event-types.ts` `MessageEventData`; `runner.ts:701-705`):
-   add `thinkingBlocks?` to `MessageEventData`; runner extracts from response and
-   writes them on the `message` event; **write the message event when text OR
-   thinkingBlocks present** (today skipped when text empty — the tool-only turn).
+5. **Event schema + writer** (`event-types.ts` `MessageEventData`;
+   `runner.ts:701-705`): add `thinkingBlocks?` to `MessageEventData`; runner
+   extracts from response and writes them on the `message` event; **write the
+   message event when text OR thinkingBlocks present** (today skipped when text
+   empty — the tool-only turn).
 
 6. **History rebuild** (`message-builder.ts:329-336` + preserved-tail 300-322 +
-   `PreservedMessage` type + `buildPreservedTail`): attach `thinkingBlocks` to the
-   rebuilt assistant message; thread through the compacted preserved tail.
+   `PreservedMessage` type + `buildPreservedTail`): attach `thinkingBlocks` to
+   the rebuilt assistant message; thread through the compacted preserved tail.
 
-7. **End-to-end test**: response(thinkingBlocks) → write message event → rebuild →
-   `convertToAnthropicFormat` emits thinking-first with signature intact. Include the
-   tool-only (empty-text) turn.
+7. **End-to-end test**: response(thinkingBlocks) → write message event → rebuild
+   → `convertToAnthropicFormat` emits thinking-first with signature intact.
+   Include the tool-only (empty-text) turn.
 
-8. **Re-enable in effort change**: the effort commit currently omits thinking; step 2
-   re-introduces it. Verify the reasoning-effort test file still green (update the
-   `thinking` assertions there to expect adaptive when effort is set).
+8. **Re-enable in effort change**: the effort commit currently omits thinking;
+   step 2 re-introduces it. Verify the reasoning-effort test file still green
+   (update the `thinking` assertions there to expect adaptive when effort is
+   set).
 
-9. **Slack italics** (sen-core): render streamed/persisted thinking as italics in the
-   Slack output. Investigate sen-core's agent→Slack streaming path; thinking text comes
-   from the provider `thinking_delta` events / the persisted thinkingBlocks.
+9. **Slack italics** (sen-core): render streamed/persisted thinking as italics
+   in the Slack output. Investigate sen-core's agent→Slack streaming path;
+   thinking text comes from the provider `thinking_delta` events / the persisted
+   thinkingBlocks.
 
 ## Compaction safety
 
-Only the verbatim tail needs thinking blocks (live tool cycle). Compacted-away turns
-become prose (no tool_use → no thinking requirement). `trimTailToolIO` only touches
-tool_use events; message-event thinking survives.
+Only the verbatim tail needs thinking blocks (live tool cycle). Compacted-away
+turns become prose (no tool_use → no thinking requirement). `trimTailToolIO`
+only touches tool_use events; message-event thinking survives.
 
 ## Deploy (after all green)
 
-`core.md` model → `claude-opus-4-8`; build lace; pin-bump sen-core; persona-refresh Ada;
-verify a live request shows model=opus-4-8 + effort=medium + thinking adaptive, and a
-tool-use turn round-trips without 400.
+`core.md` model → `claude-opus-4-8`; build lace; pin-bump sen-core;
+persona-refresh Ada; verify a live request shows model=opus-4-8 +
+effort=medium + thinking adaptive, and a tool-use turn round-trips without 400.

--- a/docs/superpowers/plans/2026-06-18-session-state-step0-guardrails.md
+++ b/docs/superpowers/plans/2026-06-18-session-state-step0-guardrails.md
@@ -1,24 +1,47 @@
 # Session-State Architecture — Step 0: Guardrails & Instrumentation Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Build the safety net — per-provider golden-bytes tests, a render-determinism test (with the determinism fixes it forces), and a production cache-health log signal — *before* any change to the session-state hot path, so every later step (the O(N²) fix) can be proven byte-safe and watched in production.
+**Goal:** Build the safety net — per-provider golden-bytes tests, a
+render-determinism test (with the determinism fixes it forces), and a production
+cache-health log signal — _before_ any change to the session-state hot path, so
+every later step (the O(N²) fix) can be proven byte-safe and watched in
+production.
 
-**Architecture:** Three deliverables, all additive except two tiny determinism fixes. (1) A reusable request-body capture harness that drives each provider's real `convert→cache→sanitize→serialize` pipeline against a local mock HTTP server and captures the *literal* serialized body; a shared fixture corpus; committed golden snapshots (refactor-equivalence gate) and cross-turn cache-stability assertions (markers stripped for Anthropic/Bedrock, whole for OpenAI/Gemini). (2) A render-determinism test on the system-prompt + tools render path, plus the `fs.readdirSync` sort fix it exposes. (3) A pure `cache-health` log-line builder wired into the runner at the `turn_end` write.
+**Architecture:** Three deliverables, all additive except two tiny determinism
+fixes. (1) A reusable request-body capture harness that drives each provider's
+real `convert→cache→sanitize→serialize` pipeline against a local mock HTTP
+server and captures the _literal_ serialized body; a shared fixture corpus;
+committed golden snapshots (refactor-equivalence gate) and cross-turn
+cache-stability assertions (markers stripped for Anthropic/Bedrock, whole for
+OpenAI/Gemini). (2) A render-determinism test on the system-prompt + tools
+render path, plus the `fs.readdirSync` sort fix it exposes. (3) A pure
+`cache-health` log-line builder wired into the runner at the `turn_end` write.
 
-**Tech Stack:** TypeScript, vitest 3.x, `node:http` mock servers, the lace `@lace/agent` package.
+**Tech Stack:** TypeScript, vitest 3.x, `node:http` mock servers, the lace
+`@lace/agent` package.
 
-**Why this order (from the spec, `docs/design/session-state-architecture.md`):** "Build the safety net before touching a byte." Nothing in this plan changes the hot path or message-building logic — it only *observes* and *pins* current behavior, except the readdir sort, which is a determinism fix the new test proves is needed. Later steps refactor against these committed golden bytes.
+**Why this order (from the spec, `docs/design/session-state-architecture.md`):**
+"Build the safety net before touching a byte." Nothing in this plan changes the
+hot path or message-building logic — it only _observes_ and _pins_ current
+behavior, except the readdir sort, which is a determinism fix the new test
+proves is needed. Later steps refactor against these committed golden bytes.
 
 ---
 
 ## Background the implementer needs
 
-**Read first:** `docs/design/session-state-architecture.md` (the spec) — specifically "Layer 3", "Invariants 4 & 5", and "Step 0".
+**Read first:** `docs/design/session-state-architecture.md` (the spec) —
+specifically "Layer 3", "Invariants 4 & 5", and "Step 0".
 
-**Key facts (already verified — do not re-derive, but do open the cited files to copy exact code):**
+**Key facts (already verified — do not re-derive, but do open the cited files to
+copy exact code):**
 
-- The neutral message type is `ProviderMessage` at `packages/agent/src/providers/base-provider.ts:925`:
+- The neutral message type is `ProviderMessage` at
+  `packages/agent/src/providers/base-provider.ts:925`:
   ```ts
   export interface ProviderMessage {
     role: 'user' | 'assistant' | 'system';
@@ -28,69 +51,159 @@
     thinkingBlocks?: ThinkingBlock[];
   }
   ```
-- The four converters live in `packages/agent/src/providers/format-converters.ts`: `convertToAnthropicFormat` (line 62), `convertToOpenAIFormat` (line 254), `convertToTextOnlyFormat` (line 324), `convertToGeminiFormat` (line 370).
-- `attachMessageCacheBreakpoints` is in `packages/agent/src/providers/cache-control.ts:158`; the anchor offset constant `ANCHOR_OFFSET_RAW_BLOCKS = 10` is at line 20.
-- `sanitizeLoneSurrogates` is in `packages/agent/src/providers/anthropic/well-formed-json.ts:18`; it runs at the Anthropic send boundary (`anthropic-provider.ts:343`).
-- **The canonical body-capture pattern already exists** at `packages/agent/src/providers/__tests__/cache-control-byte-stable.test.ts`. It stands up a `node:http` server on port 0, captures the raw request body string in a `captured: string[]`, points `new AnthropicProvider({ apiKey: 'sk-test', baseURL })` at it, and calls `provider.createResponse(messages, tools, model)`. The cache_control strip is `s.replace(/,?"cache_control":\{[^}]*\}/g, '')`. **Mirror this pattern; do not invent a new capture mechanism.**
-- Existing per-provider tests that already mock responses (crib the exact minimal response JSON + constructor shape from these — **do not hand-author response JSON**):
+- The four converters live in
+  `packages/agent/src/providers/format-converters.ts`:
+  `convertToAnthropicFormat` (line 62), `convertToOpenAIFormat` (line 254),
+  `convertToTextOnlyFormat` (line 324), `convertToGeminiFormat` (line 370).
+- `attachMessageCacheBreakpoints` is in
+  `packages/agent/src/providers/cache-control.ts:158`; the anchor offset
+  constant `ANCHOR_OFFSET_RAW_BLOCKS = 10` is at line 20.
+- `sanitizeLoneSurrogates` is in
+  `packages/agent/src/providers/anthropic/well-formed-json.ts:18`; it runs at
+  the Anthropic send boundary (`anthropic-provider.ts:343`).
+- **The canonical body-capture pattern already exists** at
+  `packages/agent/src/providers/__tests__/cache-control-byte-stable.test.ts`. It
+  stands up a `node:http` server on port 0, captures the raw request body string
+  in a `captured: string[]`, points
+  `new AnthropicProvider({ apiKey: 'sk-test', baseURL })` at it, and calls
+  `provider.createResponse(messages, tools, model)`. The cache_control strip is
+  `s.replace(/,?"cache_control":\{[^}]*\}/g, '')`. **Mirror this pattern; do not
+  invent a new capture mechanism.**
+- Existing per-provider tests that already mock responses (crib the exact
+  minimal response JSON + constructor shape from these — **do not hand-author
+  response JSON**):
   - OpenAI: `packages/agent/src/providers/openai-provider.test.ts`
   - Gemini: `packages/agent/src/providers/gemini-provider.test.ts`
-  - End-to-end body capture through the runner: `packages/agent/src/core/conversation/__tests__/runner.cache-control-e2e.test.ts`
-- Token usage type with cache fields: `ProviderResponse.usage` at `base-provider.ts:81-102` has optional `cacheCreationInputTokens` / `cacheReadInputTokens`. The runner accumulates `totalCacheCreationInputTokens` / `totalCacheReadInputTokens` and tracks `lastCacheMissReason`, then writes the `turn_end` event around `runner.ts:1115-1134`.
-- Logger: `packages/agent/src/utils/logger.ts` exports `logger`; call style is `logger.info('message', { structured: data })`.
-- `generateProjectTree` (`packages/agent/src/config/variable-providers.ts:204-219`) builds the `{{project.tree}}` template variable from `fs.readdirSync(dir, { withFileTypes: true })` **without sorting** — a latent nondeterminism. `getAllTools` (`packages/agent/src/tools/executor.ts:102-113`) is already byte-stable-sorted (binary `<`/`>`).
+  - End-to-end body capture through the runner:
+    `packages/agent/src/core/conversation/__tests__/runner.cache-control-e2e.test.ts`
+- Token usage type with cache fields: `ProviderResponse.usage` at
+  `base-provider.ts:81-102` has optional `cacheCreationInputTokens` /
+  `cacheReadInputTokens`. The runner accumulates `totalCacheCreationInputTokens`
+  / `totalCacheReadInputTokens` and tracks `lastCacheMissReason`, then writes
+  the `turn_end` event around `runner.ts:1115-1134`.
+- Logger: `packages/agent/src/utils/logger.ts` exports `logger`; call style is
+  `logger.info('message', { structured: data })`.
+- `generateProjectTree`
+  (`packages/agent/src/config/variable-providers.ts:204-219`) builds the
+  `{{project.tree}}` template variable from
+  `fs.readdirSync(dir, { withFileTypes: true })` **without sorting** — a latent
+  nondeterminism. `getAllTools` (`packages/agent/src/tools/executor.ts:102-113`)
+  is already byte-stable-sorted (binary `<`/`>`).
 
 **Test commands** (run from `packages/agent`):
+
 ```bash
 cd packages/agent
 npx vitest run <relative-path-to-test-file>     # single file
 npx vitest run -u <relative-path-to-test-file>  # update committed golden snapshots
 ```
-Typecheck/lint before each commit (repo convention, pre-commit hook enforces): from repo root `npm run typecheck && npm run lint`.
 
-**Golden snapshot mechanism:** use vitest's `await expect(body).toMatchFileSnapshot('./golden/<name>.json')`. The golden file is committed; later refactors compare against it. This *is* the spec's `Buffer.equals` refactor-equivalence gate (string compare of identical-encoding JSON is byte-equality). Each golden test ALSO captures the body twice in one run and asserts the two captures are equal *before* the snapshot compare, to catch any body-level nondeterminism immediately.
+Typecheck/lint before each commit (repo convention, pre-commit hook enforces):
+from repo root `npm run typecheck && npm run lint`.
 
-**Capture strategy — per provider (decided after reading the existing tests; do not change without reason):**
-- **Anthropic** → **real `node:http` server, literal post-SDK bytes.** This mirrors the proven `cache-control-byte-stable.test.ts`. Anthropic is the provider where literal wire bytes carry the cache (explicit `cache_control` markers live *in* the body; a 1-byte prefix drift = ~5× re-bill), so post-serializer fidelity matters most here. `AnthropicProvider` takes a `baseURL` constructor option, so this needs no provider change.
-- **OpenAI / Gemini** → **capture the request OBJECT passed to the SDK method, then `JSON.stringify` it.** Both existing provider tests already do this via a file-hoisted `vi.mock('openai')` / `vi.mock('@google/genai')` that replaces `chat.completions.create` / `models.generateContent` with a `vi.fn()`; the captured object is `mock.calls[0][0]`. This is spec-aligned (the spec defines byte-identity as `JSON.stringify(stableObject)` — the object we control), needs no provider baseURL passthrough, and reuses proven mocking. OpenAI's server-side prefix cache and Gemini's lack of a managed cache make object-level fidelity sufficient for these two. **Because `vi.mock` is hoisted and module-global per file, the OpenAI and Gemini golden/cross-turn tests are SELF-CONTAINED (mock + capture in the test file) — they do NOT use the shared Anthropic helper.**
-- **Confirmed real mock shapes** (from the existing tests — use these, don't invent):
-  - OpenAI Chat Completions response (`mockCreate.mockResolvedValue`): `{ choices: [{ message: { content: 'ok', tool_calls: undefined }, finish_reason: 'stop' }], usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 } }`. Constructor: `new OpenAIProvider({ apiKey: 'test-key', baseURL: 'http://localhost:8080/v1' })` (a custom baseURL forces the Chat Completions path via `isCustomEndpoint()`). Model: `'gpt-4o'`. The mock module is `vi.mock('openai', () => ({ default: class { chat = { completions: { create: mockCreate } } } }))`.
-  - Gemini response (`mockGenerateContent.mockResolvedValue`): `{ candidates: [{ content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' }], usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 } }`. Constructor: `new GeminiProvider({ apiKey: 'test-api-key' })`. Model: `'gemini-2.5-flash'`. The mock module is `vi.mock('@google/genai', () => ({ GoogleGenAI: class { models = { generateContent: mockGenerateContent, generateContentStream: mockGenerateContentStream } } }))` — **copy the exact factory and exported class name from `gemini-provider.test.ts:13-17` (it may export `GoogleGenAI` or another name).**
+**Golden snapshot mechanism:** use vitest's
+`await expect(body).toMatchFileSnapshot('./golden/<name>.json')`. The golden
+file is committed; later refactors compare against it. This _is_ the spec's
+`Buffer.equals` refactor-equivalence gate (string compare of identical-encoding
+JSON is byte-equality). Each golden test ALSO captures the body twice in one run
+and asserts the two captures are equal _before_ the snapshot compare, to catch
+any body-level nondeterminism immediately.
+
+**Capture strategy — per provider (decided after reading the existing tests; do
+not change without reason):**
+
+- **Anthropic** → **real `node:http` server, literal post-SDK bytes.** This
+  mirrors the proven `cache-control-byte-stable.test.ts`. Anthropic is the
+  provider where literal wire bytes carry the cache (explicit `cache_control`
+  markers live _in_ the body; a 1-byte prefix drift = ~5× re-bill), so
+  post-serializer fidelity matters most here. `AnthropicProvider` takes a
+  `baseURL` constructor option, so this needs no provider change.
+- **OpenAI / Gemini** → **capture the request OBJECT passed to the SDK method,
+  then `JSON.stringify` it.** Both existing provider tests already do this via a
+  file-hoisted `vi.mock('openai')` / `vi.mock('@google/genai')` that replaces
+  `chat.completions.create` / `models.generateContent` with a `vi.fn()`; the
+  captured object is `mock.calls[0][0]`. This is spec-aligned (the spec defines
+  byte-identity as `JSON.stringify(stableObject)` — the object we control),
+  needs no provider baseURL passthrough, and reuses proven mocking. OpenAI's
+  server-side prefix cache and Gemini's lack of a managed cache make
+  object-level fidelity sufficient for these two. **Because `vi.mock` is hoisted
+  and module-global per file, the OpenAI and Gemini golden/cross-turn tests are
+  SELF-CONTAINED (mock + capture in the test file) — they do NOT use the shared
+  Anthropic helper.**
+- **Confirmed real mock shapes** (from the existing tests — use these, don't
+  invent):
+  - OpenAI Chat Completions response (`mockCreate.mockResolvedValue`):
+    `{ choices: [{ message: { content: 'ok', tool_calls: undefined }, finish_reason: 'stop' }], usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 } }`.
+    Constructor:
+    `new OpenAIProvider({ apiKey: 'test-key', baseURL: 'http://localhost:8080/v1' })`
+    (a custom baseURL forces the Chat Completions path via
+    `isCustomEndpoint()`). Model: `'gpt-4o'`. The mock module is
+    `vi.mock('openai', () => ({ default: class { chat = { completions: { create: mockCreate } } } }))`.
+  - Gemini response (`mockGenerateContent.mockResolvedValue`):
+    `{ candidates: [{ content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' }], usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 } }`.
+    Constructor: `new GeminiProvider({ apiKey: 'test-api-key' })`. Model:
+    `'gemini-2.5-flash'`. The mock module is
+    `vi.mock('@google/genai', () => ({ GoogleGenAI: class { models = { generateContent: mockGenerateContent, generateContentStream: mockGenerateContentStream } } }))`
+    — **copy the exact factory and exported class name from
+    `gemini-provider.test.ts:13-17` (it may export `GoogleGenAI` or another
+    name).**
 
 ---
 
 ## File Structure
 
 **Create:**
-- `packages/agent/src/providers/__tests__/golden/_capture-request-body.ts` — the reusable **Anthropic** real-server body-capture helper (single-turn + two-turn). Sole responsibility: stand up a `node:http` server, drive `AnthropicProvider.createResponse`, return captured literal body string(s). (OpenAI/Gemini capture lives inside their own test files because their `vi.mock` is file-hoisted — see the Capture strategy note above.)
-- `packages/agent/src/providers/__tests__/golden/_fixtures.ts` — the shared fixture corpus: builders returning `{ messages: ProviderMessage[], tools, systemPrompt }` for each scenario (thinking blocks, multi-key/numeric tool args, image, compaction era with `preserved`, post-compaction persona re-render, unicode, orphaned tool block).
+
+- `packages/agent/src/providers/__tests__/golden/_capture-request-body.ts` — the
+  reusable **Anthropic** real-server body-capture helper (single-turn +
+  two-turn). Sole responsibility: stand up a `node:http` server, drive
+  `AnthropicProvider.createResponse`, return captured literal body string(s).
+  (OpenAI/Gemini capture lives inside their own test files because their
+  `vi.mock` is file-hoisted — see the Capture strategy note above.)
+- `packages/agent/src/providers/__tests__/golden/_fixtures.ts` — the shared
+  fixture corpus: builders returning
+  `{ messages: ProviderMessage[], tools, systemPrompt }` for each scenario
+  (thinking blocks, multi-key/numeric tool args, image, compaction era with
+  `preserved`, post-compaction persona re-render, unicode, orphaned tool block).
 - `packages/agent/src/providers/__tests__/golden/golden-bytes-anthropic.test.ts`
 - `packages/agent/src/providers/__tests__/golden/golden-bytes-openai.test.ts`
 - `packages/agent/src/providers/__tests__/golden/golden-bytes-gemini.test.ts`
 - `packages/agent/src/providers/__tests__/golden/cross-turn-cache-stability.test.ts`
 - `packages/agent/src/config/__tests__/render-determinism.test.ts`
 - `packages/agent/src/providers/__tests__/converter-determinism.test.ts`
-- `packages/agent/src/core/conversation/cache-health.ts` — pure `buildCacheHealthLog(...)` function.
+- `packages/agent/src/core/conversation/cache-health.ts` — pure
+  `buildCacheHealthLog(...)` function.
 - `packages/agent/src/core/conversation/__tests__/cache-health.test.ts`
 
 **Modify:**
-- `packages/agent/src/config/variable-providers.ts` — sort the `readdirSync` result in `generateProjectTree` (determinism fix Task 5 forces).
-- `packages/agent/src/core/conversation/runner.ts` — call `buildCacheHealthLog` + `logger.info` after the `turn_end` write (Task 8).
 
-**Note on `golden/` directory:** committed golden snapshot files land in `packages/agent/src/providers/__tests__/golden/<name>.json`. They are fixtures, not source — they will be committed and are the gate later steps must reproduce.
+- `packages/agent/src/config/variable-providers.ts` — sort the `readdirSync`
+  result in `generateProjectTree` (determinism fix Task 5 forces).
+- `packages/agent/src/core/conversation/runner.ts` — call
+  `buildCacheHealthLog` + `logger.info` after the `turn_end` write (Task 8).
+
+**Note on `golden/` directory:** committed golden snapshot files land in
+`packages/agent/src/providers/__tests__/golden/<name>.json`. They are fixtures,
+not source — they will be committed and are the gate later steps must reproduce.
 
 ---
 
 ## Task 1: Capture harness + fixture corpus (Anthropic only, to prove the harness)
 
 **Files:**
-- Create: `packages/agent/src/providers/__tests__/golden/_capture-request-body.ts`
+
+- Create:
+  `packages/agent/src/providers/__tests__/golden/_capture-request-body.ts`
 - Create: `packages/agent/src/providers/__tests__/golden/_fixtures.ts`
-- Reference (read, do not modify): `packages/agent/src/providers/__tests__/cache-control-byte-stable.test.ts`
+- Reference (read, do not modify):
+  `packages/agent/src/providers/__tests__/cache-control-byte-stable.test.ts`
 
 - [ ] **Step 1: Write the fixture corpus module**
 
-Create `_fixtures.ts`. Each fixture is a named builder returning the neutral inputs. Use only `ProviderMessage` fields. Tool calls/results use the existing `Tool` subclass pattern from `cache-control-byte-stable.test.ts` (the `EchoTool`). Keep content deterministic (no `Date.now()`).
+Create `_fixtures.ts`. Each fixture is a named builder returning the neutral
+inputs. Use only `ProviderMessage` fields. Tool calls/results use the existing
+`Tool` subclass pattern from `cache-control-byte-stable.test.ts` (the
+`EchoTool`). Keep content deterministic (no `Date.now()`).
 
 ```ts
 // ABOUTME: Shared fixture corpus for the per-provider golden-bytes tests. Each
@@ -108,7 +221,10 @@ export class EchoTool extends Tool {
   name = 'echo';
   description = 'Echo a value';
   schema = z.object({ v: z.string() });
-  protected async executeValidated(args: { v: string }, _c: ToolContext): Promise<ToolResult> {
+  protected async executeValidated(
+    args: { v: string },
+    _c: ToolContext
+  ): Promise<ToolResult> {
     return await Promise.resolve(this.createResult(args.v));
   }
 }
@@ -142,7 +258,9 @@ export const FIXTURES: GoldenFixture[] = [
       {
         role: 'assistant',
         content: 'done',
-        thinkingBlocks: [{ type: 'thinking', thinking: 'let me reason', signature: 'sig-abc' }],
+        thinkingBlocks: [
+          { type: 'thinking', thinking: 'let me reason', signature: 'sig-abc' },
+        ],
       },
     ],
   },
@@ -155,9 +273,25 @@ export const FIXTURES: GoldenFixture[] = [
       {
         role: 'assistant',
         content: '',
-        toolCalls: [{ id: 'call_1', name: 'echo', arguments: { v: 'x', count: 3, flag: true, nested: { a: 1 } } }],
+        toolCalls: [
+          {
+            id: 'call_1',
+            name: 'echo',
+            arguments: { v: 'x', count: 3, flag: true, nested: { a: 1 } },
+          },
+        ],
       },
-      { role: 'user', content: '', toolResults: [{ id: 'call_1', content: [{ type: 'text', text: 'x' }], status: 'completed' }] },
+      {
+        role: 'user',
+        content: '',
+        toolResults: [
+          {
+            id: 'call_1',
+            content: [{ type: 'text', text: 'x' }],
+            status: 'completed',
+          },
+        ],
+      },
     ],
   },
   {
@@ -172,17 +306,33 @@ export const FIXTURES: GoldenFixture[] = [
 ];
 ```
 
-> **CONFIRMED FROM SOURCE (`packages/agent/src/tools/types.ts`) — use these exact shapes everywhere in this plan:**
-> - `ToolCall` = `{ id: string; name: string; arguments: Record<string, unknown> }` (the field is **`arguments`**, NOT `input`; the converters read `toolCall.arguments`).
-> - `ToolResult` = `{ id?: string; content: ContentBlock[]; status: ToolResultStatus; metadata?; tokenUsage? }`. There is **no `isError`** — use `status: 'completed'` for success (the Anthropic converter derives `is_error` from `status !== 'completed'`).
-> - `ThinkingBlock` = `{ type: 'thinking'; thinking: string; signature: string }` (matches).
-> - `ToolResult.content` uses the **tools/types.ts** `ContentBlock` (`{ type: 'text'; text: string }`). A **message-level** image block uses the **base-provider.ts** `ContentBlock` (`{ type: 'image'; source: { type: 'base64'; media_type; data } }`) — different union, used in Task 4's image fixture.
+> **CONFIRMED FROM SOURCE (`packages/agent/src/tools/types.ts`) — use these
+> exact shapes everywhere in this plan:**
 >
-> The image / compaction-era / orphaned-tool / post-compaction fixtures are added in Task 4 once the harness is proven; this task keeps the corpus small to validate the harness end-to-end.
+> - `ToolCall` =
+>   `{ id: string; name: string; arguments: Record<string, unknown> }` (the
+>   field is **`arguments`**, NOT `input`; the converters read
+>   `toolCall.arguments`).
+> - `ToolResult` =
+>   `{ id?: string; content: ContentBlock[]; status: ToolResultStatus; metadata?; tokenUsage? }`.
+>   There is **no `isError`** — use `status: 'completed'` for success (the
+>   Anthropic converter derives `is_error` from `status !== 'completed'`).
+> - `ThinkingBlock` =
+>   `{ type: 'thinking'; thinking: string; signature: string }` (matches).
+> - `ToolResult.content` uses the **tools/types.ts** `ContentBlock`
+>   (`{ type: 'text'; text: string }`). A **message-level** image block uses the
+>   **base-provider.ts** `ContentBlock`
+>   (`{ type: 'image'; source: { type: 'base64'; media_type; data } }`) —
+>   different union, used in Task 4's image fixture.
+>
+> The image / compaction-era / orphaned-tool / post-compaction fixtures are
+> added in Task 4 once the harness is proven; this task keeps the corpus small
+> to validate the harness end-to-end.
 
 - [ ] **Step 2: Write the capture helper (Anthropic)**
 
-Create `_capture-request-body.ts`. Mirror the server setup from `cache-control-byte-stable.test.ts` exactly.
+Create `_capture-request-body.ts`. Mirror the server setup from
+`cache-control-byte-stable.test.ts` exactly.
 
 ```ts
 // ABOUTME: Reusable mock-HTTP-server harness that drives a provider's real
@@ -194,7 +344,9 @@ import { createServer, type Server } from 'node:http';
 import { AnthropicProvider } from '@lace/agent/providers/anthropic-provider';
 import type { GoldenFixture } from './_fixtures';
 
-async function startServer(handler: (body: string, n: number) => string): Promise<{ server: Server; baseURL: string; captured: string[] }> {
+async function startServer(
+  handler: (body: string, n: number) => string
+): Promise<{ server: Server; baseURL: string; captured: string[] }> {
   const captured: string[] = [];
   const server = createServer((req, res) => {
     let body = '';
@@ -211,7 +363,9 @@ async function startServer(handler: (body: string, n: number) => string): Promis
   return { server, baseURL: `http://127.0.0.1:${addr.port}`, captured };
 }
 
-export async function captureAnthropicBody(fixture: GoldenFixture): Promise<string> {
+export async function captureAnthropicBody(
+  fixture: GoldenFixture
+): Promise<string> {
   const { server, baseURL, captured } = await startServer((_b, n) =>
     JSON.stringify({
       id: `msg_${n}`,
@@ -227,20 +381,29 @@ export async function captureAnthropicBody(fixture: GoldenFixture): Promise<stri
   try {
     const provider = new AnthropicProvider({ apiKey: 'sk-test', baseURL });
     provider.setSystemPrompt(fixture.systemPrompt);
-    await provider.createResponse(fixture.messages, fixture.tools, 'claude-sonnet-4-20250514');
-    if (captured.length !== 1) throw new Error(`expected 1 request, got ${captured.length}`);
+    await provider.createResponse(
+      fixture.messages,
+      fixture.tools,
+      'claude-sonnet-4-20250514'
+    );
+    if (captured.length !== 1)
+      throw new Error(`expected 1 request, got ${captured.length}`);
     return captured[0]!;
   } finally {
-    await new Promise<void>((res, rej) => server.close((e) => (e ? rej(e) : res())));
+    await new Promise<void>((res, rej) =>
+      server.close((e) => (e ? rej(e) : res()))
+    );
   }
 }
 ```
 
 - [ ] **Step 3: Smoke-test the harness compiles and captures**
 
-Add a temporary inline test at the bottom of a scratch file is NOT allowed; instead, this is validated by Task 2's first run. Just typecheck.
+Add a temporary inline test at the bottom of a scratch file is NOT allowed;
+instead, this is validated by Task 2's first run. Just typecheck.
 
-Run: `cd packages/agent && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "_capture-request-body|_fixtures" || echo "no type errors in new files"`
+Run:
+`cd packages/agent && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "_capture-request-body|_fixtures" || echo "no type errors in new files"`
 Expected: `no type errors in new files`
 
 - [ ] **Step 4: Commit**
@@ -255,8 +418,11 @@ git commit -m "test(session-state): golden-bytes capture harness + initial fixtu
 ## Task 2: Anthropic refactor-equivalence golden snapshots
 
 **Files:**
-- Create: `packages/agent/src/providers/__tests__/golden/golden-bytes-anthropic.test.ts`
-- Create (generated): `packages/agent/src/providers/__tests__/golden/anthropic-*.json`
+
+- Create:
+  `packages/agent/src/providers/__tests__/golden/golden-bytes-anthropic.test.ts`
+- Create (generated):
+  `packages/agent/src/providers/__tests__/golden/anthropic-*.json`
 
 - [ ] **Step 1: Write the golden test**
 
@@ -282,18 +448,25 @@ describe('golden-bytes: Anthropic request body is pinned', () => {
 
 - [ ] **Step 2: Run to generate goldens (first run writes them)**
 
-Run: `cd packages/agent && npx vitest run -u src/providers/__tests__/golden/golden-bytes-anthropic.test.ts`
+Run:
+`cd packages/agent && npx vitest run -u src/providers/__tests__/golden/golden-bytes-anthropic.test.ts`
 Expected: PASS, and new `anthropic-*.json` files appear in the `golden/` dir.
 
 - [ ] **Step 3: Run again WITHOUT `-u` to prove the gate compares**
 
-Run: `cd packages/agent && npx vitest run src/providers/__tests__/golden/golden-bytes-anthropic.test.ts`
+Run:
+`cd packages/agent && npx vitest run src/providers/__tests__/golden/golden-bytes-anthropic.test.ts`
 Expected: PASS (now comparing against committed goldens).
 
 - [ ] **Step 4: Sanity-inspect one golden**
 
-Run: `cat packages/agent/src/providers/__tests__/golden/anthropic-thinking-blocks.json | head -c 400; echo`
-Expected: a JSON object containing `"model"`, `"system"`, `"messages"`, and a `"thinking"` block with `"signature":"sig-abc"`. Confirm the lone surrogate in `unicode-and-surrogates` was replaced with U+FFFD (`�`) in `anthropic-unicode-and-surrogates.json` — this proves `sanitizeLoneSurrogates` is in the captured path.
+Run:
+`cat packages/agent/src/providers/__tests__/golden/anthropic-thinking-blocks.json | head -c 400; echo`
+Expected: a JSON object containing `"model"`, `"system"`, `"messages"`, and a
+`"thinking"` block with `"signature":"sig-abc"`. Confirm the lone surrogate in
+`unicode-and-surrogates` was replaced with U+FFFD (`�`) in
+`anthropic-unicode-and-surrogates.json` — this proves `sanitizeLoneSurrogates`
+is in the captured path.
 
 - [ ] **Step 5: Commit**
 
@@ -306,12 +479,21 @@ git commit -m "test(session-state): pin Anthropic request-body golden bytes (ref
 
 ## Task 3: OpenAI + Gemini golden snapshots (object-capture, self-contained)
 
-These two tests do NOT use the shared helper — each owns a file-hoisted `vi.mock` of its SDK and captures the request *object* passed to the mocked method, then `JSON.stringify`s it. Copy the mock factory + `mockResolvedValue` shapes from the existing provider tests (cited below); they are reproduced here from those files.
+These two tests do NOT use the shared helper — each owns a file-hoisted
+`vi.mock` of its SDK and captures the request _object_ passed to the mocked
+method, then `JSON.stringify`s it. Copy the mock factory + `mockResolvedValue`
+shapes from the existing provider tests (cited below); they are reproduced here
+from those files.
 
 **Files:**
-- Create: `packages/agent/src/providers/__tests__/golden/golden-bytes-openai.test.ts`
-- Create: `packages/agent/src/providers/__tests__/golden/golden-bytes-gemini.test.ts`
-- Reference: `packages/agent/src/providers/openai-provider.test.ts:11-25,42-54,97-108`, `packages/agent/src/providers/gemini-provider.test.ts:13-17,27,67-81`
+
+- Create:
+  `packages/agent/src/providers/__tests__/golden/golden-bytes-openai.test.ts`
+- Create:
+  `packages/agent/src/providers/__tests__/golden/golden-bytes-gemini.test.ts`
+- Reference:
+  `packages/agent/src/providers/openai-provider.test.ts:11-25,42-54,97-108`,
+  `packages/agent/src/providers/gemini-provider.test.ts:13-17,27,67-81`
 
 - [ ] **Step 1: Write the OpenAI golden test (self-contained)**
 
@@ -343,14 +525,22 @@ describe('golden-bytes: OpenAI request object is pinned', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCreate.mockResolvedValue({
-      choices: [{ message: { content: 'ok', tool_calls: undefined }, finish_reason: 'stop' }],
+      choices: [
+        {
+          message: { content: 'ok', tool_calls: undefined },
+          finish_reason: 'stop',
+        },
+      ],
       usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
     });
   });
 
   for (const fixture of FIXTURES) {
     it(`pins the OpenAI object for "${fixture.name}"`, async () => {
-      const provider = new OpenAIProvider({ apiKey: 'test-key', baseURL: 'http://localhost:8080/v1' });
+      const provider = new OpenAIProvider({
+        apiKey: 'test-key',
+        baseURL: 'http://localhost:8080/v1',
+      });
       provider.setSystemPrompt(fixture.systemPrompt);
       await provider.createResponse(fixture.messages, fixture.tools, 'gpt-4o');
       const a = capture();
@@ -363,7 +553,13 @@ describe('golden-bytes: OpenAI request object is pinned', () => {
 });
 ```
 
-> Confirm the `vi.mock('openai', …)` factory matches `openai-provider.test.ts:15-25` exactly (the SDK's default export shape). If `createResponse` for `gpt-4o` with a custom baseURL still routes to the Responses API (`responses.create`) instead of `chat.completions.create`, the mock must also stub `responses.create` and `capture()` must read whichever was called — read `openai-provider.ts` `isCustomEndpoint()` to confirm the custom baseURL forces Chat Completions (the existing test relies on exactly this).
+> Confirm the `vi.mock('openai', …)` factory matches
+> `openai-provider.test.ts:15-25` exactly (the SDK's default export shape). If
+> `createResponse` for `gpt-4o` with a custom baseURL still routes to the
+> Responses API (`responses.create`) instead of `chat.completions.create`, the
+> mock must also stub `responses.create` and `capture()` must read whichever was
+> called — read `openai-provider.ts` `isCustomEndpoint()` to confirm the custom
+> baseURL forces Chat Completions (the existing test relies on exactly this).
 
 - [ ] **Step 2: Write the Gemini golden test (self-contained)**
 
@@ -379,7 +575,10 @@ const mockGenerateContentStream = vi.fn();
 // COPY the exact factory + exported class name from gemini-provider.test.ts:13-17.
 vi.mock('@google/genai', () => ({
   GoogleGenAI: class {
-    models = { generateContent: mockGenerateContent, generateContentStream: mockGenerateContentStream };
+    models = {
+      generateContent: mockGenerateContent,
+      generateContentStream: mockGenerateContentStream,
+    };
   },
 }));
 
@@ -396,8 +595,14 @@ describe('golden-bytes: Gemini request object is pinned', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGenerateContent.mockResolvedValue({
-      candidates: [{ content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' }],
-      usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+      candidates: [
+        { content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' },
+      ],
+      usageMetadata: {
+        promptTokenCount: 1,
+        candidatesTokenCount: 1,
+        totalTokenCount: 2,
+      },
     });
   });
 
@@ -405,9 +610,17 @@ describe('golden-bytes: Gemini request object is pinned', () => {
     it(`pins the Gemini object for "${fixture.name}"`, async () => {
       const provider = new GeminiProvider({ apiKey: 'test-api-key' });
       provider.setSystemPrompt(fixture.systemPrompt);
-      await provider.createResponse(fixture.messages, fixture.tools, 'gemini-2.5-flash');
+      await provider.createResponse(
+        fixture.messages,
+        fixture.tools,
+        'gemini-2.5-flash'
+      );
       const a = capture();
-      await provider.createResponse(fixture.messages, fixture.tools, 'gemini-2.5-flash');
+      await provider.createResponse(
+        fixture.messages,
+        fixture.tools,
+        'gemini-2.5-flash'
+      );
       const b = capture();
       expect(a).toBe(b); // intra-run determinism — this also pins the Date.now()/Math.random() tool-id concern: the converter must not re-mint ids for persisted history
       await expect(a).toMatchFileSnapshot(`./gemini-${fixture.name}.json`);
@@ -416,11 +629,19 @@ describe('golden-bytes: Gemini request object is pinned', () => {
 });
 ```
 
-> The exported class name in the `@google/genai` mock factory MUST be copied verbatim from `gemini-provider.test.ts:13-17` (shown above as `GoogleGenAI` — verify). The Gemini converter mints tool-call ids with `Date.now()/Math.random()` only when parsing a *response* (`gemini-provider.ts:118-119`), never when converting persisted history — so the intra-run `expect(a).toBe(b)` must hold. If it does NOT, that's a real determinism bug to surface (a re-mint leaked into the request path), not something to snapshot away.
+> The exported class name in the `@google/genai` mock factory MUST be copied
+> verbatim from `gemini-provider.test.ts:13-17` (shown above as `GoogleGenAI` —
+> verify). The Gemini converter mints tool-call ids with
+> `Date.now()/Math.random()` only when parsing a _response_
+> (`gemini-provider.ts:118-119`), never when converting persisted history — so
+> the intra-run `expect(a).toBe(b)` must hold. If it does NOT, that's a real
+> determinism bug to surface (a re-mint leaked into the request path), not
+> something to snapshot away.
 
 - [ ] **Step 3: Generate + verify both**
 
-Run: `cd packages/agent && npx vitest run -u src/providers/__tests__/golden/golden-bytes-openai.test.ts src/providers/__tests__/golden/golden-bytes-gemini.test.ts`
+Run:
+`cd packages/agent && npx vitest run -u src/providers/__tests__/golden/golden-bytes-openai.test.ts src/providers/__tests__/golden/golden-bytes-gemini.test.ts`
 Expected: PASS, goldens written.
 
 Run again without `-u`:
@@ -439,12 +660,23 @@ git commit -m "test(session-state): pin OpenAI + Gemini request-object golden by
 ## Task 4: Complete the fixture corpus (the hard wire shapes)
 
 **Files:**
+
 - Modify: `packages/agent/src/providers/__tests__/golden/_fixtures.ts`
-- Reference: `packages/agent/src/message-building/message-builder.ts` (how `context_compacted.preserved` becomes messages), `packages/agent/src/compaction/toolkit.ts:415` (`buildPreservedTail` shape), `packages/agent/src/providers/format-converters.ts:62` (Anthropic tool-result-before-text ordering, the `dropOrphanedToolBlocks` consumer).
+- Reference: `packages/agent/src/message-building/message-builder.ts` (how
+  `context_compacted.preserved` becomes messages),
+  `packages/agent/src/compaction/toolkit.ts:415` (`buildPreservedTail` shape),
+  `packages/agent/src/providers/format-converters.ts:62` (Anthropic
+  tool-result-before-text ordering, the `dropOrphanedToolBlocks` consumer).
 
 - [ ] **Step 1: Add the remaining fixtures**
 
-Append to `FIXTURES`. These cover the spec's required corpus: image block, a compaction era (a `preserved`-derived prefix + a small tail), a post-compaction persona re-render (a second system block), and an orphaned tool block (a `tool_use` with no matching `tool_result`). Build them as the *already-rebuilt* `ProviderMessage[]` (this test pins the converter+serializer, not the rebuilder — the rebuilder is pinned in Step 1's golden indirectly via fixtures that mirror its output).
+Append to `FIXTURES`. These cover the spec's required corpus: image block, a
+compaction era (a `preserved`-derived prefix + a small tail), a post-compaction
+persona re-render (a second system block), and an orphaned tool block (a
+`tool_use` with no matching `tool_result`). Build them as the _already-rebuilt_
+`ProviderMessage[]` (this test pins the converter+serializer, not the rebuilder
+— the rebuilder is pinned in Step 1's golden indirectly via fixtures that mirror
+its output).
 
 ```ts
 // Append inside FIXTURES (use the real ContentBlock image shape from base-provider.ts):
@@ -486,17 +718,25 @@ Append to `FIXTURES`. These cover the spec's required corpus: image block, a com
 },
 ```
 
-> The `ContentBlock` image shape (`source.type` / `media_type` / `data` field names) MUST be copied exactly from the `ContentBlock` union in `base-provider.ts`. If lace's internal image block differs from the Anthropic wire shape, use lace's internal shape — the converter produces the wire shape. Confirm before finalizing.
+> The `ContentBlock` image shape (`source.type` / `media_type` / `data` field
+> names) MUST be copied exactly from the `ContentBlock` union in
+> `base-provider.ts`. If lace's internal image block differs from the Anthropic
+> wire shape, use lace's internal shape — the converter produces the wire shape.
+> Confirm before finalizing.
 
 - [ ] **Step 2: Regenerate all goldens (new fixtures added)**
 
 Run: `cd packages/agent && npx vitest run -u src/providers/__tests__/golden/`
-Expected: PASS; new `*-image-block.json`, `*-orphaned-tool-block.json`, `*-post-compaction-double-system.json` for all three providers.
+Expected: PASS; new `*-image-block.json`, `*-orphaned-tool-block.json`,
+`*-post-compaction-double-system.json` for all three providers.
 
 - [ ] **Step 3: Inspect the orphaned-tool golden**
 
-Run: `cat packages/agent/src/providers/__tests__/golden/anthropic-orphaned-tool-block.json | python3 -m json.tool | grep -A2 -B2 tool_use || true`
-Expected: confirm the orphaned `tool_use` was handled consistently (either dropped or paired-with-synthetic) — whatever the current code does, it is now PINNED. Note the behavior in a one-line comment in the test file.
+Run:
+`cat packages/agent/src/providers/__tests__/golden/anthropic-orphaned-tool-block.json | python3 -m json.tool | grep -A2 -B2 tool_use || true`
+Expected: confirm the orphaned `tool_use` was handled consistently (either
+dropped or paired-with-synthetic) — whatever the current code does, it is now
+PINNED. Note the behavior in a one-line comment in the test file.
 
 - [ ] **Step 4: Run the whole golden suite without `-u`**
 
@@ -515,13 +755,22 @@ git commit -m "test(session-state): complete golden fixture corpus (image, orpha
 ## Task 5: Render-determinism test + the `readdirSync` sort fix
 
 **Files:**
+
 - Create: `packages/agent/src/config/__tests__/render-determinism.test.ts`
-- Modify: `packages/agent/src/config/variable-providers.ts:204-219` (`generateProjectTree`)
-- Reference: `packages/agent/src/config/variable-providers.ts` (`ProjectVariableProvider`), `packages/agent/src/config/prompt-manager.test.ts` (existing render-test pattern, lines ~121/238)
+- Modify: `packages/agent/src/config/variable-providers.ts:204-219`
+  (`generateProjectTree`)
+- Reference: `packages/agent/src/config/variable-providers.ts`
+  (`ProjectVariableProvider`),
+  `packages/agent/src/config/prompt-manager.test.ts` (existing render-test
+  pattern, lines ~121/238)
 
 - [ ] **Step 1: Write the failing determinism test**
 
-This test forces the dependency on directory-read order by stubbing `fs.readdirSync` to return entries in two different orders, and asserts the rendered `project.tree` variable is byte-identical regardless. Use vitest's `vi.spyOn`. Crib the `ProjectVariableProvider` construction from `variable-providers.ts`.
+This test forces the dependency on directory-read order by stubbing
+`fs.readdirSync` to return entries in two different orders, and asserts the
+rendered `project.tree` variable is byte-identical regardless. Use vitest's
+`vi.spyOn`. Crib the `ProjectVariableProvider` construction from
+`variable-providers.ts`.
 
 ```ts
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -531,19 +780,31 @@ import { ProjectVariableProvider } from '@lace/agent/config/variable-providers';
 afterEach(() => vi.restoreAllMocks());
 
 function fakeEntry(name: string, isDir: boolean): fs.Dirent {
-  return { name, isDirectory: () => isDir, isFile: () => !isDir } as unknown as fs.Dirent;
+  return {
+    name,
+    isDirectory: () => isDir,
+    isFile: () => !isDir,
+  } as unknown as fs.Dirent;
 }
 
 describe('render determinism: project tree is insensitive to readdir order', () => {
   it('produces byte-identical tree regardless of fs.readdirSync ordering', () => {
-    const entries = [fakeEntry('zebra.ts', false), fakeEntry('alpha', true), fakeEntry('mango.ts', false)];
+    const entries = [
+      fakeEntry('zebra.ts', false),
+      fakeEntry('alpha', true),
+      fakeEntry('mango.ts', false),
+    ];
 
     const render = (order: fs.Dirent[]): string => {
       const spy = vi.spyOn(fs, 'readdirSync');
       // top-level dir returns `order`; any nested dir returns empty
-      spy.mockImplementation(((_p: fs.PathLike, _o?: unknown) => order) as unknown as typeof fs.readdirSync);
+      spy.mockImplementation(
+        ((_p: fs.PathLike, _o?: unknown) =>
+          order) as unknown as typeof fs.readdirSync
+      );
       // Construct the provider against a fixed cwd so cwd is held constant.
-      const provider = new ProjectVariableProvider(/* fixed cwd / session per the real constructor */);
+      const provider =
+        new ProjectVariableProvider(/* fixed cwd / session per the real constructor */);
       const vars = provider.getVariables() as { project: { tree: string } };
       spy.mockRestore();
       return vars.project.tree;
@@ -556,16 +817,22 @@ describe('render determinism: project tree is insensitive to readdir order', () 
 });
 ```
 
-> Confirm the real `ProjectVariableProvider` constructor signature and how it determines `cwd` (it falls back to `process.cwd()`); pass a fixed directory so cwd is constant. The point is to vary ONLY readdir order.
+> Confirm the real `ProjectVariableProvider` constructor signature and how it
+> determines `cwd` (it falls back to `process.cwd()`); pass a fixed directory so
+> cwd is constant. The point is to vary ONLY readdir order.
 
 - [ ] **Step 2: Run — expect RED**
 
-Run: `cd packages/agent && npx vitest run src/config/__tests__/render-determinism.test.ts`
-Expected: FAIL — `forward` and `reversed` differ because `generateProjectTree` emits entries in readdir order.
+Run:
+`cd packages/agent && npx vitest run src/config/__tests__/render-determinism.test.ts`
+Expected: FAIL — `forward` and `reversed` differ because `generateProjectTree`
+emits entries in readdir order.
 
 - [ ] **Step 3: Fix `generateProjectTree` — sort entries byte-stably**
 
-In `variable-providers.ts`, in `generateProjectTree`, sort the filtered entries by name with a byte-stable comparator (matching the `executor.ts` convention) before iterating:
+In `variable-providers.ts`, in `generateProjectTree`, sort the filtered entries
+by name with a byte-stable comparator (matching the `executor.ts` convention)
+before iterating:
 
 ```ts
 const items = fs
@@ -575,16 +842,22 @@ const items = fs
   .slice(0, 20);
 ```
 
-> Apply the sort BEFORE `.slice(0, 20)` so which 20 entries are chosen is also deterministic.
+> Apply the sort BEFORE `.slice(0, 20)` so which 20 entries are chosen is also
+> deterministic.
 
 - [ ] **Step 4: Run — expect GREEN**
 
-Run: `cd packages/agent && npx vitest run src/config/__tests__/render-determinism.test.ts`
+Run:
+`cd packages/agent && npx vitest run src/config/__tests__/render-determinism.test.ts`
 Expected: PASS.
 
 - [ ] **Step 5: Add a wall-clock determinism assertion**
 
-Append a second test: render twice with `vi.useFakeTimers()` set to two different times, asserting `system.sessionDate` and the full rendered prompt are equal when the two times fall on the same UTC day, and confirming the prompt uses date-only (not timestamp). This pins the existing `sessionDate` mitigation (`variable-providers.ts:55`).
+Append a second test: render twice with `vi.useFakeTimers()` set to two
+different times, asserting `system.sessionDate` and the full rendered prompt are
+equal when the two times fall on the same UTC day, and confirming the prompt
+uses date-only (not timestamp). This pins the existing `sessionDate` mitigation
+(`variable-providers.ts:55`).
 
 ```ts
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -596,20 +869,27 @@ describe('render determinism: system date is date-only (stable within a UTC day)
   it('same UTC day, different wall-clock → identical sessionDate', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-06-18T01:00:00Z'));
-    const morning = (await new SystemVariableProvider().getVariables()) as { system: { sessionDate: string } };
+    const morning = (await new SystemVariableProvider().getVariables()) as {
+      system: { sessionDate: string };
+    };
     vi.setSystemTime(new Date('2026-06-18T23:00:00Z'));
-    const night = (await new SystemVariableProvider().getVariables()) as { system: { sessionDate: string } };
+    const night = (await new SystemVariableProvider().getVariables()) as {
+      system: { sessionDate: string };
+    };
     expect(morning.system.sessionDate).toBe(night.system.sessionDate);
     expect(morning.system.sessionDate).toBe('2026-06-18');
   });
 });
 ```
 
-> Confirm `SystemVariableProvider.getVariables()` is sync vs async (it returned a plain object in the explorer map — adjust `await` accordingly).
+> Confirm `SystemVariableProvider.getVariables()` is sync vs async (it returned
+> a plain object in the explorer map — adjust `await` accordingly).
 
-- [ ] **Step 6: Run the file — expect GREEN; then run full config suite for no regressions**
+- [ ] **Step 6: Run the file — expect GREEN; then run full config suite for no
+      regressions**
 
-Run: `cd packages/agent && npx vitest run src/config/__tests__/render-determinism.test.ts && npx vitest run src/config/`
+Run:
+`cd packages/agent && npx vitest run src/config/__tests__/render-determinism.test.ts && npx vitest run src/config/`
 Expected: PASS (no other config tests broken by the sort).
 
 - [ ] **Step 7: Commit**
@@ -623,91 +903,175 @@ git commit -m "fix(session-state): sort project-tree entries byte-stably + rende
 
 ## Task 6: Cross-turn cache-stability, per provider
 
-A second turn whose only difference is a longer tail must leave the shared prefix byte-stable. One file, three providers, each using its capture strategy: Anthropic via the real-server two-turn helper (markers stripped); OpenAI/Gemini via their file-hoisted SDK mocks (object capture, compared whole — no markers).
+A second turn whose only difference is a longer tail must leave the shared
+prefix byte-stable. One file, three providers, each using its capture strategy:
+Anthropic via the real-server two-turn helper (markers stripped); OpenAI/Gemini
+via their file-hoisted SDK mocks (object capture, compared whole — no markers).
 
 **Files:**
-- Modify: `packages/agent/src/providers/__tests__/golden/_capture-request-body.ts` (add `captureAnthropicTwoTurn`)
-- Create: `packages/agent/src/providers/__tests__/golden/cross-turn-cache-stability.test.ts`
-- Reference: existing `cache-control-byte-stable.test.ts` (the Anthropic pattern this generalizes)
+
+- Modify:
+  `packages/agent/src/providers/__tests__/golden/_capture-request-body.ts` (add
+  `captureAnthropicTwoTurn`)
+- Create:
+  `packages/agent/src/providers/__tests__/golden/cross-turn-cache-stability.test.ts`
+- Reference: existing `cache-control-byte-stable.test.ts` (the Anthropic pattern
+  this generalizes)
 
 - [ ] **Step 1: Add the Anthropic two-turn helper**
 
-In `_capture-request-body.ts`, add (reuses the same server; it pushes every request into `captured`):
+In `_capture-request-body.ts`, add (reuses the same server; it pushes every
+request into `captured`):
 
 ```ts
 export async function captureAnthropicTwoTurn(): Promise<[string, string]> {
   const { server, baseURL, captured } = await startServer((_b, n) =>
-    JSON.stringify({ id: `msg_${n}`, type: 'message', role: 'assistant', model: 'claude-sonnet-4-20250514',
-      content: [{ type: 'text', text: 'ok' }], stop_reason: 'end_turn', stop_sequence: null,
-      usage: { input_tokens: 1, output_tokens: 1 } })
+    JSON.stringify({
+      id: `msg_${n}`,
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-sonnet-4-20250514',
+      content: [{ type: 'text', text: 'ok' }],
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      usage: { input_tokens: 1, output_tokens: 1 },
+    })
   );
   try {
     const provider = new AnthropicProvider({ apiKey: 'sk-test', baseURL });
     provider.setSystemPrompt('You are Lace. Cached system block.');
     const base = [
-      { role: 'user' as const, content: 'q1' }, { role: 'assistant' as const, content: 'a1' },
-      { role: 'user' as const, content: 'q2' }, { role: 'assistant' as const, content: 'a2' },
+      { role: 'user' as const, content: 'q1' },
+      { role: 'assistant' as const, content: 'a1' },
+      { role: 'user' as const, content: 'q2' },
+      { role: 'assistant' as const, content: 'a2' },
     ];
-    await provider.createResponse([...base, { role: 'user', content: 'NEW1' }], [], 'claude-sonnet-4-20250514');
     await provider.createResponse(
-      [...base, { role: 'user', content: 'NEW1' }, { role: 'assistant', content: 'NEWA1' }, { role: 'user', content: 'NEW2' }],
-      [], 'claude-sonnet-4-20250514');
-    if (captured.length !== 2) throw new Error(`expected 2 requests, got ${captured.length}`);
+      [...base, { role: 'user', content: 'NEW1' }],
+      [],
+      'claude-sonnet-4-20250514'
+    );
+    await provider.createResponse(
+      [
+        ...base,
+        { role: 'user', content: 'NEW1' },
+        { role: 'assistant', content: 'NEWA1' },
+        { role: 'user', content: 'NEW2' },
+      ],
+      [],
+      'claude-sonnet-4-20250514'
+    );
+    if (captured.length !== 2)
+      throw new Error(`expected 2 requests, got ${captured.length}`);
     return [captured[0]!, captured[1]!];
   } finally {
-    await new Promise<void>((res, rej) => server.close((e) => (e ? rej(e) : res())));
+    await new Promise<void>((res, rej) =>
+      server.close((e) => (e ? rej(e) : res()))
+    );
   }
 }
 ```
 
 - [ ] **Step 2: Write the cross-turn test (self-contained for OpenAI/Gemini)**
 
-The file mocks `openai` and `@google/genai` (file-hoisted, module-global) for the OpenAI/Gemini object capture; the Anthropic case uses the real-server helper, unaffected by those mocks. `prefixOf` slices the shared base-history prefix off a captured object/body.
+The file mocks `openai` and `@google/genai` (file-hoisted, module-global) for
+the OpenAI/Gemini object capture; the Anthropic case uses the real-server
+helper, unaffected by those mocks. `prefixOf` slices the shared base-history
+prefix off a captured object/body.
 
 ```ts
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockCreate = vi.fn();
-vi.mock('openai', () => ({ default: class { chat = { completions: { create: mockCreate } }; } }));
+vi.mock('openai', () => ({
+  default: class {
+    chat = { completions: { create: mockCreate } };
+  },
+}));
 const mockGenerateContent = vi.fn();
 const mockGenerateContentStream = vi.fn();
-vi.mock('@google/genai', () => ({ GoogleGenAI: class { models = { generateContent: mockGenerateContent, generateContentStream: mockGenerateContentStream }; } }));
+vi.mock('@google/genai', () => ({
+  GoogleGenAI: class {
+    models = {
+      generateContent: mockGenerateContent,
+      generateContentStream: mockGenerateContentStream,
+    };
+  },
+}));
 
 import { OpenAIProvider } from '@lace/agent/providers/openai-provider';
 import { GeminiProvider } from '@lace/agent/providers/gemini-provider';
 import { captureAnthropicTwoTurn } from './_capture-request-body';
 
-const stripCacheControl = (s: string) => s.replace(/,?"cache_control":\{[^}]*\}/g, '');
+const stripCacheControl = (s: string) =>
+  s.replace(/,?"cache_control":\{[^}]*\}/g, '');
 
 // SHARED base history = 4 messages. Turn N+1 appends an assistant answer + a new
 // user message, so the first `sharedCount` provider-messages must be identical.
 const BASE = [
-  { role: 'user' as const, content: 'q1' }, { role: 'assistant' as const, content: 'a1' },
-  { role: 'user' as const, content: 'q2' }, { role: 'assistant' as const, content: 'a2' },
+  { role: 'user' as const, content: 'q1' },
+  { role: 'assistant' as const, content: 'a1' },
+  { role: 'user' as const, content: 'q2' },
+  { role: 'assistant' as const, content: 'a2' },
 ];
 const TURN1 = [...BASE, { role: 'user' as const, content: 'NEW1' }];
-const TURN2 = [...BASE, { role: 'user' as const, content: 'NEW1' }, { role: 'assistant' as const, content: 'NEWA1' }, { role: 'user' as const, content: 'NEW2' }];
+const TURN2 = [
+  ...BASE,
+  { role: 'user' as const, content: 'NEW1' },
+  { role: 'assistant' as const, content: 'NEWA1' },
+  { role: 'user' as const, content: 'NEW2' },
+];
 
 // Slice the shared prefix from a captured request object/body.
-function prefixFromObject(obj: Record<string, unknown[]>, key: string, sharedCount: number): string {
+function prefixFromObject(
+  obj: Record<string, unknown[]>,
+  key: string,
+  sharedCount: number
+): string {
   return JSON.stringify((obj[key] as unknown[]).slice(0, sharedCount));
 }
 
 describe('cross-turn cache stability: shared prefix is byte-stable', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCreate.mockResolvedValue({ choices: [{ message: { content: 'ok', tool_calls: undefined }, finish_reason: 'stop' }], usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 } });
-    mockGenerateContent.mockResolvedValue({ candidates: [{ content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' }], usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 } });
+    mockCreate.mockResolvedValue({
+      choices: [
+        {
+          message: { content: 'ok', tool_calls: undefined },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    });
+    mockGenerateContent.mockResolvedValue({
+      candidates: [
+        { content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' },
+      ],
+      usageMetadata: {
+        promptTokenCount: 1,
+        candidatesTokenCount: 1,
+        totalTokenCount: 2,
+      },
+    });
   });
 
   it('Anthropic: prefix identical after stripping cache_control', async () => {
     const [t1, t2] = await captureAnthropicTwoTurn();
-    const pre = (body: string) => JSON.stringify((JSON.parse(body) as { messages: unknown[] }).messages.slice(0, BASE.length));
+    const pre = (body: string) =>
+      JSON.stringify(
+        (JSON.parse(body) as { messages: unknown[] }).messages.slice(
+          0,
+          BASE.length
+        )
+      );
     expect(stripCacheControl(pre(t1))).toBe(stripCacheControl(pre(t2)));
   });
 
   it('OpenAI: request-object prefix identical (server-side cache, no markers)', async () => {
-    const p = new OpenAIProvider({ apiKey: 'test-key', baseURL: 'http://localhost:8080/v1' });
+    const p = new OpenAIProvider({
+      apiKey: 'test-key',
+      baseURL: 'http://localhost:8080/v1',
+    });
     p.setSystemPrompt('You are Lace. Cached system block.');
     await p.createResponse(TURN1, [], 'gpt-4o');
     const o1 = mockCreate.mock.calls.at(-1)![0] as Record<string, unknown[]>;
@@ -715,28 +1079,45 @@ describe('cross-turn cache stability: shared prefix is byte-stable', () => {
     const o2 = mockCreate.mock.calls.at(-1)![0] as Record<string, unknown[]>;
     // OpenAI prepends a system message → shared count = BASE.length + 1. Confirm the
     // body key ('messages') and the +1 by inspecting o1 on first run.
-    expect(prefixFromObject(o1, 'messages', BASE.length + 1)).toBe(prefixFromObject(o2, 'messages', BASE.length + 1));
+    expect(prefixFromObject(o1, 'messages', BASE.length + 1)).toBe(
+      prefixFromObject(o2, 'messages', BASE.length + 1)
+    );
   });
 
   it('Gemini: request-object prefix identical (no managed cache, no markers)', async () => {
     const p = new GeminiProvider({ apiKey: 'test-api-key' });
     p.setSystemPrompt('You are Lace. Cached system block.');
     await p.createResponse(TURN1, [], 'gemini-2.5-flash');
-    const o1 = mockGenerateContent.mock.calls.at(-1)![0] as Record<string, unknown[]>;
+    const o1 = mockGenerateContent.mock.calls.at(-1)![0] as Record<
+      string,
+      unknown[]
+    >;
     await p.createResponse(TURN2, [], 'gemini-2.5-flash');
-    const o2 = mockGenerateContent.mock.calls.at(-1)![0] as Record<string, unknown[]>;
+    const o2 = mockGenerateContent.mock.calls.at(-1)![0] as Record<
+      string,
+      unknown[]
+    >;
     // Gemini uses `contents` and a separate `systemInstruction` (no leading system message).
-    expect(prefixFromObject(o1, 'contents', BASE.length)).toBe(prefixFromObject(o2, 'contents', BASE.length));
+    expect(prefixFromObject(o1, 'contents', BASE.length)).toBe(
+      prefixFromObject(o2, 'contents', BASE.length)
+    );
   });
 });
 ```
 
-> The exact `sharedCount` and body key are facts to read off the first captured object, not to guess: OpenAI prepends a `system` chat message (so `BASE.length + 1` on the `messages` array); Gemini keeps the system prompt in `systemInstruction` and the turns in `contents` (so `BASE.length`). Adjust after inspecting `o1` on the first run.
+> The exact `sharedCount` and body key are facts to read off the first captured
+> object, not to guess: OpenAI prepends a `system` chat message (so
+> `BASE.length + 1` on the `messages` array); Gemini keeps the system prompt in
+> `systemInstruction` and the turns in `contents` (so `BASE.length`). Adjust
+> after inspecting `o1` on the first run.
 
 - [ ] **Step 3: Run — expect GREEN**
 
-Run: `cd packages/agent && npx vitest run src/providers/__tests__/golden/cross-turn-cache-stability.test.ts`
-Expected: PASS for all three. If a provider FAILS, that is a real pre-existing cache-stability bug — STOP and report it (do not paper over it); it is exactly what this gate exists to catch.
+Run:
+`cd packages/agent && npx vitest run src/providers/__tests__/golden/cross-turn-cache-stability.test.ts`
+Expected: PASS for all three. If a provider FAILS, that is a real pre-existing
+cache-stability bug — STOP and report it (do not paper over it); it is exactly
+what this gate exists to catch.
 
 - [ ] **Step 4: Commit**
 
@@ -750,44 +1131,88 @@ git commit -m "test(session-state): cross-turn cache-stability gate for all thre
 ## Task 7: Per-converter determinism (incl. the OpenAI token-count path)
 
 **Files:**
+
 - Create: `packages/agent/src/providers/__tests__/converter-determinism.test.ts`
-- Reference: `format-converters.ts` (all four converters), `gemini-provider.ts:114-125` (the `Date.now()/Math.random()` tool-id landmine)
+- Reference: `format-converters.ts` (all four converters),
+  `gemini-provider.ts:114-125` (the `Date.now()/Math.random()` tool-id landmine)
 
 - [ ] **Step 1: Write the converter-determinism test**
 
-Feed each converter the corpus twice and assert `JSON.stringify` byte-equality. Include a Gemini fixture whose tool call carries a *persisted* `gemini_echo_<ts>_<rand>`-style id, to prove the converter is deterministic *given a fixed id* (the landmine only fires if an id is re-minted, which happens only in response parsing — outside the converter).
+Feed each converter the corpus twice and assert `JSON.stringify` byte-equality.
+Include a Gemini fixture whose tool call carries a _persisted_
+`gemini_echo_<ts>_<rand>`-style id, to prove the converter is deterministic
+_given a fixed id_ (the landmine only fires if an id is re-minted, which happens
+only in response parsing — outside the converter).
 
 ```ts
 import { describe, it, expect } from 'vitest';
 import {
-  convertToAnthropicFormat, convertToOpenAIFormat, convertToGeminiFormat, convertToTextOnlyFormat,
+  convertToAnthropicFormat,
+  convertToOpenAIFormat,
+  convertToGeminiFormat,
+  convertToTextOnlyFormat,
 } from '@lace/agent/providers/format-converters';
 import { FIXTURES } from './golden/_fixtures';
 
 describe('converter determinism: each converter is a pure function of its input', () => {
   for (const fixture of FIXTURES) {
     it(`all four converters are byte-stable for "${fixture.name}"`, () => {
-      expect(JSON.stringify(convertToAnthropicFormat(fixture.messages))).toBe(JSON.stringify(convertToAnthropicFormat(fixture.messages)));
-      expect(JSON.stringify(convertToOpenAIFormat(fixture.messages))).toBe(JSON.stringify(convertToOpenAIFormat(fixture.messages)));
-      expect(JSON.stringify(convertToGeminiFormat(fixture.messages))).toBe(JSON.stringify(convertToGeminiFormat(fixture.messages)));
-      expect(JSON.stringify(convertToTextOnlyFormat(fixture.messages))).toBe(JSON.stringify(convertToTextOnlyFormat(fixture.messages)));
+      expect(JSON.stringify(convertToAnthropicFormat(fixture.messages))).toBe(
+        JSON.stringify(convertToAnthropicFormat(fixture.messages))
+      );
+      expect(JSON.stringify(convertToOpenAIFormat(fixture.messages))).toBe(
+        JSON.stringify(convertToOpenAIFormat(fixture.messages))
+      );
+      expect(JSON.stringify(convertToGeminiFormat(fixture.messages))).toBe(
+        JSON.stringify(convertToGeminiFormat(fixture.messages))
+      );
+      expect(JSON.stringify(convertToTextOnlyFormat(fixture.messages))).toBe(
+        JSON.stringify(convertToTextOnlyFormat(fixture.messages))
+      );
     });
   }
 
   it('Gemini converter is deterministic given a persisted tool-call id (no re-minting)', () => {
     const messages = [
       { role: 'user' as const, content: 'go' },
-      { role: 'assistant' as const, content: '', toolCalls: [{ id: 'gemini_echo_1700000000000_abc123', name: 'echo', arguments: { v: 'z' } }] },
-      { role: 'user' as const, content: '', toolResults: [{ id: 'gemini_echo_1700000000000_abc123', content: [{ type: 'text', text: 'z' }], status: 'completed' }] },
+      {
+        role: 'assistant' as const,
+        content: '',
+        toolCalls: [
+          {
+            id: 'gemini_echo_1700000000000_abc123',
+            name: 'echo',
+            arguments: { v: 'z' },
+          },
+        ],
+      },
+      {
+        role: 'user' as const,
+        content: '',
+        toolResults: [
+          {
+            id: 'gemini_echo_1700000000000_abc123',
+            content: [{ type: 'text', text: 'z' }],
+            status: 'completed',
+          },
+        ],
+      },
     ];
-    expect(JSON.stringify(convertToGeminiFormat(messages))).toBe(JSON.stringify(convertToGeminiFormat(messages)));
+    expect(JSON.stringify(convertToGeminiFormat(messages))).toBe(
+      JSON.stringify(convertToGeminiFormat(messages))
+    );
   });
 });
 ```
 
 - [ ] **Step 2: Add the OpenAI count-path determinism assertion**
 
-The spec (Invariant 5 / Step 0) requires the OpenAI `countTokensExplicit` wire re-serialization to be covered, because `_countTokensImpl` is live on the no-usage fallback path (`openai-provider.ts:759/1074/1400`). Add a focused test: count tokens for a fixture twice and assert equal. Construct `OpenAIProvider` with no network (token counting via tiktoken is local). Crib construction from `openai-provider.test.ts`.
+The spec (Invariant 5 / Step 0) requires the OpenAI `countTokensExplicit` wire
+re-serialization to be covered, because `_countTokensImpl` is live on the
+no-usage fallback path (`openai-provider.ts:759/1074/1400`). Add a focused test:
+count tokens for a fixture twice and assert equal. Construct `OpenAIProvider`
+with no network (token counting via tiktoken is local). Crib construction from
+`openai-provider.test.ts`.
 
 ```ts
 import { OpenAIProvider } from '@lace/agent/providers/openai-provider';
@@ -807,11 +1232,15 @@ describe('OpenAI token-count path is deterministic', () => {
 });
 ```
 
-> Confirm the public token-counting method name and signature in `openai-provider.ts` (the base class likely exposes `countTokens`). If tiktoken WASM init is async/flaky in CI, mark this `it` with a generous timeout; do not stub tiktoken (that would test the mock).
+> Confirm the public token-counting method name and signature in
+> `openai-provider.ts` (the base class likely exposes `countTokens`). If
+> tiktoken WASM init is async/flaky in CI, mark this `it` with a generous
+> timeout; do not stub tiktoken (that would test the mock).
 
 - [ ] **Step 3: Run — expect GREEN**
 
-Run: `cd packages/agent && npx vitest run src/providers/__tests__/converter-determinism.test.ts`
+Run:
+`cd packages/agent && npx vitest run src/providers/__tests__/converter-determinism.test.ts`
 Expected: PASS.
 
 - [ ] **Step 4: Commit**
@@ -826,10 +1255,13 @@ git commit -m "test(session-state): per-converter determinism + OpenAI count-pat
 ## Task 8: Production cache-health signal
 
 **Files:**
+
 - Create: `packages/agent/src/core/conversation/cache-health.ts`
 - Create: `packages/agent/src/core/conversation/__tests__/cache-health.test.ts`
-- Modify: `packages/agent/src/core/conversation/runner.ts` (after the `turn_end` write, ~line 1134)
-- Reference: `runner.ts:1115-1134` (turn_end write + accumulators), `utils/logger.ts`
+- Modify: `packages/agent/src/core/conversation/runner.ts` (after the `turn_end`
+  write, ~line 1134)
+- Reference: `runner.ts:1115-1134` (turn_end write + accumulators),
+  `utils/logger.ts`
 
 - [ ] **Step 1: Write the failing test for the pure builder**
 
@@ -858,8 +1290,13 @@ describe('buildCacheHealthLog', () => {
 
   it('reports rate 0 when there is no cached read (cold cache)', () => {
     const out = buildCacheHealthLog({
-      turnId: 't2', model: 'gpt-4o', inputTokens: 500,
-      cacheCreationInputTokens: 0, cacheReadInputTokens: 0, outputTokens: 10, cacheMissReason: 'first_turn',
+      turnId: 't2',
+      model: 'gpt-4o',
+      inputTokens: 500,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      outputTokens: 10,
+      cacheMissReason: 'first_turn',
     });
     expect(out.cacheReadRate).toBe(0);
     expect(out.cacheMissReason).toBe('first_turn');
@@ -867,8 +1304,13 @@ describe('buildCacheHealthLog', () => {
 
   it('avoids divide-by-zero when the turn sent no input tokens', () => {
     const out = buildCacheHealthLog({
-      turnId: 't3', model: 'm', inputTokens: 0,
-      cacheCreationInputTokens: 0, cacheReadInputTokens: 0, outputTokens: 0, cacheMissReason: null,
+      turnId: 't3',
+      model: 'm',
+      inputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      outputTokens: 0,
+      cacheMissReason: null,
     });
     expect(out.cacheReadRate).toBe(0);
   });
@@ -877,7 +1319,8 @@ describe('buildCacheHealthLog', () => {
 
 - [ ] **Step 2: Run — expect RED (module missing)**
 
-Run: `cd packages/agent && npx vitest run src/core/conversation/__tests__/cache-health.test.ts`
+Run:
+`cd packages/agent && npx vitest run src/core/conversation/__tests__/cache-health.test.ts`
 Expected: FAIL — `buildCacheHealthLog` not found.
 
 - [ ] **Step 3: Implement the pure builder**
@@ -902,7 +1345,10 @@ export type CacheHealthInput = {
 export type CacheHealthLog = CacheHealthInput & { cacheReadRate: number };
 
 export function buildCacheHealthLog(input: CacheHealthInput): CacheHealthLog {
-  const denom = input.cacheReadInputTokens + input.cacheCreationInputTokens + input.inputTokens;
+  const denom =
+    input.cacheReadInputTokens +
+    input.cacheCreationInputTokens +
+    input.inputTokens;
   const cacheReadRate = denom === 0 ? 0 : input.cacheReadInputTokens / denom;
   return { ...input, cacheReadRate };
 }
@@ -910,31 +1356,47 @@ export function buildCacheHealthLog(input: CacheHealthInput): CacheHealthLog {
 
 - [ ] **Step 4: Run — expect GREEN**
 
-Run: `cd packages/agent && npx vitest run src/core/conversation/__tests__/cache-health.test.ts`
+Run:
+`cd packages/agent && npx vitest run src/core/conversation/__tests__/cache-health.test.ts`
 Expected: PASS.
 
 - [ ] **Step 5: Wire it into the runner**
 
-In `runner.ts`, immediately AFTER the `turn_end` `writeAndAdvance({ type: 'turn_end', ... })` completes (around line 1134), add the log. Use the accumulators already in scope (`totalInputTokens`, `totalCacheCreationInputTokens`, `totalCacheReadInputTokens`, `totalOutputTokens`, `lastCacheMissReason`, `turnId`) and the model id (read the exact in-scope variable name for the model from the surrounding code — likely `this._config`/`modelId`). Import `buildCacheHealthLog` and `logger` at the top of the file (top-level imports per the repo import style).
+In `runner.ts`, immediately AFTER the `turn_end`
+`writeAndAdvance({ type: 'turn_end', ... })` completes (around line 1134), add
+the log. Use the accumulators already in scope (`totalInputTokens`,
+`totalCacheCreationInputTokens`, `totalCacheReadInputTokens`,
+`totalOutputTokens`, `lastCacheMissReason`, `turnId`) and the model id (read the
+exact in-scope variable name for the model from the surrounding code — likely
+`this._config`/`modelId`). Import `buildCacheHealthLog` and `logger` at the top
+of the file (top-level imports per the repo import style).
 
 ```ts
-logger.info('cache-health: turn complete', buildCacheHealthLog({
-  turnId,
-  model: modelId, // use the actual in-scope model variable name
-  inputTokens: totalInputTokens,
-  cacheCreationInputTokens: totalCacheCreationInputTokens,
-  cacheReadInputTokens: totalCacheReadInputTokens,
-  outputTokens: totalOutputTokens,
-  cacheMissReason: lastCacheMissReason ?? null,
-}));
+logger.info(
+  'cache-health: turn complete',
+  buildCacheHealthLog({
+    turnId,
+    model: modelId, // use the actual in-scope model variable name
+    inputTokens: totalInputTokens,
+    cacheCreationInputTokens: totalCacheCreationInputTokens,
+    cacheReadInputTokens: totalCacheReadInputTokens,
+    outputTokens: totalOutputTokens,
+    cacheMissReason: lastCacheMissReason ?? null,
+  })
+);
 ```
 
-> Place it in the same `finally`/success path where `turn_end` is written so it fires once per turn. Confirm the exact accumulator variable names by reading `runner.ts` around lines 696-726 and 1115-1134 — use the real names, not these if they differ.
+> Place it in the same `finally`/success path where `turn_end` is written so it
+> fires once per turn. Confirm the exact accumulator variable names by reading
+> `runner.ts` around lines 696-726 and 1115-1134 — use the real names, not these
+> if they differ.
 
 - [ ] **Step 6: Typecheck + run the runner test suite for no regressions**
 
-Run: `cd packages/agent && npx tsc --noEmit && npx vitest run src/core/conversation/`
-Expected: PASS, no regressions. (The log line is `info` level; it does not change control flow.)
+Run:
+`cd packages/agent && npx tsc --noEmit && npx vitest run src/core/conversation/`
+Expected: PASS, no regressions. (The log line is `info` level; it does not
+change control flow.)
 
 - [ ] **Step 7: Commit**
 
@@ -951,26 +1413,59 @@ git commit -m "feat(session-state): per-turn cache-health log signal (prod prefi
 
 - [ ] **Step 1: Typecheck + lint the whole repo**
 
-Run (from repo root): `npm run typecheck && npm run lint`
-Expected: clean.
+Run (from repo root): `npm run typecheck && npm run lint` Expected: clean.
 
 - [ ] **Step 2: Run the entire agent test suite**
 
-Run: `cd packages/agent && npx vitest run`
-Expected: PASS (pre-existing unrelated reds, if any — e.g. apple-container on Linux — are noted in MEMORY as expected; everything this plan added/touched is green).
+Run: `cd packages/agent && npx vitest run` Expected: PASS (pre-existing
+unrelated reds, if any — e.g. apple-container on Linux — are noted in MEMORY as
+expected; everything this plan added/touched is green).
 
 - [ ] **Step 3: Write the evergreen architecture doc for the guardrails**
 
-Create `docs/architecture/prompt-cache-stability.md` — an **evergreen** doc (present tense, describes the system as it *is*; **no ticket numbers, no spec/plan references, no "we added"/"this used to be" history**; match the tone of the existing `docs/architecture/*.md` files like `jobs.md`). It documents, for the next engineer:
-- **What lace guarantees and why:** the request prefix sent each turn must be byte-stable across turns so the provider prompt cache holds (Anthropic explicit `cache_control` markers — drift = ~5× re-bill; OpenAI server-side prefix cache — drift loses the discount; Gemini/local — drift loses KV reuse). The neutral `ProviderMessage[]` prefix is the stable thing; each provider converter turns it into that provider's wire shape.
-- **The golden-bytes gates** (`packages/agent/src/providers/__tests__/golden/`): the per-provider request snapshots pin the serialized request so any future change that alters the bytes shows up as a snapshot diff. Document the per-provider capture strategy (Anthropic = literal post-SDK bytes via a mock HTTP server; OpenAI/Gemini = the request object via an SDK module mock) and **how to add a fixture and regenerate** (`npx vitest run -u src/providers/__tests__/golden/`), and that a regeneration diff must be reviewed as a deliberate wire change.
-- **The cross-turn cache-stability gate:** turn N vs N+1 share a byte-identical prefix (Anthropic compared with `cache_control` markers stripped because the rolling anchor moves inside the prefix; OpenAI/Gemini compared whole).
-- **The determinism invariant** (`Invariant 5`): system-prompt + tools + each converter render to identical bytes regardless of wall-clock, cwd echo, or directory-read order. Note the concrete rules this enforces in code: project-tree entries are sorted byte-stably; the session date is date-only; tool order is byte-stable-sorted; Gemini tool-call ids are persisted, never re-minted, when rebuilding history.
-- **The production cache-health signal:** every turn logs `cache-health: turn complete` with the cache read/creation/uncached-input token split, the derived cache-read rate, and the cache-miss reason — so a prefix-cache regression in production is visible immediately. Document where it is emitted and how to read it (`LACE_LOG_LEVEL`).
+Create `docs/architecture/prompt-cache-stability.md` — an **evergreen** doc
+(present tense, describes the system as it _is_; **no ticket numbers, no
+spec/plan references, no "we added"/"this used to be" history**; match the tone
+of the existing `docs/architecture/*.md` files like `jobs.md`). It documents,
+for the next engineer:
 
-Add a one-line pointer to this doc from `docs/architecture/CODE-MAP.md` if that file has a docs index section (check; if it doesn't, skip).
+- **What lace guarantees and why:** the request prefix sent each turn must be
+  byte-stable across turns so the provider prompt cache holds (Anthropic
+  explicit `cache_control` markers — drift = ~5× re-bill; OpenAI server-side
+  prefix cache — drift loses the discount; Gemini/local — drift loses KV reuse).
+  The neutral `ProviderMessage[]` prefix is the stable thing; each provider
+  converter turns it into that provider's wire shape.
+- **The golden-bytes gates** (`packages/agent/src/providers/__tests__/golden/`):
+  the per-provider request snapshots pin the serialized request so any future
+  change that alters the bytes shows up as a snapshot diff. Document the
+  per-provider capture strategy (Anthropic = literal post-SDK bytes via a mock
+  HTTP server; OpenAI/Gemini = the request object via an SDK module mock) and
+  **how to add a fixture and regenerate**
+  (`npx vitest run -u src/providers/__tests__/golden/`), and that a regeneration
+  diff must be reviewed as a deliberate wire change.
+- **The cross-turn cache-stability gate:** turn N vs N+1 share a byte-identical
+  prefix (Anthropic compared with `cache_control` markers stripped because the
+  rolling anchor moves inside the prefix; OpenAI/Gemini compared whole).
+- **The determinism invariant** (`Invariant 5`): system-prompt + tools + each
+  converter render to identical bytes regardless of wall-clock, cwd echo, or
+  directory-read order. Note the concrete rules this enforces in code:
+  project-tree entries are sorted byte-stably; the session date is date-only;
+  tool order is byte-stable-sorted; Gemini tool-call ids are persisted, never
+  re-minted, when rebuilding history.
+- **The production cache-health signal:** every turn logs
+  `cache-health: turn complete` with the cache read/creation/uncached-input
+  token split, the derived cache-read rate, and the cache-miss reason — so a
+  prefix-cache regression in production is visible immediately. Document where
+  it is emitted and how to read it (`LACE_LOG_LEVEL`).
 
-> This doc is the Step-0 slice of the eventual evergreen `docs/architecture/session-state.md`, which grows as the later layers (single reducer, index projection, conversation projection/snapshots) land. Keep this file focused on the cache-stability guardrails; the broader session-state model doc comes with those steps.
+Add a one-line pointer to this doc from `docs/architecture/CODE-MAP.md` if that
+file has a docs index section (check; if it doesn't, skip).
+
+> This doc is the Step-0 slice of the eventual evergreen
+> `docs/architecture/session-state.md`, which grows as the later layers (single
+> reducer, index projection, conversation projection/snapshots) land. Keep this
+> file focused on the cache-stability guardrails; the broader session-state
+> model doc comes with those steps.
 
 - [ ] **Step 4: Commit**
 
@@ -983,7 +1478,21 @@ git commit -m "docs(architecture): prompt-cache stability guardrails (golden gat
 
 ## Self-review notes (for the executor)
 
-- **Spec coverage:** Task 2/3/4 = golden-bytes refactor-equivalence gate (per provider). Task 6 = cross-turn cache-stability gate (markers stripped for Anthropic, whole for OpenAI/Gemini). Task 5 = render-determinism (Invariant 5) + the readdir fix it forces. Task 7 = per-converter determinism + the OpenAI count-path coverage the spec calls out. Task 8 = prod cache-health signal. Together these are exactly the three Step 0 deliverables.
-- **Out of scope (do NOT do here):** unifying the three coalescers (Step 1), the seq tail-read / `loadSession` change (Step 2), the index/projection/snapshots (Steps 3-4), and the cross-process max-seq authority decision (an open design item to resolve before Step 3). This plan only builds the net.
-- **The load-bearing honesty:** the golden snapshots PIN current behavior — including any current bug. If the cross-turn test (Task 6) is red for a provider, that's a real finding to surface, not to snapshot away. The whole point of Step 0 is that later steps can't silently change the bytes.
-- **Provider response JSON / constructor shapes / exact field names** (`ToolCall`, `ToolResult`, `ContentBlock` image shape, model ids, the public `countTokens` method, the runner's accumulator variable names) MUST be read from the cited real files, never invented. Several steps say this explicitly.
+- **Spec coverage:** Task 2/3/4 = golden-bytes refactor-equivalence gate (per
+  provider). Task 6 = cross-turn cache-stability gate (markers stripped for
+  Anthropic, whole for OpenAI/Gemini). Task 5 = render-determinism
+  (Invariant 5) + the readdir fix it forces. Task 7 = per-converter
+  determinism + the OpenAI count-path coverage the spec calls out. Task 8 = prod
+  cache-health signal. Together these are exactly the three Step 0 deliverables.
+- **Out of scope (do NOT do here):** unifying the three coalescers (Step 1), the
+  seq tail-read / `loadSession` change (Step 2), the index/projection/snapshots
+  (Steps 3-4), and the cross-process max-seq authority decision (an open design
+  item to resolve before Step 3). This plan only builds the net.
+- **The load-bearing honesty:** the golden snapshots PIN current behavior —
+  including any current bug. If the cross-turn test (Task 6) is red for a
+  provider, that's a real finding to surface, not to snapshot away. The whole
+  point of Step 0 is that later steps can't silently change the bytes.
+- **Provider response JSON / constructor shapes / exact field names**
+  (`ToolCall`, `ToolResult`, `ContentBlock` image shape, model ids, the public
+  `countTokens` method, the runner's accumulator variable names) MUST be read
+  from the cited real files, never invented. Several steps say this explicitly.

--- a/docs/superpowers/plans/2026-06-18-session-state-step1-unify-reducer.md
+++ b/docs/superpowers/plans/2026-06-18-session-state-step1-unify-reducer.md
@@ -1,44 +1,72 @@
 # Session-State Architecture — Step 1: One Reducer (`foldEvent`) Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Replace the three divergent event→message coalescers with a single pure reducer `foldEvent`, so the batch rebuild, the compaction-tail build, and the runner's live tail all produce **one canonical message shape** — fixing a real per-parallel-tool-turn cache break (sent shape ≠ rebuilt shape) in the process.
+**Goal:** Replace the three divergent event→message coalescers with a single
+pure reducer `foldEvent`, so the batch rebuild, the compaction-tail build, and
+the runner's live tail all produce **one canonical message shape** — fixing a
+real per-parallel-tool-turn cache break (sent shape ≠ rebuilt shape) in the
+process.
 
-**Architecture:** A new pure module `message-building/fold-event.ts` exports `foldEvent(state, event) => state` and a `foldEvents(events) => state` batch wrapper. The canonical parallel-tool shape is Anthropic's documented form: **one assistant message carrying all `tool_use` blocks for the turn, followed by one user message carrying all `tool_result` blocks.** `buildProviderMessagesFromDurableEvents` and `buildPreservedTail` become thin wrappers over `foldEvents` (keeping their non-reducer concerns — system-prompt extraction, `context_compacted` reset + orphan cleanup, the compaction tail subset). The runner's live tail construction is changed to emit the same canonical shape so what's sent on turn N equals what's rebuilt on turn N+1.
+**Architecture:** A new pure module `message-building/fold-event.ts` exports
+`foldEvent(state, event) => state` and a `foldEvents(events) => state` batch
+wrapper. The canonical parallel-tool shape is Anthropic's documented form: **one
+assistant message carrying all `tool_use` blocks for the turn, followed by one
+user message carrying all `tool_result` blocks.**
+`buildProviderMessagesFromDurableEvents` and `buildPreservedTail` become thin
+wrappers over `foldEvents` (keeping their non-reducer concerns — system-prompt
+extraction, `context_compacted` reset + orphan cleanup, the compaction tail
+subset). The runner's live tail construction is changed to emit the same
+canonical shape so what's sent on turn N equals what's rebuilt on turn N+1.
 
 **Tech Stack:** TypeScript, vitest 3.x, `@lace/agent`.
 
-**Safety:** Every change is gated by the Step-0 golden + cross-turn + converter-determinism suites under `packages/agent/src/providers/__tests__/golden/`. The parallel-tool goldens **change deliberately** in this step (that is the bug fix); the cross-turn gate must stay green, and a new parallel-tool fixture must become cross-turn-stable where it would previously have drifted.
+**Safety:** Every change is gated by the Step-0 golden + cross-turn +
+converter-determinism suites under
+`packages/agent/src/providers/__tests__/golden/`. The parallel-tool goldens
+**change deliberately** in this step (that is the bug fix); the cross-turn gate
+must stay green, and a new parallel-tool fixture must become cross-turn-stable
+where it would previously have drifted.
 
 ---
 
 ## Background the implementer needs
 
-**Read first:** `docs/design/session-state-architecture.md` ("Layer 2 — Projections", Invariant 3, and Step 1) and `docs/architecture/prompt-cache-stability.md`.
+**Read first:** `docs/design/session-state-architecture.md` ("Layer 2 —
+Projections", Invariant 3, and Step 1) and
+`docs/architecture/prompt-cache-stability.md`.
 
 **The three coalescers today (verified — quoted shapes are real):**
 
 1. `buildProviderMessagesFromDurableEvents(sessionDir)` in
-   `packages/agent/src/message-building/message-builder.ts:212-402`. Reads the log,
-   two passes: pass 1 extracts `systemPrompt` (last `system_prompt_set` wins, warns on
-   >1 per era); pass 2 folds events into `ProviderMessage[]`. Per-event behavior:
-   - `prompt` → `extractContentBlocks(data.content)` (preserves images), drops empty.
+   `packages/agent/src/message-building/message-builder.ts:212-402`. Reads the
+   log, two passes: pass 1 extracts `systemPrompt` (last `system_prompt_set`
+   wins, warns on
+   > 1 per era); pass 2 folds events into `ProviderMessage[]`. Per-event
+   > behavior:
+   - `prompt` → `extractContentBlocks(data.content)` (preserves images), drops
+     empty.
    - `context_injected` → `extractTextFromContentBlocks` (text only) then
      `appendOrMergeUser(messages, text)` (merges into a trailing user message).
-   - `context_compacted` → **reset** `messages` to the `preserved[]` array verbatim,
-     then `dropOrphanedToolBlocks(messages)`.
+   - `context_compacted` → **reset** `messages` to the `preserved[]` array
+     verbatim, then `dropOrphanedToolBlocks(messages)`.
    - `message` → assistant; `content` is `data.content` if string else
      `extractTextFromContentBlocks` (text only); carries `thinkingBlocks`.
-   - `tool_use` → append `toolCall` to the trailing assistant (or push a new one);
-     if `result`, append to a trailing user-with-results (or push a new user). Because
-     the call-append makes the trailing message an assistant, **each result pushes a
-     NEW user**, and a second parallel call pushes a **NEW assistant** → split shape.
-2. `buildPreservedTail(events)` in `packages/agent/src/compaction/toolkit.ts:415-491`.
-   Same `tool_use` coalescing as (1). Differences: passes `data.content` through
-   verbatim for `prompt`/`context_injected`/`message` (preserves images everywhere);
-   does **not** merge `context_injected`; has **no** `context_compacted` or
-   `system_prompt_set` branch (it folds a post-compaction tail subset); runs **no**
-   orphan cleanup. Returns `PreservedMessage[]` (toolkit.ts:394-400).
+   - `tool_use` → append `toolCall` to the trailing assistant (or push a new
+     one); if `result`, append to a trailing user-with-results (or push a new
+     user). Because the call-append makes the trailing message an assistant,
+     **each result pushes a NEW user**, and a second parallel call pushes a
+     **NEW assistant** → split shape.
+2. `buildPreservedTail(events)` in
+   `packages/agent/src/compaction/toolkit.ts:415-491`. Same `tool_use`
+   coalescing as (1). Differences: passes `data.content` through verbatim for
+   `prompt`/`context_injected`/`message` (preserves images everywhere); does
+   **not** merge `context_injected`; has **no** `context_compacted` or
+   `system_prompt_set` branch (it folds a post-compaction tail subset); runs
+   **no** orphan cleanup. Returns `PreservedMessage[]` (toolkit.ts:394-400).
 3. The runner's live construction in
    `packages/agent/src/core/conversation/runner.ts`: lines 981-992 push **one**
    assistant `{ content: assistantText, toolCalls: [all calls] }`; the loop at
@@ -46,67 +74,97 @@
    `{ role: 'user', content: '', toolResults: [result.coreResult] }`.
 
 **The bug:** each `tool_use` event is written once with call+result together
-(`runner.ts:1394-1397` and the other `writeAndAdvance({type:'tool_use', data:{toolCallId,name,kind,input,result}})` sites). For a 2-call turn the log holds
-`tool_use(c1,r1)`, `tool_use(c2,r2)`. The runner **sent** `[assistant(c1,c2), user(r1), user(r2)]`; the rebuild **produces** `[assistant(c1), user(r1), assistant(c2), user(r2)]`. Different bytes → the cached prefix from turn N is invalid on turn N+1, on **every** parallel-tool turn.
+(`runner.ts:1394-1397` and the other
+`writeAndAdvance({type:'tool_use', data:{toolCallId,name,kind,input,result}})`
+sites). For a 2-call turn the log holds `tool_use(c1,r1)`, `tool_use(c2,r2)`.
+The runner **sent** `[assistant(c1,c2), user(r1), user(r2)]`; the rebuild
+**produces** `[assistant(c1), user(r1), assistant(c2), user(r2)]`. Different
+bytes → the cached prefix from turn N is invalid on turn N+1, on **every**
+parallel-tool turn.
 
-**The canonical shape (the fix):** for a turn with calls `c1..cN` and results `r1..rN`,
-produce exactly:
+**The canonical shape (the fix):** for a turn with calls `c1..cN` and results
+`r1..rN`, produce exactly:
+
 ```
 { role: 'assistant', content: <assistantText>, thinkingBlocks?, toolCalls: [c1..cN] }
 { role: 'user',      content: '',              toolResults: [r1..rN] }
 ```
-Both the reducer (rebuild) and the runner (live) must emit this. This matches the
-Anthropic Messages API's documented parallel-tool form and makes sent == rebuilt.
+
+Both the reducer (rebuild) and the runner (live) must emit this. This matches
+the Anthropic Messages API's documented parallel-tool form and makes sent ==
+rebuilt.
 
 **Shared types** (`packages/agent/src/providers/base-provider.ts`,
 `packages/agent/src/tools/types.ts`): `ProviderMessage`, `ContentBlock`
-(`text`|`image`), `ToolCall = {id,name,arguments}`, `ToolResult = {id?,content,status,…}`,
-`ThinkingBlock`. `coreToolResultFromProtocol` (toolkit.ts:22-49) maps a protocol
-result → `CoreToolResult`.
+(`text`|`image`), `ToolCall = {id,name,arguments}`,
+`ToolResult = {id?,content,status,…}`, `ThinkingBlock`.
+`coreToolResultFromProtocol` (toolkit.ts:22-49) maps a protocol result →
+`CoreToolResult`.
 
 **Helpers to keep:** `extractContentBlocks`, `extractTextFromContentBlocks`,
 `appendOrMergeUser` (message-builder.ts / message-building/append-or-merge.ts),
 `dropOrphanedToolBlocks` (message-builder.ts:115-191). These are **not** part of
-`foldEvent`'s tool coalescing — they are the rebuild-only concerns layered around it.
+`foldEvent`'s tool coalescing — they are the rebuild-only concerns layered
+around it.
 
-**Callers / blast radius:** `buildProviderMessagesFromDurableEvents` is called at
-`runner.ts:431`, `session-operations.ts:185/205/211`, and re-exported. `buildPreservedTail`
-is called at `track-compaction.ts:197,274`. Behavior-pinning tests:
-`message-builder.test.ts`, `compaction/toolkit.test.ts` (notably the
-"coalesces consecutive tool_use" tests at ~246-292 that assert the **split** shape —
-those assertions change in this step).
+**Callers / blast radius:** `buildProviderMessagesFromDurableEvents` is called
+at `runner.ts:431`, `session-operations.ts:185/205/211`, and re-exported.
+`buildPreservedTail` is called at `track-compaction.ts:197,274`.
+Behavior-pinning tests: `message-builder.test.ts`, `compaction/toolkit.test.ts`
+(notably the "coalesces consecutive tool_use" tests at ~246-292 that assert the
+**split** shape — those assertions change in this step).
 
-**Test command:** `cd packages/agent && npx vitest run <path>` (`-u` to regenerate golden snapshots).
+**Test command:** `cd packages/agent && npx vitest run <path>` (`-u` to
+regenerate golden snapshots).
 
 ---
 
 ## File Structure
 
 **Create:**
-- `packages/agent/src/message-building/fold-event.ts` — the pure reducer: `FoldState`, `foldEvent(state, event)`, `foldEvents(events)`, and the canonical tool-batch logic. One responsibility: events → canonical `ProviderMessage[]`.
-- `packages/agent/src/message-building/__tests__/fold-event.test.ts` — reducer unit tests + the incremental==batch fuzz.
-- `packages/agent/src/message-building/__tests__/sent-vs-rebuilt.test.ts` — the characterization gate proving sent-shape == rebuilt-shape for a parallel-tool turn.
+
+- `packages/agent/src/message-building/fold-event.ts` — the pure reducer:
+  `FoldState`, `foldEvent(state, event)`, `foldEvents(events)`, and the
+  canonical tool-batch logic. One responsibility: events → canonical
+  `ProviderMessage[]`.
+- `packages/agent/src/message-building/__tests__/fold-event.test.ts` — reducer
+  unit tests + the incremental==batch fuzz.
+- `packages/agent/src/message-building/__tests__/sent-vs-rebuilt.test.ts` — the
+  characterization gate proving sent-shape == rebuilt-shape for a parallel-tool
+  turn.
 
 **Modify:**
-- `packages/agent/src/message-building/message-builder.ts` — `buildProviderMessagesFromDurableEvents` delegates folding to `foldEvents`, keeping pass-1 system-prompt extraction, the `context_compacted` reset + `dropOrphanedToolBlocks`, `context_injected` merge, and empty-`prompt` drop.
-- `packages/agent/src/compaction/toolkit.ts` — `buildPreservedTail` delegates to `foldEvents` (tail subset; verbatim content).
-- `packages/agent/src/core/conversation/runner.ts` — the live tail at 1041-1044 accumulates results into one user message per tool batch (canonical shape).
-- `packages/agent/src/compaction/toolkit.test.ts` — update the two coalescing assertions to the canonical shape (deliberate).
-- Regenerated golden snapshots under `packages/agent/src/providers/__tests__/golden/` (new parallel-tool fixture + the shape change).
+
+- `packages/agent/src/message-building/message-builder.ts` —
+  `buildProviderMessagesFromDurableEvents` delegates folding to `foldEvents`,
+  keeping pass-1 system-prompt extraction, the `context_compacted` reset +
+  `dropOrphanedToolBlocks`, `context_injected` merge, and empty-`prompt` drop.
+- `packages/agent/src/compaction/toolkit.ts` — `buildPreservedTail` delegates to
+  `foldEvents` (tail subset; verbatim content).
+- `packages/agent/src/core/conversation/runner.ts` — the live tail at 1041-1044
+  accumulates results into one user message per tool batch (canonical shape).
+- `packages/agent/src/compaction/toolkit.test.ts` — update the two coalescing
+  assertions to the canonical shape (deliberate).
+- Regenerated golden snapshots under
+  `packages/agent/src/providers/__tests__/golden/` (new parallel-tool fixture +
+  the shape change).
 
 ---
 
 ## Task 1: Characterization — prove the sent-vs-rebuilt cache break (RED)
 
 **Files:**
-- Create: `packages/agent/src/message-building/__tests__/sent-vs-rebuilt.test.ts`
-- Reference: `runner.ts:981-992,1041-1044` (live shape), `message-builder.ts:364-398` (rebuild shape)
 
-This test does not depend on `foldEvent` yet. It builds the two shapes the two paths
-produce for the same 2-call parallel-tool turn and asserts they are equal. It is
-committed now as a vitest `it.fails(...)` (which PASSES while the bodied assertion
-fails — documenting the bug with green CI), and Task 5 flips `it.fails` → `it` once the
-reducer + runner are unified.
+- Create:
+  `packages/agent/src/message-building/__tests__/sent-vs-rebuilt.test.ts`
+- Reference: `runner.ts:981-992,1041-1044` (live shape),
+  `message-builder.ts:364-398` (rebuild shape)
+
+This test does not depend on `foldEvent` yet. It builds the two shapes the two
+paths produce for the same 2-call parallel-tool turn and asserts they are equal.
+It is committed now as a vitest `it.fails(...)` (which PASSES while the bodied
+assertion fails — documenting the bug with green CI), and Task 5 flips
+`it.fails` → `it` once the reducer + runner are unified.
 
 - [ ] **Step 1: Write the characterization test (as `it.fails`)**
 
@@ -125,12 +183,36 @@ import { join } from 'node:path';
 // then one user per result). Mirror runner.ts:981-992 + 1041-1044 exactly.
 function liveShape() {
   return [
-    { role: 'assistant', content: 'doing two things', toolCalls: [
-      { id: 'c1', name: 'echo', arguments: { v: 'a' } },
-      { id: 'c2', name: 'echo', arguments: { v: 'b' } },
-    ] },
-    { role: 'user', content: '', toolResults: [{ id: 'c1', content: [{ type: 'text', text: 'a' }], status: 'completed' }] },
-    { role: 'user', content: '', toolResults: [{ id: 'c2', content: [{ type: 'text', text: 'b' }], status: 'completed' }] },
+    {
+      role: 'assistant',
+      content: 'doing two things',
+      toolCalls: [
+        { id: 'c1', name: 'echo', arguments: { v: 'a' } },
+        { id: 'c2', name: 'echo', arguments: { v: 'b' } },
+      ],
+    },
+    {
+      role: 'user',
+      content: '',
+      toolResults: [
+        {
+          id: 'c1',
+          content: [{ type: 'text', text: 'a' }],
+          status: 'completed',
+        },
+      ],
+    },
+    {
+      role: 'user',
+      content: '',
+      toolResults: [
+        {
+          id: 'c2',
+          content: [{ type: 'text', text: 'b' }],
+          status: 'completed',
+        },
+      ],
+    },
   ];
 }
 
@@ -141,13 +223,60 @@ describe('sent shape equals rebuilt shape for a parallel-tool turn', () => {
     const dir = mkdtempSync(join(tmpdir(), 'lace-svr-'));
     try {
       const events = [
-        { eventSeq: 1, timestamp: '2026-06-18T00:00:00Z', type: 'system_prompt_set', data: { type: 'system_prompt_set', text: 'sys' } },
-        { eventSeq: 2, timestamp: '2026-06-18T00:00:01Z', type: 'prompt', data: { content: [{ type: 'text', text: 'do two things' }] } },
-        { eventSeq: 3, timestamp: '2026-06-18T00:00:02Z', type: 'message', data: { content: 'doing two things' } },
-        { eventSeq: 4, timestamp: '2026-06-18T00:00:03Z', type: 'tool_use', data: { toolCallId: 'c1', name: 'echo', kind: 'read', input: { v: 'a' }, result: { outcome: 'completed', content: [{ type: 'text', text: 'a' }] } } },
-        { eventSeq: 5, timestamp: '2026-06-18T00:00:04Z', type: 'tool_use', data: { toolCallId: 'c2', name: 'echo', kind: 'read', input: { v: 'b' }, result: { outcome: 'completed', content: [{ type: 'text', text: 'b' }] } } },
+        {
+          eventSeq: 1,
+          timestamp: '2026-06-18T00:00:00Z',
+          type: 'system_prompt_set',
+          data: { type: 'system_prompt_set', text: 'sys' },
+        },
+        {
+          eventSeq: 2,
+          timestamp: '2026-06-18T00:00:01Z',
+          type: 'prompt',
+          data: { content: [{ type: 'text', text: 'do two things' }] },
+        },
+        {
+          eventSeq: 3,
+          timestamp: '2026-06-18T00:00:02Z',
+          type: 'message',
+          data: { content: 'doing two things' },
+        },
+        {
+          eventSeq: 4,
+          timestamp: '2026-06-18T00:00:03Z',
+          type: 'tool_use',
+          data: {
+            toolCallId: 'c1',
+            name: 'echo',
+            kind: 'read',
+            input: { v: 'a' },
+            result: {
+              outcome: 'completed',
+              content: [{ type: 'text', text: 'a' }],
+            },
+          },
+        },
+        {
+          eventSeq: 5,
+          timestamp: '2026-06-18T00:00:04Z',
+          type: 'tool_use',
+          data: {
+            toolCallId: 'c2',
+            name: 'echo',
+            kind: 'read',
+            input: { v: 'b' },
+            result: {
+              outcome: 'completed',
+              content: [{ type: 'text', text: 'b' }],
+            },
+          },
+        },
       ];
-      writeFileSync(join(dir, 'events.jsonl'), events.map((e) => JSON.stringify(e)).join('\n') + '\n', 'utf8');
+      writeFileSync(
+        join(dir, 'events.jsonl'),
+        events.map((e) => JSON.stringify(e)).join('\n') + '\n',
+        'utf8'
+      );
 
       const { messages: rebuilt } = buildProviderMessagesFromDurableEvents(dir);
       // Compare the assistant+tool portion (drop the prompt user message at index 0).
@@ -160,36 +289,60 @@ describe('sent shape equals rebuilt shape for a parallel-tool turn', () => {
 });
 ```
 
-> Confirm the durable `tool_use` event's `result` field shape (`{ outcome, content }`) against a real event — read `coreToolResultFromProtocol` (toolkit.ts:22-49) and an existing fixture in `message-builder.test.ts` to match the protocol result shape exactly. Adjust the event JSON if it differs.
+> Confirm the durable `tool_use` event's `result` field shape
+> (`{ outcome, content }`) against a real event — read
+> `coreToolResultFromProtocol` (toolkit.ts:22-49) and an existing fixture in
+> `message-builder.test.ts` to match the protocol result shape exactly. Adjust
+> the event JSON if it differs.
 
 - [ ] **Step 2: Run — expect RED**
 
-Run: `cd packages/agent && npx vitest run src/message-building/__tests__/sent-vs-rebuilt.test.ts`
-Expected: FAIL — rebuilt is the split shape `[assistant(c1), user(r1), assistant(c2), user(r2)]`, not the canonical `liveShape()`.
+Run:
+`cd packages/agent && npx vitest run src/message-building/__tests__/sent-vs-rebuilt.test.ts`
+Expected: FAIL — rebuilt is the split shape
+`[assistant(c1), user(r1), assistant(c2), user(r2)]`, not the canonical
+`liveShape()`.
 
 - [ ] **Step 3: Commit (the failing characterization, marked)**
 
-Leave the test failing is NOT acceptable to commit on its own. Instead, do not commit yet — this test goes green at Task 5. Note its RED output and proceed to Task 2. (Commit it together with Task 5 when it passes.)
+Leave the test failing is NOT acceptable to commit on its own. Instead, do not
+commit yet — this test goes green at Task 5. Note its RED output and proceed to
+Task 2. (Commit it together with Task 5 when it passes.)
 
 ---
 
 ## Task 2: The pure `foldEvent` reducer (canonical shape)
 
 **Files:**
+
 - Create: `packages/agent/src/message-building/fold-event.ts`
 - Create: `packages/agent/src/message-building/__tests__/fold-event.test.ts`
 
 - [ ] **Step 1: Write the reducer unit tests first (RED)**
 
-Cover: single tool call+result; **two parallel calls+results → one assistant(2 calls) + one user(2 results)**; a `message` between two tool batches starts a fresh batch; `prompt`/`context_injected` close a batch; thinking blocks ride the assistant; and `foldEvents(events)` equals folding the same events one at a time (incremental == batch).
+Cover: single tool call+result; **two parallel calls+results → one assistant(2
+calls) + one user(2 results)**; a `message` between two tool batches starts a
+fresh batch; `prompt`/`context_injected` close a batch; thinking blocks ride the
+assistant; and `foldEvents(events)` equals folding the same events one at a time
+(incremental == batch).
 
 ```ts
 import { describe, it, expect } from 'vitest';
-import { foldEvent, foldEvents, initialFoldState } from '@lace/agent/message-building/fold-event';
+import {
+  foldEvent,
+  foldEvents,
+  initialFoldState,
+} from '@lace/agent/message-building/fold-event';
 
 const toolEvent = (id: string, v: string) => ({
   type: 'tool_use' as const,
-  data: { toolCallId: id, name: 'echo', kind: 'read', input: { v }, result: { outcome: 'completed', content: [{ type: 'text', text: v }] } },
+  data: {
+    toolCallId: id,
+    name: 'echo',
+    kind: 'read',
+    input: { v },
+    result: { outcome: 'completed', content: [{ type: 'text', text: v }] },
+  },
 });
 
 describe('foldEvent canonical tool-batch shape', () => {
@@ -201,7 +354,10 @@ describe('foldEvent canonical tool-batch shape', () => {
     ];
     const { messages } = foldEvents(events);
     expect(messages).toHaveLength(2);
-    expect(messages[0]).toMatchObject({ role: 'assistant', content: 'doing two things' });
+    expect(messages[0]).toMatchObject({
+      role: 'assistant',
+      content: 'doing two things',
+    });
     expect(messages[0].toolCalls?.map((c) => c.id)).toEqual(['c1', 'c2']);
     expect(messages[1]).toMatchObject({ role: 'user', content: '' });
     expect(messages[1].toolResults?.map((r) => r.id)).toEqual(['c1', 'c2']);
@@ -209,39 +365,55 @@ describe('foldEvent canonical tool-batch shape', () => {
 
   it('a message between two tool batches starts a fresh batch', () => {
     const events = [
-      { type: 'message' as const, data: { content: 'first' } }, toolEvent('c1', 'a'),
-      { type: 'message' as const, data: { content: 'second' } }, toolEvent('c2', 'b'),
+      { type: 'message' as const, data: { content: 'first' } },
+      toolEvent('c1', 'a'),
+      { type: 'message' as const, data: { content: 'second' } },
+      toolEvent('c2', 'b'),
     ];
     const { messages } = foldEvents(events);
     // assistant(first,c1), user(r1), assistant(second,c2), user(r2)
-    expect(messages.map((m) => m.role)).toEqual(['assistant', 'user', 'assistant', 'user']);
+    expect(messages.map((m) => m.role)).toEqual([
+      'assistant',
+      'user',
+      'assistant',
+      'user',
+    ]);
     expect(messages[0].toolCalls?.map((c) => c.id)).toEqual(['c1']);
     expect(messages[2].toolCalls?.map((c) => c.id)).toEqual(['c2']);
   });
 
   it('incremental fold equals batch fold', () => {
     const events = [
-      { type: 'message' as const, data: { content: 'x' } }, toolEvent('c1', 'a'), toolEvent('c2', 'b'),
-      { type: 'prompt' as const, data: { content: [{ type: 'text', text: 'next' }] } },
+      { type: 'message' as const, data: { content: 'x' } },
+      toolEvent('c1', 'a'),
+      toolEvent('c2', 'b'),
+      {
+        type: 'prompt' as const,
+        data: { content: [{ type: 'text', text: 'next' }] },
+      },
     ];
     let s = initialFoldState();
     for (const e of events) s = foldEvent(s, e);
-    expect(JSON.stringify(s.messages)).toBe(JSON.stringify(foldEvents(events).messages));
+    expect(JSON.stringify(s.messages)).toBe(
+      JSON.stringify(foldEvents(events).messages)
+    );
   });
 });
 ```
 
 - [ ] **Step 2: Run — expect RED (module missing)**
 
-Run: `cd packages/agent && npx vitest run src/message-building/__tests__/fold-event.test.ts`
+Run:
+`cd packages/agent && npx vitest run src/message-building/__tests__/fold-event.test.ts`
 Expected: FAIL — `fold-event` not found.
 
 - [ ] **Step 3: Implement `foldEvent`**
 
-The reducer is pure: `foldEvent(state, event) => state`. State carries the message list
-and a pointer to the current tool batch (the assistant index and the user index) so
-that a second parallel call appends to the same assistant (not the trailing message)
-and a second result appends to the same user. Any non-`tool_use` event closes the batch.
+The reducer is pure: `foldEvent(state, event) => state`. State carries the
+message list and a pointer to the current tool batch (the assistant index and
+the user index) so that a second parallel call appends to the same assistant
+(not the trailing message) and a second result appends to the same user. Any
+non-`tool_use` event closes the batch.
 
 ```ts
 // ABOUTME: The single pure reducer that folds durable events into the canonical
@@ -251,8 +423,15 @@ and a second result appends to the same user. Any non-`tool_use` event closes th
 // rebuild, the compaction-tail build, and the runner's live tail all share it, so
 // the shape sent on turn N equals the shape rebuilt on turn N+1.
 
-import type { ProviderMessage, ContentBlock, ThinkingBlock } from '@lace/agent/providers/base-provider';
-import type { ToolCall as CoreToolCall, ToolResult as CoreToolResult } from '@lace/agent/tools/types';
+import type {
+  ProviderMessage,
+  ContentBlock,
+  ThinkingBlock,
+} from '@lace/agent/providers/base-provider';
+import type {
+  ToolCall as CoreToolCall,
+  ToolResult as CoreToolResult,
+} from '@lace/agent/tools/types';
 import { coreToolResultFromProtocol } from '@lace/agent/compaction/toolkit'; // or its shared home — confirm import path
 import { toNonEmptyString } from '@lace/agent/message-building/message-builder'; // confirm export; else inline
 
@@ -260,7 +439,15 @@ export type FoldEventInput =
   | { type: 'prompt'; data: { content: unknown } }
   | { type: 'context_injected'; data: { content: unknown } }
   | { type: 'message'; data: { content?: unknown; thinkingBlocks?: unknown } }
-  | { type: 'tool_use'; data: { toolCallId?: unknown; name?: unknown; input?: unknown; result?: unknown } };
+  | {
+      type: 'tool_use';
+      data: {
+        toolCallId?: unknown;
+        name?: unknown;
+        input?: unknown;
+        result?: unknown;
+      };
+    };
 
 export type FoldState = {
   messages: ProviderMessage[];
@@ -289,8 +476,12 @@ export function foldEvent(state: FoldState, event: FoldEventInput): FoldState {
     const name = toNonEmptyString(event.data.name);
     if (!id || !name) return { messages, batch: state.batch };
     const call: CoreToolCall = {
-      id, name,
-      arguments: typeof event.data.input === 'object' && event.data.input ? (event.data.input as Record<string, unknown>) : {},
+      id,
+      name,
+      arguments:
+        typeof event.data.input === 'object' && event.data.input
+          ? (event.data.input as Record<string, unknown>)
+          : {},
     };
 
     // Find/establish the batch assistant: reuse the open batch's assistant; else
@@ -306,16 +497,28 @@ export function foldEvent(state: FoldState, event: FoldEventInput): FoldState {
       }
     }
     const a = messages[batch.assistantIdx]!;
-    messages[batch.assistantIdx] = { ...a, toolCalls: [...(a.toolCalls ?? []), call] };
+    messages[batch.assistantIdx] = {
+      ...a,
+      toolCalls: [...(a.toolCalls ?? []), call],
+    };
 
     if (event.data.result) {
-      const result: CoreToolResult = coreToolResultFromProtocol(event.data.result, id);
+      const result: CoreToolResult = coreToolResultFromProtocol(
+        event.data.result,
+        id
+      );
       if (batch.userIdx === null) {
         messages.push({ role: 'user', content: '', toolResults: [result] });
-        batch = { assistantIdx: batch.assistantIdx, userIdx: messages.length - 1 };
+        batch = {
+          assistantIdx: batch.assistantIdx,
+          userIdx: messages.length - 1,
+        };
       } else {
         const u = messages[batch.userIdx]!;
-        messages[batch.userIdx] = { ...u, toolResults: [...(u.toolResults ?? []), result] };
+        messages[batch.userIdx] = {
+          ...u,
+          toolResults: [...(u.toolResults ?? []), result],
+        };
       }
     }
     return { messages, batch };
@@ -324,9 +527,16 @@ export function foldEvent(state: FoldState, event: FoldEventInput): FoldState {
   // Any non-tool_use event closes the batch.
   if (event.type === 'message') {
     const content = asContent(event.data.content);
-    const thinkingBlocks = Array.isArray(event.data.thinkingBlocks) && event.data.thinkingBlocks.length > 0
-      ? (event.data.thinkingBlocks as ThinkingBlock[]) : undefined;
-    messages.push({ role: 'assistant', content, ...(thinkingBlocks ? { thinkingBlocks } : {}) });
+    const thinkingBlocks =
+      Array.isArray(event.data.thinkingBlocks) &&
+      event.data.thinkingBlocks.length > 0
+        ? (event.data.thinkingBlocks as ThinkingBlock[])
+        : undefined;
+    messages.push({
+      role: 'assistant',
+      content,
+      ...(thinkingBlocks ? { thinkingBlocks } : {}),
+    });
     return { messages, batch: null };
   }
 
@@ -345,16 +555,26 @@ export function foldEvents(events: FoldEventInput[]): FoldState {
 }
 ```
 
-> Confirm the import path for `coreToolResultFromProtocol` and `toNonEmptyString` (they live in `compaction/toolkit.ts` and `message-builder.ts` today; if importing from those creates a cycle, move the helper into a shared `message-building/` module and re-export). Do NOT duplicate the helper.
-> Note the reducer keeps content VERBATIM (no image-dropping). The `message`-event text-flattening that `message-builder` does today via `extractTextFromContentBlocks` is a **behavior question** — see Task 3 Step 2.
+> Confirm the import path for `coreToolResultFromProtocol` and
+> `toNonEmptyString` (they live in `compaction/toolkit.ts` and
+> `message-builder.ts` today; if importing from those creates a cycle, move the
+> helper into a shared `message-building/` module and re-export). Do NOT
+> duplicate the helper. Note the reducer keeps content VERBATIM (no
+> image-dropping). The `message`-event text-flattening that `message-builder`
+> does today via `extractTextFromContentBlocks` is a **behavior question** — see
+> Task 3 Step 2.
 
 - [ ] **Step 4: Add the incremental==batch fuzz**
 
-Append a fuzz test: generate random sequences of `message`/`prompt`/`tool_use` (with and without results, 1-4 calls per batch) and assert `foldEvents(seq)` equals folding one-by-one. Use a seeded PRNG (a small LCG with a fixed seed — no `Math.random()` so it's reproducible).
+Append a fuzz test: generate random sequences of `message`/`prompt`/`tool_use`
+(with and without results, 1-4 calls per batch) and assert `foldEvents(seq)`
+equals folding one-by-one. Use a seeded PRNG (a small LCG with a fixed seed — no
+`Math.random()` so it's reproducible).
 
 - [ ] **Step 5: Run — expect GREEN; commit**
 
-Run: `cd packages/agent && npx vitest run src/message-building/__tests__/fold-event.test.ts`
+Run:
+`cd packages/agent && npx vitest run src/message-building/__tests__/fold-event.test.ts`
 Expected: PASS.
 
 ```bash
@@ -367,51 +587,59 @@ git commit -m "feat(session-state): pure foldEvent reducer with canonical parall
 ## Task 3: Migrate `buildProviderMessagesFromDurableEvents` to `foldEvent`
 
 **Files:**
+
 - Modify: `packages/agent/src/message-building/message-builder.ts`
 - Reference tests: `packages/agent/src/message-building/message-builder.test.ts`
 
 - [ ] **Step 1: Delegate the fold; keep the rebuild-only concerns**
 
-Rewrite pass 2 to drive `foldEvent`, while keeping: pass-1 system-prompt extraction
-(unchanged); the empty-`prompt` drop; the `context_injected` text-flatten + merge
-(call `appendOrMergeUser` — NOT plain push, to preserve current merge behavior); the
-`context_compacted` reset to `preserved[]` + `dropOrphanedToolBlocks`; and image
-preservation for `prompt` (keep `extractContentBlocks`). Concretely: iterate events;
-for `prompt`/`message`/`tool_use` feed `foldEvent`; for `context_injected` and
-`context_compacted` apply the existing special handling and **reset the fold batch**
-(start a fresh `FoldState` seeded with the current `messages`). The cleanest structure
-is to keep a `FoldState` and, for the special events, mutate `state.messages` directly
-then set `state.batch = null`.
+Rewrite pass 2 to drive `foldEvent`, while keeping: pass-1 system-prompt
+extraction (unchanged); the empty-`prompt` drop; the `context_injected`
+text-flatten + merge (call `appendOrMergeUser` — NOT plain push, to preserve
+current merge behavior); the `context_compacted` reset to `preserved[]` +
+`dropOrphanedToolBlocks`; and image preservation for `prompt` (keep
+`extractContentBlocks`). Concretely: iterate events; for
+`prompt`/`message`/`tool_use` feed `foldEvent`; for `context_injected` and
+`context_compacted` apply the existing special handling and **reset the fold
+batch** (start a fresh `FoldState` seeded with the current `messages`). The
+cleanest structure is to keep a `FoldState` and, for the special events, mutate
+`state.messages` directly then set `state.batch = null`.
 
-> Image/text decision (resolve explicitly, do not hand-wave): today `message`-event
-> content is text-flattened by `extractTextFromContentBlocks` in this path, but
-> `buildPreservedTail` passes it through verbatim. The canonical reducer passes through
-> verbatim. Assistant `message` events in practice carry **string** content (the
-> assistant's text), so flatten-vs-verbatim is a no-op for the common case; verify by
-> grepping real transcripts / the `message` event writer. Adopt **verbatim** (the
-> reducer's behavior) for consistency, and if any test depended on flattening a
-> ContentBlock[] assistant message, update it deliberately and note why.
+> Image/text decision (resolve explicitly, do not hand-wave): today
+> `message`-event content is text-flattened by `extractTextFromContentBlocks` in
+> this path, but `buildPreservedTail` passes it through verbatim. The canonical
+> reducer passes through verbatim. Assistant `message` events in practice carry
+> **string** content (the assistant's text), so flatten-vs-verbatim is a no-op
+> for the common case; verify by grepping real transcripts / the `message` event
+> writer. Adopt **verbatim** (the reducer's behavior) for consistency, and if
+> any test depended on flattening a ContentBlock[] assistant message, update it
+> deliberately and note why.
 
 - [ ] **Step 2: Run the existing message-builder tests; update deliberately**
 
-Run: `cd packages/agent && npx vitest run src/message-building/message-builder.test.ts`
-Expected: the orphan-recovery, system-prompt, and context_injected tests PASS unchanged.
-Any test asserting the **split** parallel-tool shape must change to the canonical shape
-— update it and add a one-line comment that the canonical shape is the fix. If a test
-fails for any *other* reason, STOP and investigate (it may be a real regression).
+Run:
+`cd packages/agent && npx vitest run src/message-building/message-builder.test.ts`
+Expected: the orphan-recovery, system-prompt, and context*injected tests PASS
+unchanged. Any test asserting the **split** parallel-tool shape must change to
+the canonical shape — update it and add a one-line comment that the canonical
+shape is the fix. If a test fails for any \_other* reason, STOP and investigate
+(it may be a real regression).
 
 - [ ] **Step 3: Regenerate the golden corpus + add a parallel-tool fixture**
 
 Add a `tool-call-parallel-two` fixture to
-`packages/agent/src/providers/__tests__/golden/_fixtures.ts` (an assistant with two
-`toolCalls` and one user with two `toolResults` — the canonical shape). Regenerate:
-`cd packages/agent && npx vitest run -u src/providers/__tests__/golden/`, then run
-without `-u`. **Review the diff**: the new fixture's goldens appear; existing goldens
-should be unchanged (the existing fixtures have ≤1 tool call). Commit the regenerated goldens.
+`packages/agent/src/providers/__tests__/golden/_fixtures.ts` (an assistant with
+two `toolCalls` and one user with two `toolResults` — the canonical shape).
+Regenerate:
+`cd packages/agent && npx vitest run -u src/providers/__tests__/golden/`, then
+run without `-u`. **Review the diff**: the new fixture's goldens appear;
+existing goldens should be unchanged (the existing fixtures have ≤1 tool call).
+Commit the regenerated goldens.
 
 - [ ] **Step 4: Verify + commit**
 
-Run: `cd packages/agent && npx vitest run src/message-building src/providers/__tests__/golden && npx tsc --noEmit`
+Run:
+`cd packages/agent && npx vitest run src/message-building src/providers/__tests__/golden && npx tsc --noEmit`
 Expected: PASS.
 
 ```bash
@@ -424,32 +652,36 @@ git commit -m "refactor(session-state): buildProviderMessagesFromDurableEvents f
 ## Task 4: Migrate `buildPreservedTail` to `foldEvent`
 
 **Files:**
+
 - Modify: `packages/agent/src/compaction/toolkit.ts`
 - Modify: `packages/agent/src/compaction/toolkit.test.ts`
 
 - [ ] **Step 1: Delegate to `foldEvents`**
 
-`buildPreservedTail(events)` becomes: map the typed tail events to `FoldEventInput`
-and return `foldEvents(...).messages` as `PreservedMessage[]` (the types are
-structurally identical — `PreservedMessage` is `ProviderMessage` minus nothing
-relevant; confirm and, if identical, have `buildPreservedTail` return the reducer's
-messages directly). The tail contains no `context_compacted`/`system_prompt_set`, so no
-special handling is needed. Verbatim content is already what the reducer does.
+`buildPreservedTail(events)` becomes: map the typed tail events to
+`FoldEventInput` and return `foldEvents(...).messages` as `PreservedMessage[]`
+(the types are structurally identical — `PreservedMessage` is `ProviderMessage`
+minus nothing relevant; confirm and, if identical, have `buildPreservedTail`
+return the reducer's messages directly). The tail contains no
+`context_compacted`/`system_prompt_set`, so no special handling is needed.
+Verbatim content is already what the reducer does.
 
 - [ ] **Step 2: Update the two coalescing assertions (deliberate)**
 
-In `toolkit.test.ts`, the test "coalesces consecutive tool_use events" currently asserts
-the **split** shape (2 assistants, 2 users for interleaved results). Change it to the
-canonical shape: **one assistant with both calls, one user with both results.** Add a
-one-line comment: the canonical parallel-tool shape is what the runner now sends, so the
-preserved tail matches it. Keep the "coalesces multiple tool_calls when no results" test
-(it already asserts one assistant with 2 calls — still true).
+In `toolkit.test.ts`, the test "coalesces consecutive tool_use events" currently
+asserts the **split** shape (2 assistants, 2 users for interleaved results).
+Change it to the canonical shape: **one assistant with both calls, one user with
+both results.** Add a one-line comment: the canonical parallel-tool shape is
+what the runner now sends, so the preserved tail matches it. Keep the "coalesces
+multiple tool_calls when no results" test (it already asserts one assistant with
+2 calls — still true).
 
 - [ ] **Step 3: Run — expect GREEN; commit**
 
 Run: `cd packages/agent && npx vitest run src/compaction && npx tsc --noEmit`
-Expected: PASS (the compaction strategy/byte-safe seam tests must stay green — the
-preserved array shape changed but is still valid and orphan-free for live turns).
+Expected: PASS (the compaction strategy/byte-safe seam tests must stay green —
+the preserved array shape changed but is still valid and orphan-free for live
+turns).
 
 ```bash
 git add packages/agent/src/compaction/toolkit.ts packages/agent/src/compaction/toolkit.test.ts
@@ -461,36 +693,46 @@ git commit -m "refactor(session-state): buildPreservedTail folds via foldEvent (
 ## Task 5: Make the runner's live tail emit the canonical shape
 
 **Files:**
-- Modify: `packages/agent/src/core/conversation/runner.ts` (the tool loop, ~1001-1059)
-- Create/commit: `packages/agent/src/message-building/__tests__/sent-vs-rebuilt.test.ts` (from Task 1) now goes green
+
+- Modify: `packages/agent/src/core/conversation/runner.ts` (the tool loop,
+  ~1001-1059)
+- Create/commit:
+  `packages/agent/src/message-building/__tests__/sent-vs-rebuilt.test.ts` (from
+  Task 1) now goes green
 
 - [ ] **Step 1: Accumulate results into one user per tool batch**
 
-Today (runner.ts:1041-1044) each tool result pushes a **new** user message. Change it
-so all results of the current batch accumulate into a **single** trailing user message,
-matching the canonical shape (the assistant with all calls was already pushed once at
-981-992). Concretely: before the per-call loop, after pushing the assistant message,
-push one empty `{ role: 'user', content: '', toolResults: [] }`; inside the loop, append
-`result.coreResult` to that message's `toolResults` instead of pushing a new user.
-Keep the existing `shouldContinue`/`permission_cancelled` handling unchanged.
+Today (runner.ts:1041-1044) each tool result pushes a **new** user message.
+Change it so all results of the current batch accumulate into a **single**
+trailing user message, matching the canonical shape (the assistant with all
+calls was already pushed once at 981-992). Concretely: before the per-call loop,
+after pushing the assistant message, push one empty
+`{ role: 'user', content: '', toolResults: [] }`; inside the loop, append
+`result.coreResult` to that message's `toolResults` instead of pushing a new
+user. Keep the existing `shouldContinue`/`permission_cancelled` handling
+unchanged.
 
-> Read 1001-1059 carefully: the loop also handles `shouldContinue=false` mid-batch.
-> Ensure the single-user accumulation still holds if the batch stops early (a partial
-> result set in one user message is fine and matches what a partial rebuild produces).
-> Do not change control flow other than where results are appended.
+> Read 1001-1059 carefully: the loop also handles `shouldContinue=false`
+> mid-batch. Ensure the single-user accumulation still holds if the batch stops
+> early (a partial result set in one user message is fine and matches what a
+> partial rebuild produces). Do not change control flow other than where results
+> are appended.
 
-- [ ] **Step 2: Flip the characterization test `it.fails` → `it` (now genuinely GREEN)**
+- [ ] **Step 2: Flip the characterization test `it.fails` → `it` (now genuinely
+      GREEN)**
 
-The reducer + runner are now unified, so the assertion passes — which means `it.fails`
-would now FAIL (it expects a failure). Change `it.fails(` back to `it(` in
-`sent-vs-rebuilt.test.ts` and remove the two-line `it.fails` comment.
+The reducer + runner are now unified, so the assertion passes — which means
+`it.fails` would now FAIL (it expects a failure). Change `it.fails(` back to
+`it(` in `sent-vs-rebuilt.test.ts` and remove the two-line `it.fails` comment.
 
-Run: `cd packages/agent && npx vitest run src/message-building/__tests__/sent-vs-rebuilt.test.ts`
+Run:
+`cd packages/agent && npx vitest run src/message-building/__tests__/sent-vs-rebuilt.test.ts`
 Expected: PASS — rebuilt tail now equals the canonical live shape.
 
 Then run the runner suite for regressions:
 `cd packages/agent && npx vitest run src/core/conversation && npx tsc --noEmit`
-Expected: PASS. Any runner test asserting the old N-user shape is updated deliberately.
+Expected: PASS. Any runner test asserting the old N-user shape is updated
+deliberately.
 
 ```bash
 git add packages/agent/src/core/conversation/runner.ts packages/agent/src/message-building/__tests__/sent-vs-rebuilt.test.ts
@@ -502,33 +744,39 @@ git commit -m "fix(session-state): runner emits canonical parallel-tool shape (s
 ## Task 6: Full verification + evergreen doc
 
 **Files:**
-- Create: `packages/agent/src/providers/__tests__/golden/cross-turn-parallel-tool.test.ts` (or extend the cross-turn test)
-- Modify: `docs/architecture/prompt-cache-stability.md` (add the reducer + canonical-shape section)
+
+- Create:
+  `packages/agent/src/providers/__tests__/golden/cross-turn-parallel-tool.test.ts`
+  (or extend the cross-turn test)
+- Modify: `docs/architecture/prompt-cache-stability.md` (add the reducer +
+  canonical-shape section)
 
 - [ ] **Step 1: Add a cross-turn parallel-tool stability assertion**
 
-Extend `cross-turn-cache-stability.test.ts` (or add a sibling) with a two-turn scenario
-whose turn 1 includes a parallel-tool exchange, asserting the shared prefix (through the
-parallel-tool turn) is byte-stable across turn 2. Before this step it would have drifted;
-now it is stable. Run and confirm GREEN.
+Extend `cross-turn-cache-stability.test.ts` (or add a sibling) with a two-turn
+scenario whose turn 1 includes a parallel-tool exchange, asserting the shared
+prefix (through the parallel-tool turn) is byte-stable across turn 2. Before
+this step it would have drifted; now it is stable. Run and confirm GREEN.
 
 - [ ] **Step 2: Full Step-0 + Step-1 gate run**
 
-Run (repo root): `npm run typecheck && npm run lint`
-Run: `cd packages/agent && npx vitest run src/message-building src/compaction src/core/conversation src/providers/__tests__/golden`
-Expected: PASS (the known environmental `ollama-integration.test.ts` red is unrelated).
+Run (repo root): `npm run typecheck && npm run lint` Run:
+`cd packages/agent && npx vitest run src/message-building src/compaction src/core/conversation src/providers/__tests__/golden`
+Expected: PASS (the known environmental `ollama-integration.test.ts` red is
+unrelated).
 
 - [ ] **Step 3: Document the reducer in the evergreen doc**
 
-Add a section to `docs/architecture/prompt-cache-stability.md` (present-tense, no refs):
-"**One reducer.** Events become messages through a single pure reducer
-(`packages/agent/src/message-building/fold-event.ts`). A turn's parallel tool calls fold
-into one assistant message carrying all `tool_use` blocks followed by one user message
-carrying all `tool_result` blocks — the Anthropic parallel-tool form. The batch rebuild
-(`buildProviderMessagesFromDurableEvents`), the compaction tail (`buildPreservedTail`),
-and the runner's live tail all share this reducer, so the shape sent on one turn is the
-shape rebuilt on the next, and the cached prefix holds across parallel-tool turns." Note
-that `context_compacted` reset + `dropOrphanedToolBlocks` and the `context_injected`
+Add a section to `docs/architecture/prompt-cache-stability.md` (present-tense,
+no refs): "**One reducer.** Events become messages through a single pure reducer
+(`packages/agent/src/message-building/fold-event.ts`). A turn's parallel tool
+calls fold into one assistant message carrying all `tool_use` blocks followed by
+one user message carrying all `tool_result` blocks — the Anthropic parallel-tool
+form. The batch rebuild (`buildProviderMessagesFromDurableEvents`), the
+compaction tail (`buildPreservedTail`), and the runner's live tail all share
+this reducer, so the shape sent on one turn is the shape rebuilt on the next,
+and the cached prefix holds across parallel-tool turns." Note that
+`context_compacted` reset + `dropOrphanedToolBlocks` and the `context_injected`
 text-merge remain rebuild-only concerns layered around the reducer.
 
 - [ ] **Step 4: Commit**
@@ -542,18 +790,21 @@ git commit -m "test+docs(session-state): cross-turn parallel-tool stability + re
 
 ## Self-review notes (for the executor)
 
-- **The canonical shape is the contract:** one assistant (all `tool_use`) + one user
-  (all `tool_result`) per turn. All three paths must produce it. The whole point is
-  sent == rebuilt, proven by `sent-vs-rebuilt.test.ts`.
+- **The canonical shape is the contract:** one assistant (all `tool_use`) + one
+  user (all `tool_result`) per turn. All three paths must produce it. The whole
+  point is sent == rebuilt, proven by `sent-vs-rebuilt.test.ts`.
 - **Deliberate golden/test changes:** the parallel-tool goldens and the two
-  `toolkit.test.ts` coalescing assertions change *on purpose* (the bug fix). Single-tool
-  and non-tool goldens must NOT change — if they do, that's an unintended regression;
-  STOP.
+  `toolkit.test.ts` coalescing assertions change _on purpose_ (the bug fix).
+  Single-tool and non-tool goldens must NOT change — if they do, that's an
+  unintended regression; STOP.
 - **Keep rebuild-only concerns out of the reducer:** system-prompt extraction,
-  `context_compacted` reset + `dropOrphanedToolBlocks`, `context_injected` text-merge,
-  and empty-`prompt` drop stay in `buildProviderMessagesFromDurableEvents`. The reducer
-  is pure event→message folding with verbatim content.
-- **Do not touch seq derivation, the index, or snapshots** — those are Steps 2-4.
-- **No invented details:** confirm `coreToolResultFromProtocol`/`toNonEmptyString` import
-  paths, the protocol `result` shape in `tool_use` events, and `PreservedMessage` vs
+  `context_compacted` reset + `dropOrphanedToolBlocks`, `context_injected`
+  text-merge, and empty-`prompt` drop stay in
+  `buildProviderMessagesFromDurableEvents`. The reducer is pure event→message
+  folding with verbatim content.
+- **Do not touch seq derivation, the index, or snapshots** — those are Steps
+  2-4.
+- **No invented details:** confirm
+  `coreToolResultFromProtocol`/`toNonEmptyString` import paths, the protocol
+  `result` shape in `tool_use` events, and `PreservedMessage` vs
   `ProviderMessage` structural identity against source before finalizing.

--- a/docs/superpowers/plans/2026-06-18-session-state-step2-coalesce-turn-entry-reads.md
+++ b/docs/superpowers/plans/2026-06-18-session-state-step2-coalesce-turn-entry-reads.md
@@ -1,61 +1,128 @@
 # Session-State Architecture — Step 2: Coalesce Turn-Entry Reads Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Cut the per-turn cost of reading the durable event log by reading and parsing it **once** at turn entry and deriving the three things the turn needs from that single parsed array — instead of three independent full reads, each re-parsing the whole log.
+**Goal:** Cut the per-turn cost of reading the durable event log by reading and
+parsing it **once** at turn entry and deriving the three things the turn needs
+from that single parsed array — instead of three independent full reads, each
+re-parsing the whole log.
 
-**Architecture:** Separate I/O from derivation. A new `readParsedSessionEvents(sessionDir)` reads the log and parses every line **once** into a sorted `ParsedSessionEvent[]`. Three existing turn-entry derivers (`buildProviderMessagesFromDurableEvents`, `deriveFilesReadFromDurableEvents`, `findLastTurnEndEventSeq`) gain pure `*FromParsedEvents` cores that operate on that array; their original I/O signatures stay for non-hot-path callers. A single `loadTurnEntryProjection(sessionDir, cwd)` does one read + the three pure derivations, and the runner calls it once. **No wire bytes, no durable format, no seq assignment changes** — purely where parsing happens.
+**Architecture:** Separate I/O from derivation. A new
+`readParsedSessionEvents(sessionDir)` reads the log and parses every line
+**once** into a sorted `ParsedSessionEvent[]`. Three existing turn-entry
+derivers (`buildProviderMessagesFromDurableEvents`,
+`deriveFilesReadFromDurableEvents`, `findLastTurnEndEventSeq`) gain pure
+`*FromParsedEvents` cores that operate on that array; their original I/O
+signatures stay for non-hot-path callers. A single
+`loadTurnEntryProjection(sessionDir, cwd)` does one read + the three pure
+derivations, and the runner calls it once. **No wire bytes, no durable format,
+no seq assignment changes** — purely where parsing happens.
 
 **Tech Stack:** TypeScript, vitest 3.x, `@lace/agent`.
 
-**Why this is safe and why now:** This is the spec's Step 2 ("buy time — make Ada usable"), restricted to the byte-safe subset. The dominant per-turn costs (the per-append `deriveNextEventSeqAcrossSessionFiles` scan and the per-iteration inject read) are deliberately **not** touched here — they require the durable index and cross-process seq authority of Step 3. Step 2 is the low-risk read-coalescing that also establishes the "parse once, derive many" shape the projection (Step 4) builds on.
+**Why this is safe and why now:** This is the spec's Step 2 ("buy time — make
+Ada usable"), restricted to the byte-safe subset. The dominant per-turn costs
+(the per-append `deriveNextEventSeqAcrossSessionFiles` scan and the
+per-iteration inject read) are deliberately **not** touched here — they require
+the durable index and cross-process seq authority of Step 3. Step 2 is the
+low-risk read-coalescing that also establishes the "parse once, derive many"
+shape the projection (Step 4) builds on.
 
 ---
 
 ## Background the implementer needs
 
-**Read first:** `docs/design/session-state-architecture.md` (Step 2 and Invariant 2), `docs/architecture/prompt-cache-stability.md`.
+**Read first:** `docs/design/session-state-architecture.md` (Step 2 and
+Invariant 2), `docs/architecture/prompt-cache-stability.md`.
 
-**The three independent turn-entry reads today** (all in `packages/agent/src/core/conversation/runner.ts`, turn setup ~lines 410–490) — each calls `readAllSessionEventLines` and parses the whole log separately:
+**The three independent turn-entry reads today** (all in
+`packages/agent/src/core/conversation/runner.ts`, turn setup ~lines 410–490) —
+each calls `readAllSessionEventLines` and parses the whole log separately:
 
-1. `buildProviderMessagesFromDurableEvents(sessionDir)` — `packages/agent/src/message-building/message-builder.ts:212`. Returns `{ messages: ProviderMessage[]; systemPrompt: string }` (type `BuiltProviderMessages`). Internally: `readAllSessionEventLines` (which itself parses every line to sort by `eventSeq`), then re-parses every line into `parsedEvents`, then a system-prompt pass and a fold pass. Called at `runner.ts:431`.
-2. `deriveFilesReadFromDurableEvents(sessionDir, cwd)` — `packages/agent/src/message-building/files-from-events.ts:18` (confirm exact path/signature). Reads the log, scans `tool_use` events with a `file_read`/completed outcome, returns a `Set<string>` or `string[]` of file paths. Called at `runner.ts:413`.
-3. `findLastTurnEndEventSeq(sessionDir)` — `packages/agent/src/storage/event-log.ts:365`. Reads the log, returns the `eventSeq` of the most recent `turn_end` (or `undefined`). Called at `runner.ts:490`.
+1. `buildProviderMessagesFromDurableEvents(sessionDir)` —
+   `packages/agent/src/message-building/message-builder.ts:212`. Returns
+   `{ messages: ProviderMessage[]; systemPrompt: string }` (type
+   `BuiltProviderMessages`). Internally: `readAllSessionEventLines` (which
+   itself parses every line to sort by `eventSeq`), then re-parses every line
+   into `parsedEvents`, then a system-prompt pass and a fold pass. Called at
+   `runner.ts:431`.
+2. `deriveFilesReadFromDurableEvents(sessionDir, cwd)` —
+   `packages/agent/src/message-building/files-from-events.ts:18` (confirm exact
+   path/signature). Reads the log, scans `tool_use` events with a
+   `file_read`/completed outcome, returns a `Set<string>` or `string[]` of file
+   paths. Called at `runner.ts:413`.
+3. `findLastTurnEndEventSeq(sessionDir)` —
+   `packages/agent/src/storage/event-log.ts:365`. Reads the log, returns the
+   `eventSeq` of the most recent `turn_end` (or `undefined`). Called at
+   `runner.ts:490`.
 
-**The reader:** `readAllSessionEventLines(sessionDir): string[]` — `packages/agent/src/storage/event-log.ts:102`. Reads legacy `events.jsonl` + the new-layout transcript shards, then **sorts the lines by parsing each line's `eventSeq`**. So every caller that then re-parses pays for two parses of the whole log.
+**The reader:** `readAllSessionEventLines(sessionDir): string[]` —
+`packages/agent/src/storage/event-log.ts:102`. Reads legacy `events.jsonl` + the
+new-layout transcript shards, then **sorts the lines by parsing each line's
+`eventSeq`**. So every caller that then re-parses pays for two parses of the
+whole log.
 
-**Durable event shape on disk** (one JSON object per line): at minimum `{ eventSeq: number, timestamp: string, type: string, turnId?, turnSeq?, data: object }`. The three derivers only need `eventSeq`, `type`, and `data`.
+**Durable event shape on disk** (one JSON object per line): at minimum
+`{ eventSeq: number, timestamp: string, type: string, turnId?, turnSeq?, data: object }`.
+The three derivers only need `eventSeq`, `type`, and `data`.
 
-**Non-hot-path callers that must keep working unchanged:** `buildProviderMessagesFromDurableEvents` is also called from `packages/agent/src/rpc/handlers/session-operations.ts:185,205,211` (RPC handlers). Keep its `(sessionDir) => BuiltProviderMessages` signature intact (it will delegate to the new pure core).
+**Non-hot-path callers that must keep working unchanged:**
+`buildProviderMessagesFromDurableEvents` is also called from
+`packages/agent/src/rpc/handlers/session-operations.ts:185,205,211` (RPC
+handlers). Keep its `(sessionDir) => BuiltProviderMessages` signature intact (it
+will delegate to the new pure core).
 
-**What is explicitly OUT of scope for Step 2** (do not touch — Step 3): `deriveNextEventSeqAcrossSessionFiles` (the per-append seq scan), `readImmediateInjectsSince` / `readDurableEvents` (the per-iteration inject read), `appendDurableEvent` seq assignment, `writeAndAdvance` state read/write, and `loadSession`'s repair. Reads/parsing/derivation only.
+**What is explicitly OUT of scope for Step 2** (do not touch — Step 3):
+`deriveNextEventSeqAcrossSessionFiles` (the per-append seq scan),
+`readImmediateInjectsSince` / `readDurableEvents` (the per-iteration inject
+read), `appendDurableEvent` seq assignment, `writeAndAdvance` state read/write,
+and `loadSession`'s repair. Reads/parsing/derivation only.
 
-**Test command:** `cd packages/agent && npx vitest run <path>`. Typecheck/lint from repo root: `npm run typecheck && npm run lint`.
+**Test command:** `cd packages/agent && npx vitest run <path>`. Typecheck/lint
+from repo root: `npm run typecheck && npm run lint`.
 
 ---
 
 ## File Structure
 
 **Create:**
-- `packages/agent/src/message-building/parsed-events.ts` — the `ParsedSessionEvent` type and `readParsedSessionEvents(sessionDir)` (read + parse + sort once). One responsibility: turn the durable log into a parsed, sorted event array.
-- `packages/agent/src/message-building/turn-entry-projection.ts` — `loadTurnEntryProjection(sessionDir, cwd)`: one read, three pure derivations, returns the bundle the runner needs. The single hot-path entry.
+
+- `packages/agent/src/message-building/parsed-events.ts` — the
+  `ParsedSessionEvent` type and `readParsedSessionEvents(sessionDir)` (read +
+  parse + sort once). One responsibility: turn the durable log into a parsed,
+  sorted event array.
+- `packages/agent/src/message-building/turn-entry-projection.ts` —
+  `loadTurnEntryProjection(sessionDir, cwd)`: one read, three pure derivations,
+  returns the bundle the runner needs. The single hot-path entry.
 - `packages/agent/src/message-building/__tests__/parsed-events.test.ts`
 - `packages/agent/src/message-building/__tests__/turn-entry-projection.test.ts`
 
 **Modify:**
-- `packages/agent/src/message-building/message-builder.ts` — add `buildProviderMessagesFromParsedEvents(events)`; make `buildProviderMessagesFromDurableEvents(sessionDir)` delegate to it.
-- `packages/agent/src/message-building/files-from-events.ts` — add `deriveFilesReadFromParsedEvents(events, cwd)`; make the I/O version delegate.
-- `packages/agent/src/storage/event-log.ts` — add `findLastTurnEndSeqFromParsedEvents(events)`; make `findLastTurnEndEventSeq(sessionDir)` delegate.
-- `packages/agent/src/core/conversation/runner.ts` — replace the three turn-entry calls (413, 431, 490) with one `loadTurnEntryProjection`.
+
+- `packages/agent/src/message-building/message-builder.ts` — add
+  `buildProviderMessagesFromParsedEvents(events)`; make
+  `buildProviderMessagesFromDurableEvents(sessionDir)` delegate to it.
+- `packages/agent/src/message-building/files-from-events.ts` — add
+  `deriveFilesReadFromParsedEvents(events, cwd)`; make the I/O version delegate.
+- `packages/agent/src/storage/event-log.ts` — add
+  `findLastTurnEndSeqFromParsedEvents(events)`; make
+  `findLastTurnEndEventSeq(sessionDir)` delegate.
+- `packages/agent/src/core/conversation/runner.ts` — replace the three
+  turn-entry calls (413, 431, 490) with one `loadTurnEntryProjection`.
 
 ---
 
 ## Task 1: `readParsedSessionEvents` — read + parse + sort once
 
 **Files:**
+
 - Create: `packages/agent/src/message-building/parsed-events.ts`
 - Create: `packages/agent/src/message-building/__tests__/parsed-events.test.ts`
-- Reference: `packages/agent/src/storage/event-log.ts:102` (`readAllSessionEventLines`) and `:194` (how it reads shards + legacy).
+- Reference: `packages/agent/src/storage/event-log.ts:102`
+  (`readAllSessionEventLines`) and `:194` (how it reads shards + legacy).
 
 - [ ] **Step 1: Write the failing test**
 
@@ -76,9 +143,19 @@ describe('readParsedSessionEvents', () => {
   it('reads, parses, and sorts events by eventSeq from the legacy log', () => {
     // Intentionally out of order on disk; a malformed line must be skipped.
     const lines = [
-      JSON.stringify({ eventSeq: 2, timestamp: 't', type: 'message', data: { content: 'b' } }),
+      JSON.stringify({
+        eventSeq: 2,
+        timestamp: 't',
+        type: 'message',
+        data: { content: 'b' },
+      }),
       'not json',
-      JSON.stringify({ eventSeq: 1, timestamp: 't', type: 'prompt', data: { content: 'a' } }),
+      JSON.stringify({
+        eventSeq: 1,
+        timestamp: 't',
+        type: 'prompt',
+        data: { content: 'a' },
+      }),
     ];
     writeFileSync(join(dir, 'events.jsonl'), lines.join('\n') + '\n', 'utf8');
 
@@ -94,11 +171,17 @@ describe('readParsedSessionEvents', () => {
 });
 ```
 
-- [ ] **Step 2: Run — expect RED** (`cd packages/agent && npx vitest run src/message-building/__tests__/parsed-events.test.ts`) — module not found.
+- [ ] **Step 2: Run — expect RED**
+      (`cd packages/agent && npx vitest run src/message-building/__tests__/parsed-events.test.ts`)
+      — module not found.
 
 - [ ] **Step 3: Implement**
 
-The file read must cover the SAME files `readAllSessionEventLines` covers (legacy `events.jsonl` + new-layout shards). Reuse the existing file-listing helpers from `event-log.ts` rather than reimplementing shard discovery. Read `event-log.ts:102-148` and use the same `listTranscriptFiles(getLaceDir(), sessionId)` + legacy-path logic.
+The file read must cover the SAME files `readAllSessionEventLines` covers
+(legacy `events.jsonl` + new-layout shards). Reuse the existing file-listing
+helpers from `event-log.ts` rather than reimplementing shard discovery. Read
+`event-log.ts:102-148` and use the same
+`listTranscriptFiles(getLaceDir(), sessionId)` + legacy-path logic.
 
 ```ts
 // ABOUTME: Reads the durable session event log and parses every line ONCE into a
@@ -114,17 +197,26 @@ export type ParsedSessionEvent = {
   data: Record<string, unknown>;
 };
 
-export function readParsedSessionEvents(sessionDir: string): ParsedSessionEvent[] {
+export function readParsedSessionEvents(
+  sessionDir: string
+): ParsedSessionEvent[] {
   const lines = readAllSessionEventLines(sessionDir); // already shard+legacy aware, sorted
   const events: ParsedSessionEvent[] = [];
   for (const line of lines) {
     if (!line) continue;
     try {
-      const p = JSON.parse(line) as { eventSeq?: unknown; type?: unknown; data?: unknown };
+      const p = JSON.parse(line) as {
+        eventSeq?: unknown;
+        type?: unknown;
+        data?: unknown;
+      };
       events.push({
         eventSeq: typeof p.eventSeq === 'number' ? p.eventSeq : 0,
         type: typeof p.type === 'string' ? p.type : '',
-        data: typeof p.data === 'object' && p.data ? (p.data as Record<string, unknown>) : {},
+        data:
+          typeof p.data === 'object' && p.data
+            ? (p.data as Record<string, unknown>)
+            : {},
       });
     } catch {
       // skip malformed
@@ -134,7 +226,12 @@ export function readParsedSessionEvents(sessionDir: string): ParsedSessionEvent[
 }
 ```
 
-> NOTE: `readAllSessionEventLines` already returns lines sorted by `eventSeq`, so this parses each line exactly once more (down from the 2× the hot path pays today: the sort-parse plus each deriver's own parse). A later refinement could expose the raw lines without the sort-parse, but that touches `readAllSessionEventLines`'s many callers — out of scope here. The win in this plan is collapsing **three** parses (one per deriver) into **one**.
+> NOTE: `readAllSessionEventLines` already returns lines sorted by `eventSeq`,
+> so this parses each line exactly once more (down from the 2× the hot path pays
+> today: the sort-parse plus each deriver's own parse). A later refinement could
+> expose the raw lines without the sort-parse, but that touches
+> `readAllSessionEventLines`'s many callers — out of scope here. The win in this
+> plan is collapsing **three** parses (one per deriver) into **one**.
 
 - [ ] **Step 4: Run — expect GREEN.**
 
@@ -150,17 +247,24 @@ git commit -m "feat(session-state): readParsedSessionEvents — parse the durabl
 ## Task 2: Pure `*FromParsedEvents` derivers (with delegating I/O wrappers)
 
 **Files:**
+
 - Modify: `packages/agent/src/message-building/message-builder.ts`
 - Modify: `packages/agent/src/message-building/files-from-events.ts`
 - Modify: `packages/agent/src/storage/event-log.ts`
-- Test: `packages/agent/src/message-building/__tests__/parsed-events.test.ts` (extend) or a new equivalence test file.
+- Test: `packages/agent/src/message-building/__tests__/parsed-events.test.ts`
+  (extend) or a new equivalence test file.
 
 - [ ] **Step 1: Extract `buildProviderMessagesFromParsedEvents`**
 
-In `message-builder.ts`, split the existing `buildProviderMessagesFromDurableEvents` so the pure logic takes the parsed array. Keep the public I/O signature delegating:
+In `message-builder.ts`, split the existing
+`buildProviderMessagesFromDurableEvents` so the pure logic takes the parsed
+array. Keep the public I/O signature delegating:
 
 ```ts
-import { readParsedSessionEvents, type ParsedSessionEvent } from './parsed-events';
+import {
+  readParsedSessionEvents,
+  type ParsedSessionEvent,
+} from './parsed-events';
 
 export function buildProviderMessagesFromParsedEvents(
   parsedEvents: ParsedSessionEvent[]
@@ -171,33 +275,51 @@ export function buildProviderMessagesFromParsedEvents(
   // fold pass are unchanged.
 }
 
-export function buildProviderMessagesFromDurableEvents(sessionDir: string): BuiltProviderMessages {
-  return buildProviderMessagesFromParsedEvents(readParsedSessionEvents(sessionDir));
+export function buildProviderMessagesFromDurableEvents(
+  sessionDir: string
+): BuiltProviderMessages {
+  return buildProviderMessagesFromParsedEvents(
+    readParsedSessionEvents(sessionDir)
+  );
 }
 ```
 
-> The current function's local `ParsedEvent` type is `{ type: string; data: Record<string, unknown> }` — a structural subset of `ParsedSessionEvent`, so the existing two passes work unchanged on `ParsedSessionEvent[]`. Delete the now-redundant local read + re-parse loop.
+> The current function's local `ParsedEvent` type is
+> `{ type: string; data: Record<string, unknown> }` — a structural subset of
+> `ParsedSessionEvent`, so the existing two passes work unchanged on
+> `ParsedSessionEvent[]`. Delete the now-redundant local read + re-parse loop.
 
 - [ ] **Step 2: Extract `deriveFilesReadFromParsedEvents`**
 
 In `files-from-events.ts`, do the same split:
 
 ```ts
-import { readParsedSessionEvents, type ParsedSessionEvent } from './parsed-events';
+import {
+  readParsedSessionEvents,
+  type ParsedSessionEvent,
+} from './parsed-events';
 
 export function deriveFilesReadFromParsedEvents(
   parsedEvents: ParsedSessionEvent[],
   cwd: string
 ): /* the existing return type — confirm Set<string> vs string[] */ {
   // existing scan body, iterating parsedEvents instead of re-reading+re-parsing
-}
+};
 
-export function deriveFilesReadFromDurableEvents(sessionDir: string, cwd: string) {
-  return deriveFilesReadFromParsedEvents(readParsedSessionEvents(sessionDir), cwd);
+export function deriveFilesReadFromDurableEvents(
+  sessionDir: string,
+  cwd: string
+) {
+  return deriveFilesReadFromParsedEvents(
+    readParsedSessionEvents(sessionDir),
+    cwd
+  );
 }
 ```
 
-> Open `files-from-events.ts` and match the REAL signature/return type exactly. The scan currently reads each line and `JSON.parse`s — replace that with iterating `parsedEvents`.
+> Open `files-from-events.ts` and match the REAL signature/return type exactly.
+> The scan currently reads each line and `JSON.parse`s — replace that with
+> iterating `parsedEvents`.
 
 - [ ] **Step 3: Extract `findLastTurnEndSeqFromParsedEvents`**
 
@@ -214,7 +336,9 @@ export function findLastTurnEndSeqFromParsedEvents(
   return last;
 }
 
-export function findLastTurnEndEventSeq(sessionDir: string): number | undefined {
+export function findLastTurnEndEventSeq(
+  sessionDir: string
+): number | undefined {
   // keep its current behavior, but it MAY import readParsedSessionEvents to delegate.
   // If importing parsed-events into event-log.ts creates a cycle (parsed-events
   // imports readAllSessionEventLines FROM event-log.ts), DO NOT delegate here —
@@ -223,11 +347,17 @@ export function findLastTurnEndEventSeq(sessionDir: string): number | undefined 
 }
 ```
 
-> **Cycle warning:** `parsed-events.ts` imports from `event-log.ts`. So `event-log.ts` importing `parsed-events.ts` would cycle. Resolve by NOT having `findLastTurnEndEventSeq` delegate — just add the pure `findLastTurnEndSeqFromParsedEvents` (no import needed; it takes an array). Confirm the existing `findLastTurnEndEventSeq` still works unchanged.
+> **Cycle warning:** `parsed-events.ts` imports from `event-log.ts`. So
+> `event-log.ts` importing `parsed-events.ts` would cycle. Resolve by NOT having
+> `findLastTurnEndEventSeq` delegate — just add the pure
+> `findLastTurnEndSeqFromParsedEvents` (no import needed; it takes an array).
+> Confirm the existing `findLastTurnEndEventSeq` still works unchanged.
 
 - [ ] **Step 4: Write equivalence tests**
 
-For a fixture log written to a temp dir, assert each pure deriver fed `readParsedSessionEvents(dir)` equals the original I/O function on the same `dir`:
+For a fixture log written to a temp dir, assert each pure deriver fed
+`readParsedSessionEvents(dir)` equals the original I/O function on the same
+`dir`:
 
 ```ts
 it('pure derivers equal their I/O counterparts on the same log', () => {
@@ -236,21 +366,29 @@ it('pure derivers equal their I/O counterparts on the same log', () => {
   // ...writeFileSync...
   const events = readParsedSessionEvents(dir);
 
-  expect(JSON.stringify(buildProviderMessagesFromParsedEvents(events)))
-    .toBe(JSON.stringify(buildProviderMessagesFromDurableEvents(dir)));
-  expect([...deriveFilesReadFromParsedEvents(events, cwd)])
-    .toEqual([...deriveFilesReadFromDurableEvents(dir, cwd)]);
-  expect(findLastTurnEndSeqFromParsedEvents(events))
-    .toBe(findLastTurnEndEventSeq(dir));
+  expect(JSON.stringify(buildProviderMessagesFromParsedEvents(events))).toBe(
+    JSON.stringify(buildProviderMessagesFromDurableEvents(dir))
+  );
+  expect([...deriveFilesReadFromParsedEvents(events, cwd)]).toEqual([
+    ...deriveFilesReadFromDurableEvents(dir, cwd),
+  ]);
+  expect(findLastTurnEndSeqFromParsedEvents(events)).toBe(
+    findLastTurnEndEventSeq(dir)
+  );
 });
 ```
 
-> Build the fixture with a `tool_use` whose `data` matches what `deriveFilesReadFromDurableEvents` scans for (a `file_read` kind / completed outcome with a path). Read `files-from-events.ts` for the exact event shape it keys on so the fixture exercises a non-empty files-read set.
+> Build the fixture with a `tool_use` whose `data` matches what
+> `deriveFilesReadFromDurableEvents` scans for (a `file_read` kind / completed
+> outcome with a path). Read `files-from-events.ts` for the exact event shape it
+> keys on so the fixture exercises a non-empty files-read set.
 
 - [ ] **Step 5: Run — expect GREEN; full message-building suite green**
 
-Run: `cd packages/agent && npx vitest run src/message-building && npx tsc --noEmit`
-Expected: PASS (existing message-builder tests unchanged; goldens unaffected — same outputs).
+Run:
+`cd packages/agent && npx vitest run src/message-building && npx tsc --noEmit`
+Expected: PASS (existing message-builder tests unchanged; goldens unaffected —
+same outputs).
 
 - [ ] **Step 6: Commit**
 
@@ -264,8 +402,10 @@ git commit -m "refactor(session-state): pure *FromParsedEvents derivers over one
 ## Task 3: `loadTurnEntryProjection` — one read, three derivations
 
 **Files:**
+
 - Create: `packages/agent/src/message-building/turn-entry-projection.ts`
-- Create: `packages/agent/src/message-building/__tests__/turn-entry-projection.test.ts`
+- Create:
+  `packages/agent/src/message-building/__tests__/turn-entry-projection.test.ts`
 
 - [ ] **Step 1: Write the failing test (incl. the read-count gate)**
 
@@ -280,15 +420,40 @@ import { buildProviderMessagesFromDurableEvents } from '@lace/agent/message-buil
 
 describe('loadTurnEntryProjection', () => {
   let dir: string;
-  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'lace-tep-')); });
-  afterEach(() => { rmSync(dir, { recursive: true, force: true }); vi.restoreAllMocks(); });
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'lace-tep-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
 
   it('reads the log exactly once and returns all three derivations', () => {
     const lines = [
-      JSON.stringify({ eventSeq: 1, timestamp: 't', type: 'system_prompt_set', data: { type: 'system_prompt_set', text: 'sys' } }),
-      JSON.stringify({ eventSeq: 2, timestamp: 't', type: 'prompt', data: { content: [{ type: 'text', text: 'hi' }] } }),
-      JSON.stringify({ eventSeq: 3, timestamp: 't', type: 'message', data: { content: [{ type: 'text', text: 'hello' }] } }),
-      JSON.stringify({ eventSeq: 4, timestamp: 't', type: 'turn_end', data: { stopReason: 'end_turn' } }),
+      JSON.stringify({
+        eventSeq: 1,
+        timestamp: 't',
+        type: 'system_prompt_set',
+        data: { type: 'system_prompt_set', text: 'sys' },
+      }),
+      JSON.stringify({
+        eventSeq: 2,
+        timestamp: 't',
+        type: 'prompt',
+        data: { content: [{ type: 'text', text: 'hi' }] },
+      }),
+      JSON.stringify({
+        eventSeq: 3,
+        timestamp: 't',
+        type: 'message',
+        data: { content: [{ type: 'text', text: 'hello' }] },
+      }),
+      JSON.stringify({
+        eventSeq: 4,
+        timestamp: 't',
+        type: 'turn_end',
+        data: { stopReason: 'end_turn' },
+      }),
     ];
     writeFileSync(join(dir, 'events.jsonl'), lines.join('\n') + '\n', 'utf8');
 
@@ -298,7 +463,9 @@ describe('loadTurnEntryProjection', () => {
     expect(spy).toHaveBeenCalledTimes(1); // the whole point: ONE read+parse
     expect(proj.systemPrompt).toBe('sys');
     expect(proj.lastTurnEndSeq).toBe(4);
-    expect(Array.isArray(proj.filesRead) || proj.filesRead instanceof Set).toBe(true);
+    expect(Array.isArray(proj.filesRead) || proj.filesRead instanceof Set).toBe(
+      true
+    );
     // messages equivalence with the standalone builder:
     expect(JSON.stringify(proj.messages)).toBe(
       JSON.stringify(buildProviderMessagesFromDurableEvents(dir).messages)
@@ -307,7 +474,14 @@ describe('loadTurnEntryProjection', () => {
 });
 ```
 
-> `vi.spyOn` on a module export requires `loadTurnEntryProjection` to call `readParsedSessionEvents` via the module namespace import (`import * as parsedEvents` then `parsedEvents.readParsedSessionEvents(...)`) OR the spy must target the right binding. Simplest: have `turn-entry-projection.ts` import the namespace and call `pe.readParsedSessionEvents`. Confirm the spy registers a call; if module-binding makes the spy not fire, count `fs.readFileSync` calls scoped to the session file instead.
+> `vi.spyOn` on a module export requires `loadTurnEntryProjection` to call
+> `readParsedSessionEvents` via the module namespace import
+> (`import * as parsedEvents` then `parsedEvents.readParsedSessionEvents(...)`)
+> OR the spy must target the right binding. Simplest: have
+> `turn-entry-projection.ts` import the namespace and call
+> `pe.readParsedSessionEvents`. Confirm the spy registers a call; if
+> module-binding makes the spy not fire, count `fs.readFileSync` calls scoped to
+> the session file instead.
 
 - [ ] **Step 2: Run — expect RED.**
 
@@ -338,7 +512,9 @@ export function loadTurnEntryProjection(sessionDir: string, cwd: string): TurnEn
 }
 ```
 
-> Match `filesRead`'s real type (Set vs array) to `deriveFilesReadFromParsedEvents`. Confirm `BuiltProviderMessages` is exported from `message-builder.ts` (if not, export it).
+> Match `filesRead`'s real type (Set vs array) to
+> `deriveFilesReadFromParsedEvents`. Confirm `BuiltProviderMessages` is exported
+> from `message-builder.ts` (if not, export it).
 
 - [ ] **Step 4: Run — expect GREEN; commit**
 
@@ -352,39 +528,65 @@ git commit -m "feat(session-state): loadTurnEntryProjection — one read, three 
 ## Task 4: Wire into the runner + verify byte-safety
 
 **Files:**
+
 - Modify: `packages/agent/src/core/conversation/runner.ts` (turn setup ~410–490)
 
 - [ ] **Step 1: Replace the three calls with one**
 
 Read `runner.ts:410-495`. Today (approximately):
+
 ```ts
-const filesRead = deriveFilesReadFromDurableEvents(sessionDir, runtimeBinding.toolRuntime.cwd); // ~413
+const filesRead = deriveFilesReadFromDurableEvents(
+  sessionDir,
+  runtimeBinding.toolRuntime.cwd
+); // ~413
 // ...
 const { messages: rebuiltMessages, systemPrompt: frozenSystemPrompt } =
   buildProviderMessagesFromDurableEvents(sessionDir); // ~431
 // ...
 let lastSeenEventSeq = findLastTurnEndEventSeq(sessionDir) ?? 0; // ~490
 ```
-Replace with a single load near the top of turn setup (before the first use), preserving the exact downstream variable names and the `frozenSystemPrompt` empty-check that follows line 431:
+
+Replace with a single load near the top of turn setup (before the first use),
+preserving the exact downstream variable names and the `frozenSystemPrompt`
+empty-check that follows line 431:
+
 ```ts
-const turnEntry = loadTurnEntryProjection(sessionDir, runtimeBinding.toolRuntime.cwd);
+const turnEntry = loadTurnEntryProjection(
+  sessionDir,
+  runtimeBinding.toolRuntime.cwd
+);
 const filesRead = turnEntry.filesRead;
 const rebuiltMessages = turnEntry.messages;
 const frozenSystemPrompt = turnEntry.systemPrompt;
 let providerMessages = rebuiltMessages;
 let lastSeenEventSeq = turnEntry.lastTurnEndSeq ?? 0;
 ```
-Keep the existing `if (!frozenSystemPrompt) throw ...` corruption guard. Remove the three now-unused imports if nothing else in the file uses them (check — `buildProviderMessagesFromDurableEvents` may be imported for other reasons; only remove if truly unused). Add the `loadTurnEntryProjection` import (top-level).
 
-> Be careful about ORDER: `filesRead` was derived at ~413 (before the messages at ~431) and may be used between 413 and 431. Moving all three to one call at the top preserves every downstream use as long as the single load happens before the earliest use (line ~413). Verify nothing between the old 413 and 490 mutates the session log in a way that would change what the later reads saw — it does not (turn setup is read-only before the agentic loop starts).
+Keep the existing `if (!frozenSystemPrompt) throw ...` corruption guard. Remove
+the three now-unused imports if nothing else in the file uses them (check —
+`buildProviderMessagesFromDurableEvents` may be imported for other reasons; only
+remove if truly unused). Add the `loadTurnEntryProjection` import (top-level).
+
+> Be careful about ORDER: `filesRead` was derived at ~413 (before the messages
+> at ~431) and may be used between 413 and 431. Moving all three to one call at
+> the top preserves every downstream use as long as the single load happens
+> before the earliest use (line ~413). Verify nothing between the old 413 and
+> 490 mutates the session log in a way that would change what the later reads
+> saw — it does not (turn setup is read-only before the agentic loop starts).
 
 - [ ] **Step 2: Verify the byte-safety gates are untouched**
 
-Run the full sent==rebuilt / golden / cross-turn / reducer suites + the runner suite:
+Run the full sent==rebuilt / golden / cross-turn / reducer suites + the runner
+suite:
+
 ```bash
 cd packages/agent && npx vitest run src/message-building src/providers/__tests__ src/core/conversation
 ```
-Expected: PASS (the known `ollama-integration.test.ts` env failures excluded). The message output is identical (same parse, same derivers), so goldens and sent-vs-rebuilt are unaffected.
+
+Expected: PASS (the known `ollama-integration.test.ts` env failures excluded).
+The message output is identical (same parse, same derivers), so goldens and
+sent-vs-rebuilt are unaffected.
 
 - [ ] **Step 3: typecheck + lint**
 
@@ -392,7 +594,12 @@ Run (repo root): `npm run typecheck && npm run lint` → clean.
 
 - [ ] **Step 4: Document in the evergreen doc**
 
-Add a short paragraph to `docs/architecture/prompt-cache-stability.md` (or the session-state architecture doc) — present-tense, no refs: that turn entry reads and parses the durable log once via `loadTurnEntryProjection`, deriving the message prefix, files-read, and last-turn-end watermark from that single parse, and that the per-append seq scan and the per-iteration inject read remain (addressed by the durable index). Keep it factual.
+Add a short paragraph to `docs/architecture/prompt-cache-stability.md` (or the
+session-state architecture doc) — present-tense, no refs: that turn entry reads
+and parses the durable log once via `loadTurnEntryProjection`, deriving the
+message prefix, files-read, and last-turn-end watermark from that single parse,
+and that the per-append seq scan and the per-iteration inject read remain
+(addressed by the durable index). Keep it factual.
 
 - [ ] **Step 5: Commit**
 
@@ -405,7 +612,18 @@ git commit -m "perf(session-state): turn entry reads the durable log once (loadT
 
 ## Self-review notes (for the executor)
 
-- **Byte-safety is the contract:** the message output of the new path must be identical to the old (it is — same parse, same derivers). The golden + sent-vs-rebuilt + cross-turn suites are the proof; they must stay green with zero golden changes.
-- **The win is collapsing three turn-entry reads/parses into one.** It does NOT remove the per-append `deriveNextEventSeqAcrossSessionFiles` scan or the per-iteration inject read — those are Step 3 (the durable index), and touching them here would mean cross-process seq work that is explicitly deferred.
-- **No invented details:** confirm `deriveFilesReadFromDurableEvents`'s real path/signature/return type, `BuiltProviderMessages` export, and the runner's exact turn-setup variable names and ordering before finalizing. The import-cycle note in Task 2 Step 3 is load-bearing — do not make `event-log.ts` import `parsed-events.ts`.
-- **Out of scope:** seq assignment, injects, state read/write, loadSession, compaction.
+- **Byte-safety is the contract:** the message output of the new path must be
+  identical to the old (it is — same parse, same derivers). The golden +
+  sent-vs-rebuilt + cross-turn suites are the proof; they must stay green with
+  zero golden changes.
+- **The win is collapsing three turn-entry reads/parses into one.** It does NOT
+  remove the per-append `deriveNextEventSeqAcrossSessionFiles` scan or the
+  per-iteration inject read — those are Step 3 (the durable index), and touching
+  them here would mean cross-process seq work that is explicitly deferred.
+- **No invented details:** confirm `deriveFilesReadFromDurableEvents`'s real
+  path/signature/return type, `BuiltProviderMessages` export, and the runner's
+  exact turn-setup variable names and ordering before finalizing. The
+  import-cycle note in Task 2 Step 3 is load-bearing — do not make
+  `event-log.ts` import `parsed-events.ts`.
+- **Out of scope:** seq assignment, injects, state read/write, loadSession,
+  compaction.

--- a/docs/superpowers/plans/2026-06-18-session-state-step3a-recall-nonlossy.md
+++ b/docs/superpowers/plans/2026-06-18-session-state-step3a-recall-nonlossy.md
@@ -1,45 +1,48 @@
 # Session-State Step 3.1 — `event_journal` Non-Lossy Recall Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
 
-**Goal:** Add a durable `event_journal` table (one row per event, with the **verbatim**
-JSONL line) to the existing recall SQLite DB, so `/recall` returns original event bytes
-instead of today's lossy FTS-rendered rows (#22). This is the safest sub-step of Step 3:
-purely additive, **never on a correctness path**, best-effort + backfill-repaired like
-today's recall index.
+**Goal:** Add a durable `event_journal` table (one row per event, with the
+**verbatim** JSONL line) to the existing recall SQLite DB, so `/recall` returns
+original event bytes instead of today's lossy FTS-rendered rows (#22). This is
+the safest sub-step of Step 3: purely additive, **never on a correctness path**,
+best-effort + backfill-repaired like today's recall index.
 
 **Architecture:** Extend `recall/index-db.ts` (better-sqlite3, WAL) with an
-`event_journal` table written by a **dedicated unfiltered writer** (every event type,
-not the `eventToRow` FTS filter), best-effort write-through in `appendDurableEvent`
-alongside the existing FTS insert, and repaired by the existing startup backfill. Recall
-returns `event_journal.line`.
+`event_journal` table written by a **dedicated unfiltered writer** (every event
+type, not the `eventToRow` FTS filter), best-effort write-through in
+`appendDurableEvent` alongside the existing FTS insert, and repaired by the
+existing startup backfill. Recall returns `event_journal.line`.
 
-**Tech Stack:** TypeScript, better-sqlite3, vitest. Per sen-core principle: real SQLite
-in tests (tempdir), never mocked.
+**Tech Stack:** TypeScript, better-sqlite3, vitest. Per sen-core principle: real
+SQLite in tests (tempdir), never mocked.
 
 ---
 
 ## Background (verified facts)
 
-- Recall DB: `<getLaceDir()>/recall/index.sqlite`, better-sqlite3 `@^12.10.0`, WAL,
-  opened via `getRecallIndex()` singleton (`packages/agent/src/storage/recall/index-db.ts`).
-  Schema applied in `applySchema` (~line 116-145); `SCHEMA_VERSION = 2` (line 21).
+- Recall DB: `<getLaceDir()>/recall/index.sqlite`, better-sqlite3 `@^12.10.0`,
+  WAL, opened via `getRecallIndex()` singleton
+  (`packages/agent/src/storage/recall/index-db.ts`). Schema applied in
+  `applySchema` (~line 116-145); `SCHEMA_VERSION = 2` (line 21).
 - FTS table `events` (virtual, FTS5) is **lossy**: only 5 event types indexed
-  (`prompt`/`message`/`tool_use`/`context_injected`/`context_compacted`), content
-  rendered/sanitized, no `turnId`/`turnSeq`, no verbatim line. `eventToRow`
-  (`event-to-row.ts`) returns `null` for all other types (the FTS filter — **must not**
-  be reused for the journal).
+  (`prompt`/`message`/`tool_use`/`context_injected`/`context_compacted`),
+  content rendered/sanitized, no `turnId`/`turnSeq`, no verbatim line.
+  `eventToRow` (`event-to-row.ts`) returns `null` for all other types (the FTS
+  filter — **must not** be reused for the journal).
 - Write-through today: `appendDurableEvent` (`event-log.ts:~517-522`) does
   `const row = eventToRow(written, {sessionId, persona}); if (row) insertRow(getRecallIndex(), row);`
   best-effort (try/catch, non-fatal).
-- Backfill: `backfillIndex` (`recall/backfill.ts`) scans JSONL on startup, per-session
-  `db.transaction(...).immediate`, dedups by `event_id` (`session_id:event_seq`).
+- Backfill: `backfillIndex` (`recall/backfill.ts`) scans JSONL on startup,
+  per-session `db.transaction(...).immediate`, dedups by `event_id`
+  (`session_id:event_seq`).
 - `insertRow` (`recall/index-writer.ts`) wraps inserts in `BEGIN IMMEDIATE`.
-- The recall query path (`recall.ts`) reads FTS rows and renders results — find where it
-  returns content to the caller.
+- The recall query path (`recall.ts`) reads FTS rows and renders results — find
+  where it returns content to the caller.
 
-**Event id convention:** `event_id = "${sessionId}:${eventSeq}"` (used by FTS dedup).
-Reuse it as the journal PK so backfill dedup is consistent.
+**Event id convention:** `event_id = "${sessionId}:${eventSeq}"` (used by FTS
+dedup). Reuse it as the journal PK so backfill dedup is consistent.
 
 **Test command:** `cd packages/agent && npx vitest run <path>`.
 
@@ -48,20 +51,23 @@ Reuse it as the journal PK so backfill dedup is consistent.
 ## File Structure
 
 **Modify:**
-- `packages/agent/src/storage/recall/index-db.ts` — add the `event_journal` table to
-  `applySchema`; bump `SCHEMA_VERSION` to 3.
-- `packages/agent/src/storage/recall/index-writer.ts` — add `insertJournalRow(db, row)`
-  (unfiltered, every event, verbatim line), `BEGIN IMMEDIATE`, dedup by PK.
-- `packages/agent/src/storage/event-log.ts` — in `appendDurableEvent`, write the journal
-  row best-effort alongside the existing FTS insert (verbatim line = the exact string
-  appended to JSONL).
-- `packages/agent/src/storage/recall/backfill.ts` — also insert `event_journal` rows
-  during the per-session backfill (every event, verbatim line).
-- `packages/agent/src/storage/recall/recall.ts` (or wherever recall returns content) —
-  return the verbatim event (parsed from `event_journal.line`) instead of the rendered
-  FTS content.
+
+- `packages/agent/src/storage/recall/index-db.ts` — add the `event_journal`
+  table to `applySchema`; bump `SCHEMA_VERSION` to 3.
+- `packages/agent/src/storage/recall/index-writer.ts` — add
+  `insertJournalRow(db, row)` (unfiltered, every event, verbatim line),
+  `BEGIN IMMEDIATE`, dedup by PK.
+- `packages/agent/src/storage/event-log.ts` — in `appendDurableEvent`, write the
+  journal row best-effort alongside the existing FTS insert (verbatim line = the
+  exact string appended to JSONL).
+- `packages/agent/src/storage/recall/backfill.ts` — also insert `event_journal`
+  rows during the per-session backfill (every event, verbatim line).
+- `packages/agent/src/storage/recall/recall.ts` (or wherever recall returns
+  content) — return the verbatim event (parsed from `event_journal.line`)
+  instead of the rendered FTS content.
 
 **Create:**
+
 - `packages/agent/src/storage/recall/__tests__/event-journal.test.ts`
 
 ---
@@ -70,8 +76,8 @@ Reuse it as the journal PK so backfill dedup is consistent.
 
 **Files:** `index-db.ts`
 
-- [ ] **Step 1: Write a failing test** (open a temp DB via the real open path, assert
-  the table exists with the expected columns):
+- [ ] **Step 1: Write a failing test** (open a temp DB via the real open path,
+      assert the table exists with the expected columns):
 
 ```ts
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -82,20 +88,27 @@ import { openRecallIndex } from '@lace/agent/storage/recall/index-db';
 
 describe('event_journal schema', () => {
   let dir: string;
-  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'lace-ej-')); });
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'lace-ej-'));
+  });
   afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
   it('creates event_journal with the verbatim-line column', () => {
     const db = openRecallIndex(join(dir, 'index.sqlite'));
-    const cols = db.handle.prepare(`PRAGMA table_info(event_journal)`).all() as { name: string }[];
+    const cols = db.handle
+      .prepare(`PRAGMA table_info(event_journal)`)
+      .all() as { name: string }[];
     const names = cols.map((c) => c.name).sort();
-    expect(names).toEqual(['event_seq', 'line', 'session_id', 'ts', 'type'].sort());
+    expect(names).toEqual(
+      ['event_seq', 'line', 'session_id', 'ts', 'type'].sort()
+    );
   });
 });
 ```
 
-> Confirm how to reach the raw better-sqlite3 handle from the `Db` wrapper (the test
-> uses `db.handle` — match the real wrapper's field/getter; read `index-db.ts`).
+> Confirm how to reach the raw better-sqlite3 handle from the `Db` wrapper (the
+> test uses `db.handle` — match the real wrapper's field/getter; read
+> `index-db.ts`).
 
 - [ ] **Step 2: Run — RED.**
 
@@ -113,13 +126,14 @@ CREATE TABLE IF NOT EXISTS event_journal (
 CREATE INDEX IF NOT EXISTS ej_session ON event_journal(session_id, event_seq);
 ```
 
-> Match the existing migration mechanism: `applySchema` keys off `SCHEMA_VERSION` in
-> `_meta`. Bumping to 3 must ADD the table on existing DBs without dropping the FTS
-> `events` table or its data. Read how `applySchema` handles a version bump (does it
-> `DROP`+recreate, or `CREATE IF NOT EXISTS`?). If it drops-and-rebuilds everything on a
-> version bump, that's fine — the backfill repopulates both tables from JSONL; confirm
-> that's the existing behavior and that it's acceptable (it triggers a one-time
-> re-backfill on upgrade).
+> Match the existing migration mechanism: `applySchema` keys off
+> `SCHEMA_VERSION` in `_meta`. Bumping to 3 must ADD the table on existing DBs
+> without dropping the FTS `events` table or its data. Read how `applySchema`
+> handles a version bump (does it `DROP`+recreate, or `CREATE IF NOT EXISTS`?).
+> If it drops-and-rebuilds everything on a version bump, that's fine — the
+> backfill repopulates both tables from JSONL; confirm that's the existing
+> behavior and that it's acceptable (it triggers a one-time re-backfill on
+> upgrade).
 
 - [ ] **Step 4: Run — GREEN. Commit.**
 
@@ -134,18 +148,37 @@ git commit -m "feat(session-state): event_journal table (verbatim-line recall st
 
 **Files:** `index-writer.ts`, `event-journal.test.ts`
 
-- [ ] **Step 1: Failing test** — inserting a `turn_end` (which `eventToRow` drops)
-  produces a journal row; double-insert is idempotent:
+- [ ] **Step 1: Failing test** — inserting a `turn_end` (which `eventToRow`
+      drops) produces a journal row; double-insert is idempotent:
 
 ```ts
 import { insertJournalRow } from '@lace/agent/storage/recall/index-writer';
 // ... open db ...
 it('journals EVERY event type incl. turn_end, idempotently', () => {
   const db = openRecallIndex(join(dir, 'index.sqlite'));
-  const line = JSON.stringify({ eventSeq: 7, timestamp: 't', type: 'turn_end', data: { stopReason: 'end_turn' } });
-  insertJournalRow(db, { session_id: 's1', event_seq: 7, type: 'turn_end', ts: 't', line });
-  insertJournalRow(db, { session_id: 's1', event_seq: 7, type: 'turn_end', ts: 't', line }); // dup → no-op
-  const rows = db.handle.prepare(`SELECT line FROM event_journal WHERE session_id='s1'`).all() as { line: string }[];
+  const line = JSON.stringify({
+    eventSeq: 7,
+    timestamp: 't',
+    type: 'turn_end',
+    data: { stopReason: 'end_turn' },
+  });
+  insertJournalRow(db, {
+    session_id: 's1',
+    event_seq: 7,
+    type: 'turn_end',
+    ts: 't',
+    line,
+  });
+  insertJournalRow(db, {
+    session_id: 's1',
+    event_seq: 7,
+    type: 'turn_end',
+    ts: 't',
+    line,
+  }); // dup → no-op
+  const rows = db.handle
+    .prepare(`SELECT line FROM event_journal WHERE session_id='s1'`)
+    .all() as { line: string }[];
   expect(rows).toHaveLength(1);
   expect(rows[0].line).toBe(line);
 });
@@ -153,28 +186,45 @@ it('journals EVERY event type incl. turn_end, idempotently', () => {
 
 - [ ] **Step 2: RED.**
 
-- [ ] **Step 3: Implement `insertJournalRow`** (mirror `insertRow`'s `BEGIN IMMEDIATE` +
-  in-transaction guard; PK-dedup via `INSERT OR IGNORE`):
+- [ ] **Step 3: Implement `insertJournalRow`** (mirror `insertRow`'s
+      `BEGIN IMMEDIATE` + in-transaction guard; PK-dedup via
+      `INSERT OR IGNORE`):
 
 ```ts
-export type JournalRow = { session_id: string; event_seq: number; type: string; ts: string; line: string };
+export type JournalRow = {
+  session_id: string;
+  event_seq: number;
+  type: string;
+  ts: string;
+  line: string;
+};
 
 export function insertJournalRow(db: Db, row: JournalRow): void {
-  if (db.inTransaction) { insertJournalRowInner(db, row); return; }
+  if (db.inTransaction) {
+    insertJournalRowInner(db, row);
+    return;
+  }
   db.exec('BEGIN IMMEDIATE');
-  try { insertJournalRowInner(db, row); db.exec('COMMIT'); }
-  catch (err) { db.exec('ROLLBACK'); throw err; }
+  try {
+    insertJournalRowInner(db, row);
+    db.exec('COMMIT');
+  } catch (err) {
+    db.exec('ROLLBACK');
+    throw err;
+  }
 }
 function insertJournalRowInner(db: Db, row: JournalRow): void {
-  db.handle.prepare(
-    `INSERT OR IGNORE INTO event_journal (session_id, event_seq, type, ts, line) VALUES (?, ?, ?, ?, ?)`
-  ).run(row.session_id, row.event_seq, row.type, row.ts, row.line);
+  db.handle
+    .prepare(
+      `INSERT OR IGNORE INTO event_journal (session_id, event_seq, type, ts, line) VALUES (?, ?, ?, ?, ?)`
+    )
+    .run(row.session_id, row.event_seq, row.type, row.ts, row.line);
 }
 ```
 
-> Match the real `Db` wrapper API (`db.inTransaction`, `db.exec`, `db.handle.prepare` —
-> confirm against `index-writer.ts`/`index-db.ts`; if the wrapper exposes `prepare`
-> directly, use that).
+> Match the real `Db` wrapper API (`db.inTransaction`, `db.exec`,
+> `db.handle.prepare` — confirm against `index-writer.ts`/`index-db.ts`; if the
+> wrapper exposes `prepare` directly, use that).
 
 - [ ] **Step 4: GREEN. Commit.**
 
@@ -190,18 +240,18 @@ git commit -m "feat(session-state): unfiltered event_journal writer (every type,
 **Files:** `event-log.ts`, `backfill.ts`, test
 
 - [ ] **Step 1: Failing test** — after `appendDurableEvent`, the journal has the
-  verbatim line for the appended event (incl. a `turn_end`). (Use the real append path
-  against a temp laceDir; assert `event_journal` got the row.)
+      verbatim line for the appended event (incl. a `turn_end`). (Use the real
+      append path against a temp laceDir; assert `event_journal` got the row.)
 
-> Construct the test to drive `appendDurableEvent` for a `prompt` and a `turn_end`, then
-> query `event_journal`. The verbatim `line` must equal the exact string written to the
-> JSONL (`JSON.stringify(written)`).
+> Construct the test to drive `appendDurableEvent` for a `prompt` and a
+> `turn_end`, then query `event_journal`. The verbatim `line` must equal the
+> exact string written to the JSONL (`JSON.stringify(written)`).
 
 - [ ] **Step 2: RED.**
 
-- [ ] **Step 3: Wire write-through** in `appendDurableEvent`, right after the existing
-  FTS `insertRow`, best-effort (its own try/catch — a journal failure must NEVER fail the
-  append):
+- [ ] **Step 3: Wire write-through** in `appendDurableEvent`, right after the
+      existing FTS `insertRow`, best-effort (its own try/catch — a journal
+      failure must NEVER fail the append):
 
 ```ts
 try {
@@ -210,31 +260,34 @@ try {
     event_seq: written.eventSeq,
     type: written.type,
     ts: written.timestamp,
-    line: JSON.stringify(written),   // the EXACT bytes appended to JSONL
+    line: JSON.stringify(written), // the EXACT bytes appended to JSONL
   });
 } catch (err) {
   console.error('event_journal write failed:', err);
 }
 ```
 
-> The `line` must be byte-identical to what was appended to the JSONL. The append writes
-> `${JSON.stringify(written)}\n` — store `JSON.stringify(written)` (without the newline)
-> so replaying it through the parser matches a JSONL line read. Confirm the JSONL write
-> expression and match it exactly.
+> The `line` must be byte-identical to what was appended to the JSONL. The
+> append writes `${JSON.stringify(written)}\n` — store `JSON.stringify(written)`
+> (without the newline) so replaying it through the parser matches a JSONL line
+> read. Confirm the JSONL write expression and match it exactly.
 
-- [ ] **Step 4: Extend backfill** (`backfill.ts`) to also `insertJournalRow` for every
-  scanned event (every type, verbatim line = the raw JSONL line read), inside the same
-  per-session `.immediate` transaction. The journal dedups by PK, so re-running backfill
-  is safe.
+- [ ] **Step 4: Extend backfill** (`backfill.ts`) to also `insertJournalRow` for
+      every scanned event (every type, verbatim line = the raw JSONL line read),
+      inside the same per-session `.immediate` transaction. The journal dedups
+      by PK, so re-running backfill is safe.
 
-> The backfill reads raw JSONL lines; store each raw line verbatim as `line`. Parse just
-> enough (`eventSeq`, `type`, `timestamp`) for the columns. Confirm the backfill's
-> existing per-session transaction and add the journal insert inside it.
+> The backfill reads raw JSONL lines; store each raw line verbatim as `line`.
+> Parse just enough (`eventSeq`, `type`, `timestamp`) for the columns. Confirm
+> the backfill's existing per-session transaction and add the journal insert
+> inside it.
 
 - [ ] **Step 5: GREEN; run the full recall suite.**
 
-Run: `cd packages/agent && npx vitest run src/storage/recall src/storage/event-log.test.ts && npx tsc --noEmit`
-Expected: PASS (existing recall/backfill tests unaffected; the journal is additive).
+Run:
+`cd packages/agent && npx vitest run src/storage/recall src/storage/event-log.test.ts && npx tsc --noEmit`
+Expected: PASS (existing recall/backfill tests unaffected; the journal is
+additive).
 
 - [ ] **Step 6: Commit.**
 
@@ -249,19 +302,22 @@ git commit -m "feat(session-state): write-through + backfill event_journal (verb
 
 **Files:** `recall.ts` (the recall query/return path), test
 
-- [ ] **Step 1: Find the recall return path.** Read `recall.ts`: the FTS search finds
-  matching `event_id`s; today it returns rendered/lossy content. Change the result
-  assembly to fetch `event_journal.line` for each matched `event_id`
-  (`session_id`+`event_seq`) and return the **parsed verbatim event** (full `data`, all
-  fields), falling back to the FTS-rendered content only when the journal row is missing
-  (older sessions mid-backfill).
+- [ ] **Step 1: Find the recall return path.** Read `recall.ts`: the FTS search
+      finds matching `event_id`s; today it returns rendered/lossy content.
+      Change the result assembly to fetch `event_journal.line` for each matched
+      `event_id` (`session_id`+`event_seq`) and return the **parsed verbatim
+      event** (full `data`, all fields), falling back to the FTS-rendered
+      content only when the journal row is missing (older sessions
+      mid-backfill).
 
-- [ ] **Step 2: Failing test** — a recall hit returns the original event `data` (e.g. a
-  `tool_use` with its full input/result), not the `tool=…\ninput=…` rendering.
+- [ ] **Step 2: Failing test** — a recall hit returns the original event `data`
+      (e.g. a `tool_use` with its full input/result), not the `tool=…\ninput=…`
+      rendering.
 
 - [ ] **Step 3: Implement; keep FTS for the SEARCH (matching), journal for the
-  RETURNED content.** (FTS stays the index that answers "which events match the query";
-  the journal supplies the verbatim payload for the matched events.)
+      RETURNED content.** (FTS stays the index that answers "which events match
+      the query"; the journal supplies the verbatim payload for the matched
+      events.)
 
 - [ ] **Step 4: GREEN; full recall suite + typecheck + lint.**
 
@@ -276,14 +332,16 @@ git commit -m "feat(session-state): recall returns verbatim events from event_jo
 
 ## Self-review notes (for the executor)
 
-- **Zero correctness risk:** the journal is additive and best-effort; nothing in the
-  hot path or seq assignment reads it. If a journal write fails, the append still
-  succeeds and backfill repairs it. Do NOT let any journal failure throw out of
-  `appendDurableEvent`.
-- **Verbatim is the contract:** `line` must equal the exact JSONL bytes (so a future
-  reader/reducer over `line` is byte-identical to reading the JSONL). The write-through
-  stores `JSON.stringify(written)`; the backfill stores the raw line read.
-- **Out of scope:** seq assignment, the flock/head file, the injects tail-read — those
-  are Steps 3.2/3.3. This step touches only the recall index.
+- **Zero correctness risk:** the journal is additive and best-effort; nothing in
+  the hot path or seq assignment reads it. If a journal write fails, the append
+  still succeeds and backfill repairs it. Do NOT let any journal failure throw
+  out of `appendDurableEvent`.
+- **Verbatim is the contract:** `line` must equal the exact JSONL bytes (so a
+  future reader/reducer over `line` is byte-identical to reading the JSONL). The
+  write-through stores `JSON.stringify(written)`; the backfill stores the raw
+  line read.
+- **Out of scope:** seq assignment, the flock/head file, the injects tail-read —
+  those are Steps 3.2/3.3. This step touches only the recall index.
 - **Confirm against source:** the `Db` wrapper API, `applySchema`'s version-bump
-  behavior, the JSONL write expression, and the recall return path — do not invent them.
+  behavior, the JSONL write expression, and the recall return path — do not
+  invent them.

--- a/docs/superpowers/plans/2026-06-18-session-state-step3b-injects-tailread.md
+++ b/docs/superpowers/plans/2026-06-18-session-state-step3b-injects-tailread.md
@@ -1,47 +1,52 @@
 # Session-State Step 3.2 — Injects Byte-Offset Tail-Read Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
 
-**Goal:** Replace the per-loop-iteration **full-log scan** for immediate injects with an
-incremental **byte-offset tail-read** of the JSONL shards — reading only newly-appended
-bytes. This removes the second per-turn bottleneck and, crucially, **keeps reading the
-source of truth** (the JSONL), so a cross-process inject is seen the instant its line
-lands — never lagged by a derived index.
+**Goal:** Replace the per-loop-iteration **full-log scan** for immediate injects
+with an incremental **byte-offset tail-read** of the JSONL shards — reading only
+newly-appended bytes. This removes the second per-turn bottleneck and,
+crucially, **keeps reading the source of truth** (the JSONL), so a cross-process
+inject is seen the instant its line lands — never lagged by a derived index.
 
-**Architecture:** A stateful `InjectTailer` holds, per shard file, the byte offset read
-so far (advanced only to the last complete newline, so a concurrently-appended partial
-line is never mis-parsed). Each `readNew()` reads `[offset, EOF)` of each shard, parses
-complete lines, filters `context_injected` events with `priority='immediate'` and
-`eventSeq > watermark`, returns their texts, and advances offsets + watermark. The runner
-creates one tailer per turn and calls it where it calls `readImmediateInjectsSince` today.
+**Architecture:** A stateful `InjectTailer` holds, per shard file, the byte
+offset read so far (advanced only to the last complete newline, so a
+concurrently-appended partial line is never mis-parsed). Each `readNew()` reads
+`[offset, EOF)` of each shard, parses complete lines, filters `context_injected`
+events with `priority='immediate'` and `eventSeq > watermark`, returns their
+texts, and advances offsets + watermark. The runner creates one tailer per turn
+and calls it where it calls `readImmediateInjectsSince` today.
 
 **Tech Stack:** TypeScript, vitest, `node:fs`.
 
-**Why safe:** reads the JSONL (truth), append-only ⇒ new content is always at the end ⇒
-no lag, no missed cross-process inject. The only hazard is a partial trailing line, which
-the last-newline offset rule rules out.
+**Why safe:** reads the JSONL (truth), append-only ⇒ new content is always at
+the end ⇒ no lag, no missed cross-process inject. The only hazard is a partial
+trailing line, which the last-newline offset rule rules out.
 
 ---
 
 ## Background (verified facts — confirm against source before finalizing)
 
-- Today: `readImmediateInjectsSince(sessionDir, afterEventSeq): { injections: string[];
-  newWatermark: number }` (`packages/agent/src/core/conversation/runner.ts:~321-340`).
-  It calls `readDurableEvents(sessionDir, { afterEventSeq, limit: MAX_SAFE_INTEGER })`
-  → `readAllSessionEventLines` (a **full read of all shards**, parsed + sorted), then
-  filters `type==='context_injected'` AND `data.priority==='immediate'`, extracting text
-  via `extractInjectedText(data.content)`. Returns texts + the max seq seen.
-- Called **per loop iteration** at `runner.ts:~546` with `lastSeenEventSeq`; the runner
-  threads the returned `newWatermark` back into `lastSeenEventSeq`.
-- Shards: `<laceDir>/transcripts/<persona>/<YYYY-MM-DD>/<sessionId>.jsonl` plus the legacy
-  `<sessionDir>/events.jsonl`. `listTranscriptFiles(laceDir, sessionId)`
-  (`storage/transcript-paths.ts`) enumerates the new-layout shards; legacy path via the
-  existing helper in `event-log.ts`. (Reuse the SAME file set `readAllSessionEventLines`
-  reads — do not reinvent shard discovery.)
-- The append writes `${JSON.stringify(written)}\n` and has a newline-guard that prepends
-  `\n` if a prior write lacked one — so the file is `\n`-delimited.
-- `extractInjectedText` and the `priority==='immediate'` filter — reuse the EXACT existing
-  predicates so behavior is identical.
+- Today:
+  `readImmediateInjectsSince(sessionDir, afterEventSeq): { injections: string[]; newWatermark: number }`
+  (`packages/agent/src/core/conversation/runner.ts:~321-340`). It calls
+  `readDurableEvents(sessionDir, { afterEventSeq, limit: MAX_SAFE_INTEGER })` →
+  `readAllSessionEventLines` (a **full read of all shards**, parsed + sorted),
+  then filters `type==='context_injected'` AND `data.priority==='immediate'`,
+  extracting text via `extractInjectedText(data.content)`. Returns texts + the
+  max seq seen.
+- Called **per loop iteration** at `runner.ts:~546` with `lastSeenEventSeq`; the
+  runner threads the returned `newWatermark` back into `lastSeenEventSeq`.
+- Shards: `<laceDir>/transcripts/<persona>/<YYYY-MM-DD>/<sessionId>.jsonl` plus
+  the legacy `<sessionDir>/events.jsonl`.
+  `listTranscriptFiles(laceDir, sessionId)` (`storage/transcript-paths.ts`)
+  enumerates the new-layout shards; legacy path via the existing helper in
+  `event-log.ts`. (Reuse the SAME file set `readAllSessionEventLines` reads — do
+  not reinvent shard discovery.)
+- The append writes `${JSON.stringify(written)}\n` and has a newline-guard that
+  prepends `\n` if a prior write lacked one — so the file is `\n`-delimited.
+- `extractInjectedText` and the `priority==='immediate'` filter — reuse the
+  EXACT existing predicates so behavior is identical.
 
 **Test command:** `cd packages/agent && npx vitest run <path>`.
 
@@ -50,14 +55,17 @@ the last-newline offset rule rules out.
 ## File Structure
 
 **Create:**
-- `packages/agent/src/storage/inject-tailer.ts` — `InjectTailer` class / factory + the
-  partial-line-safe per-shard offset reader.
+
+- `packages/agent/src/storage/inject-tailer.ts` — `InjectTailer` class /
+  factory + the partial-line-safe per-shard offset reader.
 - `packages/agent/src/storage/__tests__/inject-tailer.test.ts`
 
 **Modify:**
-- `packages/agent/src/core/conversation/runner.ts` — create one `InjectTailer` per turn
-  (at turn setup, seeded so it only surfaces injects after the turn-entry watermark) and
-  call `tailer.readNew()` where `readImmediateInjectsSince` is called today.
+
+- `packages/agent/src/core/conversation/runner.ts` — create one `InjectTailer`
+  per turn (at turn setup, seeded so it only surfaces injects after the
+  turn-entry watermark) and call `tailer.readNew()` where
+  `readImmediateInjectsSince` is called today.
 
 ---
 
@@ -65,7 +73,8 @@ the last-newline offset rule rules out.
 
 **Files:** `inject-tailer.ts`, test
 
-- [ ] **Step 1: Failing test — reads only complete new lines, holds back a partial tail.**
+- [ ] **Step 1: Failing test — reads only complete new lines, holds back a
+      partial tail.**
 
 ```ts
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -76,7 +85,9 @@ import { readNewCompleteLines } from '@lace/agent/storage/inject-tailer';
 
 describe('readNewCompleteLines', () => {
   let f: string;
-  beforeEach(() => { f = join(mkdtempSync(join(tmpdir(), 'lace-tail-')), 'events.jsonl'); });
+  beforeEach(() => {
+    f = join(mkdtempSync(join(tmpdir(), 'lace-tail-')), 'events.jsonl');
+  });
   afterEach(() => rmSync(f, { recursive: true, force: true }));
 
   it('returns only newline-terminated lines and advances the offset past them', () => {
@@ -99,16 +110,19 @@ describe('readNewCompleteLines', () => {
   });
 
   it('returns {lines:[], offset} for a missing file', () => {
-    expect(readNewCompleteLines(join(f, 'nope'), 0)).toEqual({ lines: [], offset: 0 });
+    expect(readNewCompleteLines(join(f, 'nope'), 0)).toEqual({
+      lines: [],
+      offset: 0,
+    });
   });
 });
 ```
 
 - [ ] **Step 2: RED.**
 
-- [ ] **Step 3: Implement `readNewCompleteLines(file, offset)`** — read `[offset, EOF)`,
-  find the last `\n`, return complete lines, advance offset only to just past the last
-  `\n` (the trailing partial stays unread):
+- [ ] **Step 3: Implement `readNewCompleteLines(file, offset)`** — read
+      `[offset, EOF)`, find the last `\n`, return complete lines, advance offset
+      only to just past the last `\n` (the trailing partial stays unread):
 
 ```ts
 // ABOUTME: Incremental, partial-line-safe tail reader for the durable JSONL shards.
@@ -118,9 +132,16 @@ describe('readNewCompleteLines', () => {
 // so it never lags a derived index.
 import * as fs from 'node:fs';
 
-export function readNewCompleteLines(file: string, offset: number): { lines: string[]; offset: number } {
+export function readNewCompleteLines(
+  file: string,
+  offset: number
+): { lines: string[]; offset: number } {
   let fd: number;
-  try { fd = fs.openSync(file, 'r'); } catch { return { lines: [], offset }; }
+  try {
+    fd = fs.openSync(file, 'r');
+  } catch {
+    return { lines: [], offset };
+  }
   try {
     const size = fs.fstatSync(fd).size;
     if (size <= offset) return { lines: [], offset }; // nothing new (or truncated — see note)
@@ -132,18 +153,22 @@ export function readNewCompleteLines(file: string, offset: number): { lines: str
     if (lastNl === -1) return { lines: [], offset }; // no complete line yet; hold back
     const complete = text.slice(0, lastNl); // excludes the trailing partial (if any)
     const lines = complete.split('\n').filter((l) => l.length > 0);
-    return { lines, offset: offset + Buffer.byteLength(text.slice(0, lastNl + 1), 'utf8') };
+    return {
+      lines,
+      offset: offset + Buffer.byteLength(text.slice(0, lastNl + 1), 'utf8'),
+    };
   } finally {
     fs.closeSync(fd);
   }
 }
 ```
 
-> **Note (truncation):** if `size < offset` (the file shrank — shouldn't happen for an
-> append-only log, but be defensive), reset to read from 0. Decide and implement: the
-> safest is to treat `size < offset` as "re-read from 0" so a rotated/replaced file is
-> not silently skipped; document the choice. Use BYTE offsets (`Buffer.byteLength`) not
-> char offsets, since multibyte UTF-8 makes char ≠ byte.
+> **Note (truncation):** if `size < offset` (the file shrank — shouldn't happen
+> for an append-only log, but be defensive), reset to read from 0. Decide and
+> implement: the safest is to treat `size < offset` as "re-read from 0" so a
+> rotated/replaced file is not silently skipped; document the choice. Use BYTE
+> offsets (`Buffer.byteLength`) not char offsets, since multibyte UTF-8 makes
+> char ≠ byte.
 
 - [ ] **Step 4: GREEN. Commit.**
 
@@ -158,9 +183,10 @@ git commit -m "feat(session-state): partial-line-safe JSONL tail reader"
 
 **Files:** `inject-tailer.ts`, test
 
-- [ ] **Step 1: Failing test** — a tailer surfaces an immediate inject appended after
-  creation, across the SAME shard and a NEW shard, exactly once, with the right
-  watermark; non-immediate injects and non-inject events are ignored.
+- [ ] **Step 1: Failing test** — a tailer surfaces an immediate inject appended
+      after creation, across the SAME shard and a NEW shard, exactly once, with
+      the right watermark; non-immediate injects and non-inject events are
+      ignored.
 
 ```ts
 import { createInjectTailer } from '@lace/agent/storage/inject-tailer';
@@ -181,21 +207,24 @@ it('surfaces only new immediate injects, across shards, once', () => {
 
 - [ ] **Step 2: RED.**
 
-- [ ] **Step 3: Implement `createInjectTailer(laceDir, sessionId, afterEventSeq)`** —
-  holds a `Map<filePath, offset>` and a `watermark = afterEventSeq`. `readNew()`:
-  enumerate the current shard file set (the SAME set `readAllSessionEventLines` uses:
-  legacy + `listTranscriptFiles`); for each file, `readNewCompleteLines(file, offset)`,
-  parse each line, and for events with `type==='context_injected'`,
-  `data.priority==='immediate'`, and `eventSeq > watermark`, collect
-  `extractInjectedText(data.content)` (reuse the existing helper) and raise the
-  watermark; update the offset map. A **new** shard file not in the map starts at offset
-  0. Return `{ injections, newWatermark }`.
+- [ ] **Step 3: Implement
+      `createInjectTailer(laceDir, sessionId, afterEventSeq)`** — holds a
+      `Map<filePath, offset>` and a `watermark = afterEventSeq`. `readNew()`:
+      enumerate the current shard file set (the SAME set
+      `readAllSessionEventLines` uses: legacy + `listTranscriptFiles`); for each
+      file, `readNewCompleteLines(file, offset)`, parse each line, and for
+      events with `type==='context_injected'`, `data.priority==='immediate'`,
+      and `eventSeq > watermark`, collect `extractInjectedText(data.content)`
+      (reuse the existing helper) and raise the watermark; update the offset
+      map. A **new** shard file not in the map starts at offset 0. Return
+      `{ injections, newWatermark }`.
 
 > Reuse `extractInjectedText` and the exact predicates from the current
 > `readImmediateInjectsSince` so behavior is identical. The watermark filter
-> (`eventSeq > watermark`) is what dedups across shards and makes re-reads idempotent —
-> keep it even though offsets already prevent re-reading bytes (belt-and-suspenders, and
-> it handles a brand-new shard whose early events are ≤ watermark).
+> (`eventSeq > watermark`) is what dedups across shards and makes re-reads
+> idempotent — keep it even though offsets already prevent re-reading bytes
+> (belt-and-suspenders, and it handles a brand-new shard whose early events are
+> ≤ watermark).
 
 - [ ] **Step 4: GREEN. Commit.**
 
@@ -210,35 +239,43 @@ git commit -m "feat(session-state): InjectTailer — incremental immediate-injec
 
 **Files:** `inject-tailer.test.ts`, `runner.ts`
 
-- [ ] **Step 1: Differential test** — for a corpus of shard states (incl. a cross-process
-  inject appended between two `readNew()` calls, a cross-date shard, interleaved
-  tool_use/turn events, a non-immediate inject), assert the union of `tailer.readNew()`
-  results over the sequence equals what the OLD `readImmediateInjectsSince` would return
-  for the same watermark. (Import the old function; it still exists.)
+- [ ] **Step 1: Differential test** — for a corpus of shard states (incl. a
+      cross-process inject appended between two `readNew()` calls, a cross-date
+      shard, interleaved tool_use/turn events, a non-immediate inject), assert
+      the union of `tailer.readNew()` results over the sequence equals what the
+      OLD `readImmediateInjectsSince` would return for the same watermark.
+      (Import the old function; it still exists.)
 
-> This pins behavioral equivalence: the tail-read returns exactly the injects the full
-> scan would, in order, with no misses and no dups.
+> This pins behavioral equivalence: the tail-read returns exactly the injects
+> the full scan would, in order, with no misses and no dups.
 
-- [ ] **Step 2: RED/GREEN as you build the test** (it should pass once Task 2 is correct;
-  if it reveals a discrepancy, fix the tailer — the full scan is the oracle).
+- [ ] **Step 2: RED/GREEN as you build the test** (it should pass once Task 2 is
+      correct; if it reveals a discrepancy, fix the tailer — the full scan is
+      the oracle).
 
-- [ ] **Step 3: Wire into the runner.** At turn setup, create one tailer seeded with the
-  turn-entry watermark (`lastSeenEventSeq` from `loadTurnEntryProjection`):
-  `const injectTailer = createInjectTailer(getLaceDir(), sessionId, lastSeenEventSeq);`
-  Replace the per-iteration `readImmediateInjectsSince(sessionDir, lastSeenEventSeq)` call
-  (~runner.ts:546) with `const { injections, newWatermark } = injectTailer.readNew();`
-  and keep threading `lastSeenEventSeq = newWatermark`. Leave the injection-application
-  logic (how injections become messages) unchanged.
+- [ ] **Step 3: Wire into the runner.** At turn setup, create one tailer seeded
+      with the turn-entry watermark (`lastSeenEventSeq` from
+      `loadTurnEntryProjection`):
+      `const injectTailer = createInjectTailer(getLaceDir(), sessionId, lastSeenEventSeq);`
+      Replace the per-iteration
+      `readImmediateInjectsSince(sessionDir, lastSeenEventSeq)` call
+      (~runner.ts:546) with
+      `const { injections, newWatermark } = injectTailer.readNew();` and keep
+      threading `lastSeenEventSeq = newWatermark`. Leave the
+      injection-application logic (how injections become messages) unchanged.
 
 > Confirm `sessionId`/`getLaceDir()` are in scope at the call site (sessionId =
-> `path.basename(sessionDir)`). The tailer is per-turn (recreated each turn), so offsets
-> reset each turn — correct, because each turn re-seeds from the turn-entry watermark.
+> `path.basename(sessionDir)`). The tailer is per-turn (recreated each turn), so
+> offsets reset each turn — correct, because each turn re-seeds from the
+> turn-entry watermark.
 
-- [ ] **Step 4: Verify — full runner + storage suites green, byte gates untouched.**
+- [ ] **Step 4: Verify — full runner + storage suites green, byte gates
+      untouched.**
 
-Run: `cd packages/agent && npx vitest run src/core/conversation src/storage src/providers/__tests__/golden && npx tsc --noEmit`
-Expected: PASS (the env-only `ollama-integration` excluded). Injects behave identically;
-no golden/sent-vs-rebuilt change (this is a read-path change only).
+Run:
+`cd packages/agent && npx vitest run src/core/conversation src/storage src/providers/__tests__/golden && npx tsc --noEmit`
+Expected: PASS (the env-only `ollama-integration` excluded). Injects behave
+identically; no golden/sent-vs-rebuilt change (this is a read-path change only).
 
 - [ ] **Step 5: Commit.**
 
@@ -251,16 +288,18 @@ git commit -m "perf(session-state): runner reads immediate injects via increment
 
 ## Self-review notes (for the executor)
 
-- **Reads the truth, never an index:** the tailer reads the JSONL shards directly, so a
-  cross-process inject is seen as soon as its line lands. Do NOT route this through the
-  `event_journal` (it lags — that was the rejected rev1 design).
-- **Partial-line safety is load-bearing:** advance the offset only to the last complete
-  `\n`. A concurrently-appended partial line must be held back and read next time, never
-  parsed partially.
-- **Behavioral equivalence is the gate:** the differential test (Task 3 Step 1) proves
-  the tail-read returns exactly what the full scan returned. If it ever diverges, the
-  full scan is the oracle — fix the tailer.
-- **Out of scope:** seq assignment / the flock + head file (Step 3.3); the `event_journal`
-  (Step 3.1, done). This step changes only the inject read path.
-- **Confirm against source:** the exact shard file set, `extractInjectedText`, the
-  `priority==='immediate'` predicate, and the runner call site + in-scope variables.
+- **Reads the truth, never an index:** the tailer reads the JSONL shards
+  directly, so a cross-process inject is seen as soon as its line lands. Do NOT
+  route this through the `event_journal` (it lags — that was the rejected rev1
+  design).
+- **Partial-line safety is load-bearing:** advance the offset only to the last
+  complete `\n`. A concurrently-appended partial line must be held back and read
+  next time, never parsed partially.
+- **Behavioral equivalence is the gate:** the differential test (Task 3 Step 1)
+  proves the tail-read returns exactly what the full scan returned. If it ever
+  diverges, the full scan is the oracle — fix the tailer.
+- **Out of scope:** seq assignment / the flock + head file (Step 3.3); the
+  `event_journal` (Step 3.1, done). This step changes only the inject read path.
+- **Confirm against source:** the exact shard file set, `extractInjectedText`,
+  the `priority==='immediate'` predicate, and the runner call site + in-scope
+  variables.

--- a/docs/superpowers/plans/2026-06-18-session-state-step3c-seq-flock-head.md
+++ b/docs/superpowers/plans/2026-06-18-session-state-step3c-seq-flock-head.md
@@ -1,54 +1,66 @@
 # Session-State Step 3.3 — Cross-Process Seq Authority (flock + head file) Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
 
 **THIS IS THE LOG-CORRUPTION-CRITICAL STEP.** Read the design first:
-`docs/design/2026-06-18-session-state-step3-index-and-seq-authority.md` (rev2). A mistake
-here corrupts the durable event log. Every task ends green; the seq-cutover task carries
-real two-subprocess concurrency and crash-injection tests, and the whole change is
-re-reviewed before it deploys to a live coworker.
+`docs/design/2026-06-18-session-state-step3-index-and-seq-authority.md` (rev2).
+A mistake here corrupts the durable event log. Every task ends green; the
+seq-cutover task carries real two-subprocess concurrency and crash-injection
+tests, and the whole change is re-reviewed before it deploys to a live coworker.
 
-**Goal:** Replace the per-append full-log scan (`deriveNextEventSeqAcrossSessionFiles`)
-that assigns `eventSeq` with an **O(1)** read of a per-session **monotonic head file**,
-guarded by a per-session **cross-process file lock**, using **reserve-before-append** so
-a crash burns a harmless gap rather than a duplicate seq.
+**Goal:** Replace the per-append full-log scan
+(`deriveNextEventSeqAcrossSessionFiles`) that assigns `eventSeq` with an
+**O(1)** read of a per-session **monotonic head file**, guarded by a per-session
+**cross-process file lock**, using **reserve-before-append** so a crash burns a
+harmless gap rather than a duplicate seq.
 
-**Architecture:** A sync `mkdir`+owner-token cross-process lock (`session-lock.ts`). A
-per-session head file `<sessionDir>/.seq` holding the next-free seq (`seq-head.ts`).
-`appendDurableEvent` does, under the lock: read/seed the head `H`, write head `H+1`
-(reserve), append the JSONL line with `seq=H`. The head reconciles to
-`MAX(stored, MAX(JSONL)+1)` on open. `SessionState.nextEventSeq` is retired as an
-authority. Wrapping the lock inside `appendDurableEvent` covers all ~20 callers; the only
-non-`appendDurableEvent` writer is `session/fork` (a new session, no race — lazy seed).
+**Architecture:** A sync `mkdir`+owner-token cross-process lock
+(`session-lock.ts`). A per-session head file `<sessionDir>/.seq` holding the
+next-free seq (`seq-head.ts`). `appendDurableEvent` does, under the lock:
+read/seed the head `H`, write head `H+1` (reserve), append the JSONL line with
+`seq=H`. The head reconciles to `MAX(stored, MAX(JSONL)+1)` on open.
+`SessionState.nextEventSeq` is retired as an authority. Wrapping the lock inside
+`appendDurableEvent` covers all ~20 callers; the only non-`appendDurableEvent`
+writer is `session/fork` (a new session, no race — lazy seed).
 
-**Tech Stack:** TypeScript, vitest, `node:fs`, `node:child_process` (real subprocess
-concurrency tests). Per the codebase: real files in tests (tempdir), never mocked.
+**Tech Stack:** TypeScript, vitest, `node:fs`, `node:child_process` (real
+subprocess concurrency tests). Per the codebase: real files in tests (tempdir),
+never mocked.
 
 ---
 
 ## Background (verified facts)
 
-- `appendDurableEvent(sessionDir, state, event)` (`packages/agent/src/storage/event-log.ts:~434`)
-  is **synchronous**. ~20 call sites all go through it (prompt.ts, permissions.ts,
-  session-operations.ts, session.ts, subagent-job.ts, job-notifications.ts,
-  inject-notification.ts, runner.ts, server.ts, repairOrphanTurnStarts). Keep it sync.
-- Today it assigns `eventSeq = deriveNextEventSeqAcrossSessionFiles(laceDir, sessionId)`
-  (`event-log.ts:~472`), a full O(events) scan over legacy + all persona/date shards,
-  **outside any cross-process lock**. Returns `nextState.nextEventSeq = written.eventSeq+1`.
-- `session/fork` (`session.ts:941`) copies events with raw `appendFileSync`, preserving
-  seqs — bypasses `appendDurableEvent`. (Safe: new session, no concurrent appender.)
+- `appendDurableEvent(sessionDir, state, event)`
+  (`packages/agent/src/storage/event-log.ts:~434`) is **synchronous**. ~20 call
+  sites all go through it (prompt.ts, permissions.ts, session-operations.ts,
+  session.ts, subagent-job.ts, job-notifications.ts, inject-notification.ts,
+  runner.ts, server.ts, repairOrphanTurnStarts). Keep it sync.
+- Today it assigns
+  `eventSeq = deriveNextEventSeqAcrossSessionFiles(laceDir, sessionId)`
+  (`event-log.ts:~472`), a full O(events) scan over legacy + all persona/date
+  shards, **outside any cross-process lock**. Returns
+  `nextState.nextEventSeq = written.eventSeq+1`.
+- `session/fork` (`session.ts:941`) copies events with raw `appendFileSync`,
+  preserving seqs — bypasses `appendDurableEvent`. (Safe: new session, no
+  concurrent appender.)
 - `loadSession` (`session-store.ts:~284`) repairs `state.nextEventSeq` from
-  `deriveNextEventSeqFromEventLog` (= `MAX(JSONL)+1`) and rewrites state on mismatch.
-- Consumers are **gap-tolerant** (verified by the design review): the reducer sorts by
-  seq; watermarks compare `>`/`<=`; checkpoints match exact stored seqs; recall ranges
-  tolerate missing neighbors. Nothing assumes gapless seqs **except** the `loadSession`
-  repair, which this plan retires.
+  `deriveNextEventSeqFromEventLog` (= `MAX(JSONL)+1`) and rewrites state on
+  mismatch.
+- Consumers are **gap-tolerant** (verified by the design review): the reducer
+  sorts by seq; watermarks compare `>`/`<=`; checkpoints match exact stored
+  seqs; recall ranges tolerate missing neighbors. Nothing assumes gapless seqs
+  **except** the `loadSession` repair, which this plan retires.
 
 **Invariants (from the design — do not violate):**
-- Reserve-before-append: write head `H+1` BEFORE appending JSONL `seq=H`. A crash in
-  between burns `H` (a gap). Never a duplicate.
-- Reconcile monotonic: `head = MAX(readHead()|0, MAX(JSONL)+1)` on open — never moves down.
-- The lock is held across the JSONL append (so seeding reads a stable `MAX(JSONL)`).
+
+- Reserve-before-append: write head `H+1` BEFORE appending JSONL `seq=H`. A
+  crash in between burns `H` (a gap). Never a duplicate.
+- Reconcile monotonic: `head = MAX(readHead()|0, MAX(JSONL)+1)` on open — never
+  moves down.
+- The lock is held across the JSONL append (so seeding reads a stable
+  `MAX(JSONL)`).
 - Gaps are allowed; seq is unique + monotonic.
 
 **Test command:** `cd packages/agent && npx vitest run <path>`.
@@ -58,20 +70,24 @@ concurrency tests). Per the codebase: real files in tests (tempdir), never mocke
 ## File Structure
 
 **Create:**
-- `packages/agent/src/storage/session-lock.ts` — `withSessionLock(sessionDir, fn)`: sync
-  `mkdir`+owner-token cross-process lock.
-- `packages/agent/src/storage/seq-head.ts` — `readHead`, `reserveSeq`, `seedHead`,
-  `reconcileHead` over `<sessionDir>/.seq`.
+
+- `packages/agent/src/storage/session-lock.ts` —
+  `withSessionLock(sessionDir, fn)`: sync `mkdir`+owner-token cross-process
+  lock.
+- `packages/agent/src/storage/seq-head.ts` — `readHead`, `reserveSeq`,
+  `seedHead`, `reconcileHead` over `<sessionDir>/.seq`.
 - `packages/agent/src/storage/__tests__/session-lock.test.ts`
 - `packages/agent/src/storage/__tests__/seq-head.test.ts`
-- `packages/agent/src/storage/__tests__/seq-concurrency.test.ts` (real subprocesses)
+- `packages/agent/src/storage/__tests__/seq-concurrency.test.ts` (real
+  subprocesses)
 - `packages/agent/src/storage/__tests__/seq-crash.test.ts` (crash-injection)
 - `packages/agent/src/storage/__tests__/_seq-append-child.ts` (helper script the
   concurrency/crash tests spawn)
 
 **Modify:**
-- `packages/agent/src/storage/event-log.ts` — `appendDurableEvent` assigns seq via the
-  locked head reserve.
+
+- `packages/agent/src/storage/event-log.ts` — `appendDurableEvent` assigns seq
+  via the locked head reserve.
 - `packages/agent/src/storage/session-store.ts` — stop repairing/rewriting
   `state.nextEventSeq` from a JSONL scan; reconcile the head on open instead.
 
@@ -81,20 +97,32 @@ concurrency tests). Per the codebase: real files in tests (tempdir), never mocke
 
 **Files:** `session-lock.ts`, `session-lock.test.ts`
 
-- [ ] **Step 1: Failing tests** — mutual exclusion, owner-token-safe release, stale
-  reclaim, re-entrancy is NOT supported (nested acquire of the same lock in the same
-  process must not deadlock the test — design it non-reentrant and document):
+- [ ] **Step 1: Failing tests** — mutual exclusion, owner-token-safe release,
+      stale reclaim, re-entrancy is NOT supported (nested acquire of the same
+      lock in the same process must not deadlock the test — design it
+      non-reentrant and document):
 
 ```ts
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  mkdirSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { withSessionLock, SEQ_LOCK_STALE_MS } from '@lace/agent/storage/session-lock';
+import {
+  withSessionLock,
+  SEQ_LOCK_STALE_MS,
+} from '@lace/agent/storage/session-lock';
 
 describe('withSessionLock', () => {
   let dir: string;
-  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'lace-lock-')); });
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'lace-lock-'));
+  });
   afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
   it('runs the critical section and releases (lock dir gone after)', () => {
@@ -104,7 +132,11 @@ describe('withSessionLock', () => {
   });
 
   it('releases even if the critical section throws', () => {
-    expect(() => withSessionLock(dir, () => { throw new Error('boom'); })).toThrow('boom');
+    expect(() =>
+      withSessionLock(dir, () => {
+        throw new Error('boom');
+      })
+    ).toThrow('boom');
     expect(existsSync(join(dir, '.seq.lock'))).toBe(false);
   });
 
@@ -114,7 +146,7 @@ describe('withSessionLock', () => {
     mkdirSync(lockDir);
     writeFileSync(join(lockDir, 'owner'), 'dead-process-token');
     // Backdate it beyond the staleness threshold.
-    const old = Date.now() / 1000 - (SEQ_LOCK_STALE_MS / 1000) - 5;
+    const old = Date.now() / 1000 - SEQ_LOCK_STALE_MS / 1000 - 5;
     require('node:fs').utimesSync(lockDir, old, old);
     const r = withSessionLock(dir, () => 'reclaimed');
     expect(r).toBe('reclaimed');
@@ -124,8 +156,9 @@ describe('withSessionLock', () => {
     const lockDir = join(dir, '.seq.lock');
     mkdirSync(lockDir);
     writeFileSync(join(lockDir, 'owner'), 'live-other-token'); // fresh mtime
-    expect(() => withSessionLock(dir, () => 'should-not-run', { timeoutMs: 200 }))
-      .toThrow(/lock timeout/i);
+    expect(() =>
+      withSessionLock(dir, () => 'should-not-run', { timeoutMs: 200 })
+    ).toThrow(/lock timeout/i);
     rmSync(lockDir, { recursive: true, force: true });
   });
 });
@@ -133,12 +166,13 @@ describe('withSessionLock', () => {
 
 - [ ] **Step 2: RED.**
 
-- [ ] **Step 3: Implement the lock.** Core guarantees: `mkdir` is atomic cross-process
-  (one winner); a unique owner token written inside makes release safe (only the owner
-  removes it, so an un-hung former holder cannot delete a successor's lock); staleness
-  reclaim only removes a lock whose mtime is older than `SEQ_LOCK_STALE_MS` (set it well
-  above the sub-10ms critical section — e.g. 30_000 — so a live holder is never
-  false-reclaimed).
+- [ ] **Step 3: Implement the lock.** Core guarantees: `mkdir` is atomic
+      cross-process (one winner); a unique owner token written inside makes
+      release safe (only the owner removes it, so an un-hung former holder
+      cannot delete a successor's lock); staleness reclaim only removes a lock
+      whose mtime is older than `SEQ_LOCK_STALE_MS` (set it well above the
+      sub-10ms critical section — e.g. 30_000 — so a live holder is never
+      false-reclaimed).
 
 ```ts
 // ABOUTME: A per-session cross-process advisory lock for the durable-append critical
@@ -155,7 +189,11 @@ export const SEQ_LOCK_STALE_MS = 30_000;
 const DEFAULT_TIMEOUT_MS = 10_000;
 const SPIN_MS = 5;
 
-export function withSessionLock<T>(sessionDir: string, fn: () => T, opts?: { timeoutMs?: number }): T {
+export function withSessionLock<T>(
+  sessionDir: string,
+  fn: () => T,
+  opts?: { timeoutMs?: number }
+): T {
   const lockDir = path.join(sessionDir, '.seq.lock');
   const ownerPath = path.join(lockDir, 'owner');
   const token = randomUUID();
@@ -171,7 +209,8 @@ export function withSessionLock<T>(sessionDir: string, fn: () => T, opts?: { tim
       if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
       // held — reclaim if stale
       tryReclaimStale(lockDir);
-      if (nowMs() > deadline) throw new Error(`session-lock timeout on ${lockDir}`);
+      if (nowMs() > deadline)
+        throw new Error(`session-lock timeout on ${lockDir}`);
       spin(SPIN_MS);
     }
   }
@@ -202,20 +241,25 @@ function tryReclaimStale(lockDir: string): void {
   }
 }
 
-function nowMs(): number { return Number(process.hrtime.bigint() / 1_000_000n); }
+function nowMs(): number {
+  return Number(process.hrtime.bigint() / 1_000_000n);
+}
 function spin(ms: number): void {
   const end = nowMs() + ms;
-  while (nowMs() < end) { /* busy-wait; the section is sub-ms so contention is brief */ }
+  while (nowMs() < end) {
+    /* busy-wait; the section is sub-ms so contention is brief */
+  }
 }
 ```
 
-> The busy-wait `spin` is acceptable because the critical section is sub-10ms and
-> contention is rare (Jesse confirmed cross-process appends "should not" happen; this is
-> the safety net). If a reviewer objects to busy-wait, replace with a tiny blocking sleep
-> (`Atomics.wait` on a SharedArrayBuffer) — but do NOT make the function async. `nowMs`
-> via `process.hrtime` avoids the banned `Date.now()` in non-test code paths; confirm the
-> repo's stance and use the real clock the rest of `event-log.ts` uses (it uses
-> `new Date().toISOString()` for timestamps, so wall-clock is allowed here).
+> The busy-wait `spin` is acceptable because the critical section is sub-10ms
+> and contention is rare (Jesse confirmed cross-process appends "should not"
+> happen; this is the safety net). If a reviewer objects to busy-wait, replace
+> with a tiny blocking sleep (`Atomics.wait` on a SharedArrayBuffer) — but do
+> NOT make the function async. `nowMs` via `process.hrtime` avoids the banned
+> `Date.now()` in non-test code paths; confirm the repo's stance and use the
+> real clock the rest of `event-log.ts` uses (it uses `new Date().toISOString()`
+> for timestamps, so wall-clock is allowed here).
 
 - [ ] **Step 4: GREEN. Commit.**
 
@@ -230,11 +274,16 @@ git commit -m "feat(session-state): per-session cross-process mkdir+token lock"
 
 **Files:** `seq-head.ts`, `seq-head.test.ts`
 
-- [ ] **Step 1: Failing tests** — read/seed/reserve/reconcile semantics, head stores the
-  **next-free** seq, reconcile is monotonic and never below `MAX(JSONL)+1`:
+- [ ] **Step 1: Failing tests** — read/seed/reserve/reconcile semantics, head
+      stores the **next-free** seq, reconcile is monotonic and never below
+      `MAX(JSONL)+1`:
 
 ```ts
-import { readHead, reserveSeq, reconcileHead } from '@lace/agent/storage/seq-head';
+import {
+  readHead,
+  reserveSeq,
+  reconcileHead,
+} from '@lace/agent/storage/seq-head';
 // ... temp sessionDir with some JSONL events up to seq 10 ...
 
 it('seeds from MAX(JSONL)+1 when the head is missing', () => {
@@ -248,29 +297,31 @@ it('reserve is strictly increasing', () => {
   expect(b).toBe(a + 1);
 });
 it('reconcile never lowers the head and floors at MAX(JSONL)+1', () => {
-  writeHead(sessionDir, 5);           // stale head below JSONL max 10
+  writeHead(sessionDir, 5); // stale head below JSONL max 10
   reconcileHead(sessionDir, () => 10); // MAX(JSONL)=10
   expect(readHead(sessionDir)).toBe(11);
-  reconcileHead(sessionDir, () => 3);  // lower — must not move down
+  reconcileHead(sessionDir, () => 3); // lower — must not move down
   expect(readHead(sessionDir)).toBe(11);
 });
 ```
 
 - [ ] **Step 2: RED.**
 
-- [ ] **Step 3: Implement.** `reserveSeq(sessionDir, deriveMaxJsonl)`: read the head (or
-  seed = `deriveMaxJsonl()+1` if missing); `seq = head`; write head = `seq+1`; return
-  `seq`. **Caller holds the lock.** `reconcileHead(sessionDir, deriveMaxJsonl)`:
-  `head = MAX(readHead()|0, deriveMaxJsonl()+1)`; write it. Head file = a single integer
-  as text. `deriveMaxJsonl` is injected (the caller passes
-  `() => deriveNextEventSeqAcrossSessionFiles(...) - 1` or a max helper) so this module
-  has no shard-discovery dependency.
+- [ ] **Step 3: Implement.** `reserveSeq(sessionDir, deriveMaxJsonl)`: read the
+      head (or seed = `deriveMaxJsonl()+1` if missing); `seq = head`; write head
+      = `seq+1`; return `seq`. **Caller holds the lock.**
+      `reconcileHead(sessionDir, deriveMaxJsonl)`:
+      `head = MAX(readHead()|0, deriveMaxJsonl()+1)`; write it. Head file = a
+      single integer as text. `deriveMaxJsonl` is injected (the caller passes
+      `() => deriveNextEventSeqAcrossSessionFiles(...) - 1` or a max helper) so
+      this module has no shard-discovery dependency.
 
-> Note: `deriveNextEventSeqAcrossSessionFiles` returns `MAX+1`; so `MAX(JSONL) =
-> deriveNextEventSeqAcrossSessionFiles(...) - 1` and `MAX(JSONL)+1 =
-> deriveNextEventSeqAcrossSessionFiles(...)`. Use the existing function as the seed
-> source to avoid duplicating shard discovery; the `+1`/`-1` bookkeeping must be exact —
-> add a test that the seeded first seq equals what the OLD code would have assigned.
+> Note: `deriveNextEventSeqAcrossSessionFiles` returns `MAX+1`; so
+> `MAX(JSONL) = deriveNextEventSeqAcrossSessionFiles(...) - 1` and
+> `MAX(JSONL)+1 = deriveNextEventSeqAcrossSessionFiles(...)`. Use the existing
+> function as the seed source to avoid duplicating shard discovery; the
+> `+1`/`-1` bookkeeping must be exact — add a test that the seeded first seq
+> equals what the OLD code would have assigned.
 
 - [ ] **Step 4: GREEN. Commit.**
 
@@ -285,34 +336,39 @@ git commit -m "feat(session-state): per-session monotonic head file (next-free s
 
 **Files:** `event-log.ts`
 
-- [ ] **Step 1: Failing test** — the first append to a session that already has JSONL
-  events (seq up to N) gets seq N+1 (parity with the old derive); two sequential appends
-  get strictly increasing seqs; and the head file ends at the right next-free value.
+- [ ] **Step 1: Failing test** — the first append to a session that already has
+      JSONL events (seq up to N) gets seq N+1 (parity with the old derive); two
+      sequential appends get strictly increasing seqs; and the head file ends at
+      the right next-free value.
 
 - [ ] **Step 2: RED.**
 
 - [ ] **Step 3: Implement.** Wrap the seq assignment + JSONL append in
-  `withSessionLock(sessionDir, () => { ... })`, replacing the `deriveNextEventSeq...`
-  line. Inside the lock: `const eventSeq = reserveSeq(sessionDir, () => deriveNextEventSeqAcrossSessionFiles(laceDir, sessionId) - 1);`
-  (head reserve, seeding on first use), then the existing newline-guard + `appendFileSync`
-  with `seq=eventSeq`. **Reserve-before-append is guaranteed because `reserveSeq` writes
-  head `H+1` before returning `H`, and the JSONL append follows.** Keep the turn_end dedup
-  (`findTurnEndEventByTurnId`) — but move it INSIDE the lock and BEFORE the reserve, so a
-  duplicate turn_end neither reserves a seq nor appends (read the JSONL under the lock; it
-  is the truth, never stale). The recall/journal write-through stays OUTSIDE the lock
-  (best-effort, not correctness).
+      `withSessionLock(sessionDir, () => { ... })`, replacing the
+      `deriveNextEventSeq...` line. Inside the lock:
+      `const eventSeq = reserveSeq(sessionDir, () => deriveNextEventSeqAcrossSessionFiles(laceDir, sessionId) - 1);`
+      (head reserve, seeding on first use), then the existing newline-guard +
+      `appendFileSync` with `seq=eventSeq`. **Reserve-before-append is
+      guaranteed because `reserveSeq` writes head `H+1` before returning `H`,
+      and the JSONL append follows.** Keep the turn_end dedup
+      (`findTurnEndEventByTurnId`) — but move it INSIDE the lock and BEFORE the
+      reserve, so a duplicate turn_end neither reserves a seq nor appends (read
+      the JSONL under the lock; it is the truth, never stale). The
+      recall/journal write-through stays OUTSIDE the lock (best-effort, not
+      correctness).
 
-> The seed's `deriveNextEventSeqAcrossSessionFiles` runs only on the FIRST append per
-> session per process (when `.seq` is absent); thereafter `reserveSeq` is a pure head
-> read/increment — no scan. Confirm `.seq` persists so the scan is one-time.
-> `nextState.nextEventSeq = eventSeq + 1` stays for compatibility but is no longer an
-> authority (Task 5 retires its repair).
+> The seed's `deriveNextEventSeqAcrossSessionFiles` runs only on the FIRST
+> append per session per process (when `.seq` is absent); thereafter
+> `reserveSeq` is a pure head read/increment — no scan. Confirm `.seq` persists
+> so the scan is one-time. `nextState.nextEventSeq = eventSeq + 1` stays for
+> compatibility but is no longer an authority (Task 5 retires its repair).
 
 - [ ] **Step 4: GREEN; run the full storage + event-log + runner suites.**
 
-Run: `cd packages/agent && npx vitest run src/storage src/core/conversation && npx tsc --noEmit`
-Expected: PASS. The `.seq` lock dir + `.seq` file appear in session dirs — confirm no
-test asserts an exact session-dir file listing that would break.
+Run:
+`cd packages/agent && npx vitest run src/storage src/core/conversation && npx tsc --noEmit`
+Expected: PASS. The `.seq` lock dir + `.seq` file appear in session dirs —
+confirm no test asserts an exact session-dir file listing that would break.
 
 - [ ] **Step 5: Commit.**
 
@@ -325,42 +381,47 @@ git commit -m "feat(session-state): assign eventSeq via locked head reserve (no 
 
 ## Task 4: Real two-subprocess concurrency + crash-injection tests
 
-**Files:** `_seq-append-child.ts`, `seq-concurrency.test.ts`, `seq-crash.test.ts`
+**Files:** `_seq-append-child.ts`, `seq-concurrency.test.ts`,
+`seq-crash.test.ts`
 
 This is the gold-standard proof. It spawns REAL OS processes.
 
-- [ ] **Step 1: The child script** `_seq-append-child.ts` — given a sessionDir + a count,
-  appends `count` events via `appendDurableEvent` and exits. (A thin wrapper so the test
-  can spawn it with `node`/`tsx`.)
+- [ ] **Step 1: The child script** `_seq-append-child.ts` — given a sessionDir +
+      a count, appends `count` events via `appendDurableEvent` and exits. (A
+      thin wrapper so the test can spawn it with `node`/`tsx`.)
 
-- [ ] **Step 2: Concurrency test** — spawn N (e.g. 4) children that each append M (e.g.
-  50) events to the SAME sessionDir concurrently; wait for all; then read every JSONL
-  line across all shards and assert: every `eventSeq` is **unique** (no dup), the set is
-  **monotonic with gaps allowed**, and the count of distinct seqs == N*M (no lost
-  appends). This is the test that proves the lock prevents the cross-process dup race.
+- [ ] **Step 2: Concurrency test** — spawn N (e.g. 4) children that each append
+      M (e.g. 50) events to the SAME sessionDir concurrently; wait for all; then
+      read every JSONL line across all shards and assert: every `eventSeq` is
+      **unique** (no dup), the set is **monotonic with gaps allowed**, and the
+      count of distinct seqs == N\*M (no lost appends). This is the test that
+      proves the lock prevents the cross-process dup race.
 
 ```ts
 // Spawn children; collect; then:
 const seqs = allEventSeqsAcrossShards(sessionDir);
 expect(new Set(seqs).size).toBe(seqs.length); // NO DUPLICATES
-expect(seqs.length).toBe(N * M);               // no lost appends
+expect(seqs.length).toBe(N * M); // no lost appends
 const sorted = [...seqs].sort((a, b) => a - b);
-for (let i = 1; i < sorted.length; i++) expect(sorted[i]).toBeGreaterThan(sorted[i - 1]); // strictly increasing
+for (let i = 1; i < sorted.length; i++)
+  expect(sorted[i]).toBeGreaterThan(sorted[i - 1]); // strictly increasing
 ```
 
-> Use `node:child_process` `spawnSync`/`spawn`. Run the child via the repo's TS runner
-> (check how other spawn-based tests run TS — `tsx`? a prebuilt entry?). If spawning TS
-> is awkward, compile the child or use a `.mjs` shim that imports the built module. Mark
-> this test appropriately if it must run under `--no-file-parallelism` (it spawns
-> processes); the agent package already runs `src/__tests__` serially.
+> Use `node:child_process` `spawnSync`/`spawn`. Run the child via the repo's TS
+> runner (check how other spawn-based tests run TS — `tsx`? a prebuilt entry?).
+> If spawning TS is awkward, compile the child or use a `.mjs` shim that imports
+> the built module. Mark this test appropriately if it must run under
+> `--no-file-parallelism` (it spawns processes); the agent package already runs
+> `src/__tests__` serially.
 
-- [ ] **Step 3: Crash-injection test** — assert reserve-before-append yields a GAP, not a
-  dup, when a process dies between the head reserve and the JSONL append. Drive this
-  deterministically: a child that calls `reserveSeq` (advancing the head) then `exit(1)`
-  BEFORE appending; then a normal append; assert the JSONL has NO duplicate seq and the
-  burned seq is simply absent (a gap). (You may need a tiny test-only seam to reserve
-  without appending — e.g. call `reserveSeq` directly in the child — that's fine; it
-  exercises the exact crash window.)
+- [ ] **Step 3: Crash-injection test** — assert reserve-before-append yields a
+      GAP, not a dup, when a process dies between the head reserve and the JSONL
+      append. Drive this deterministically: a child that calls `reserveSeq`
+      (advancing the head) then `exit(1)` BEFORE appending; then a normal
+      append; assert the JSONL has NO duplicate seq and the burned seq is simply
+      absent (a gap). (You may need a tiny test-only seam to reserve without
+      appending — e.g. call `reserveSeq` directly in the child — that's fine; it
+      exercises the exact crash window.)
 
 - [ ] **Step 4: GREEN. Commit.**
 
@@ -375,35 +436,39 @@ git commit -m "test(session-state): two-subprocess seq concurrency + crash-injec
 
 **Files:** `session-store.ts`
 
-- [ ] **Step 1: Failing test** — opening a session whose head/JSONL have a GAP does NOT
-  rewrite `state.json` on every load (today's repair would, because gaps make
-  `nextEventSeq` != `MAX(JSONL)+1` mismatch its expectation).
+- [ ] **Step 1: Failing test** — opening a session whose head/JSONL have a GAP
+      does NOT rewrite `state.json` on every load (today's repair would, because
+      gaps make `nextEventSeq` != `MAX(JSONL)+1` mismatch its expectation).
 
 - [ ] **Step 2: RED** (the current `loadSession` repair rewrites state when
-  `state.nextEventSeq !== deriveNextEventSeqFromEventLog`).
+      `state.nextEventSeq !== deriveNextEventSeqFromEventLog`).
 
-- [ ] **Step 3: Implement.** In `loadSession`, replace the `state.nextEventSeq` repair
-  with `reconcileHead(sessionDir, () => deriveNextEventSeqAcrossSessionFiles(...) - 1)`
-  (the head becomes the reconciled authority on open). Keep `state.nextEventSeq` as a
-  derived/advisory field (set it from the reconciled head for back-compat) but DO NOT
-  drive seq assignment from it and DO NOT rewrite state.json solely to "repair" it. Read
-  `session-store.ts:~284` and the `readSessionState` corruption guard
-  (`session-store.ts:~160`) and ensure the guard's intent (a bad nextEventSeq must not
-  wedge turns) is preserved by the head reconcile.
+- [ ] **Step 3: Implement.** In `loadSession`, replace the `state.nextEventSeq`
+      repair with
+      `reconcileHead(sessionDir, () => deriveNextEventSeqAcrossSessionFiles(...) - 1)`
+      (the head becomes the reconciled authority on open). Keep
+      `state.nextEventSeq` as a derived/advisory field (set it from the
+      reconciled head for back-compat) but DO NOT drive seq assignment from it
+      and DO NOT rewrite state.json solely to "repair" it. Read
+      `session-store.ts:~284` and the `readSessionState` corruption guard
+      (`session-store.ts:~160`) and ensure the guard's intent (a bad
+      nextEventSeq must not wedge turns) is preserved by the head reconcile.
 
 - [ ] **Step 4: GREEN; full suite + typecheck + lint.**
 
-Run (repo root): `npm run typecheck && npm run lint`
-Run: `cd packages/agent && npx vitest run src/storage src/core/conversation src/providers/__tests__/golden`
-Expected: PASS. Goldens/sent-vs-rebuilt unchanged (seq assignment doesn't change wire bytes — seqs are not sent to providers).
+Run (repo root): `npm run typecheck && npm run lint` Run:
+`cd packages/agent && npx vitest run src/storage src/core/conversation src/providers/__tests__/golden`
+Expected: PASS. Goldens/sent-vs-rebuilt unchanged (seq assignment doesn't change
+wire bytes — seqs are not sent to providers).
 
 - [ ] **Step 5: Commit + evergreen doc.**
 
-Add a section to `docs/architecture/prompt-cache-stability.md` (or a session-state doc):
-present-tense, no refs — "Event sequence numbers are assigned under a per-session file
-lock from a monotonic head file (`<sessionDir>/.seq`), reserve-before-append so a crash
-yields a gap rather than a duplicate; the head reconciles to `MAX(JSONL)+1` on open. Seqs
-are unique and monotonic; gaps are normal and every consumer tolerates them."
+Add a section to `docs/architecture/prompt-cache-stability.md` (or a
+session-state doc): present-tense, no refs — "Event sequence numbers are
+assigned under a per-session file lock from a monotonic head file
+(`<sessionDir>/.seq`), reserve-before-append so a crash yields a gap rather than
+a duplicate; the head reconciles to `MAX(JSONL)+1` on open. Seqs are unique and
+monotonic; gaps are normal and every consumer tolerates them."
 
 ```bash
 git add packages/agent/src/storage/session-store.ts docs/architecture/prompt-cache-stability.md
@@ -414,16 +479,19 @@ git commit -m "refactor(session-state): head file is the seq authority; retire n
 
 ## Self-review notes (for the executor) — READ THESE
 
-- **The corruption invariant:** reserve-before-append (head `H+1` written before JSONL
-  `seq=H`) + the lock held across the append + reconcile-on-open. If any of those three is
-  violated, you can get a duplicate seq. The two-subprocess test (Task 4) is the proof —
-  if it ever shows a duplicate, STOP; the design is being violated.
-- **Lock release safety:** release only if the owner token still matches (a stale-reclaim
-  changed it). Never `rmSync` the lock unconditionally in `finally`.
-- **Do NOT make `appendDurableEvent` async** (20 sync call sites). The lock is sync.
-- **turn_end dedup reads the JSONL under the lock** (the truth) — never the lagging
-  `event_journal`.
-- **Out of scope:** the `event_journal` (3.1, done), the injects tail-read (3.2, done),
-  the projection/snapshots (Steps 4-5).
-- **After this plan is GREEN, it is RE-REVIEWED (adversarial) before any deploy to Ada.**
-  Do not deploy from this plan; hand back for review.
+- **The corruption invariant:** reserve-before-append (head `H+1` written before
+  JSONL `seq=H`) + the lock held across the append + reconcile-on-open. If any
+  of those three is violated, you can get a duplicate seq. The two-subprocess
+  test (Task 4) is the proof — if it ever shows a duplicate, STOP; the design is
+  being violated.
+- **Lock release safety:** release only if the owner token still matches (a
+  stale-reclaim changed it). Never `rmSync` the lock unconditionally in
+  `finally`.
+- **Do NOT make `appendDurableEvent` async** (20 sync call sites). The lock is
+  sync.
+- **turn_end dedup reads the JSONL under the lock** (the truth) — never the
+  lagging `event_journal`.
+- **Out of scope:** the `event_journal` (3.1, done), the injects tail-read (3.2,
+  done), the projection/snapshots (Steps 4-5).
+- **After this plan is GREEN, it is RE-REVIEWED (adversarial) before any deploy
+  to Ada.** Do not deploy from this plan; hand back for review.

--- a/docs/superpowers/plans/2026-06-18-session-state-step4-inmemory-projection.md
+++ b/docs/superpowers/plans/2026-06-18-session-state-step4-inmemory-projection.md
@@ -1,65 +1,73 @@
 # Session-State Step 4 — In-Memory Conversation Projection (O(tail) turn entry) Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
 
-**Goal:** Stop re-parsing the whole event log at every turn entry. Hold the rebuilt
-conversation projection (the `FoldState` + system prompt + files-read + last-turn-end
-watermark) **in memory across turns**, and on each turn fold only the **new tail**
-(events appended since the cached head) into it — O(tail) instead of O(events).
+**Goal:** Stop re-parsing the whole event log at every turn entry. Hold the
+rebuilt conversation projection (the `FoldState` + system prompt + files-read +
+last-turn-end watermark) **in memory across turns**, and on each turn fold only
+the **new tail** (events appended since the cached head) into it — O(tail)
+instead of O(events).
 
-**Architecture:** A per-session projection cache in `AgentServerState` (same pattern as
-`toolExecutorCache`). On turn entry, read the O(1) `.seq` tip (`readHead`): if a cached
-projection exists for this session, tail-read the events with `eventSeq` ≥ the cached
-head and fold them into the cached `FoldState` via `foldEvent` (incremental==batch is
-already proven), update the derived fields + head, and reuse. On a cache miss (process
-start, session switch, or a detected inconsistency) fall back to the existing full
-`loadTurnEntryProjection`. A sampled production **divergence canary** re-derives the full
-projection and compares; on mismatch it alarms and rebuilds. **No wire-byte change** —
-the projection feeds the same converters; the Step-0 golden + sent-vs-rebuilt gates and a
-new incremental==full differential test are the proof.
+**Architecture:** A per-session projection cache in `AgentServerState` (same
+pattern as `toolExecutorCache`). On turn entry, read the O(1) `.seq` tip
+(`readHead`): if a cached projection exists for this session, tail-read the
+events with `eventSeq` ≥ the cached head and fold them into the cached
+`FoldState` via `foldEvent` (incremental==batch is already proven), update the
+derived fields + head, and reuse. On a cache miss (process start, session
+switch, or a detected inconsistency) fall back to the existing full
+`loadTurnEntryProjection`. A sampled production **divergence canary** re-derives
+the full projection and compares; on mismatch it alarms and rebuilds. **No
+wire-byte change** — the projection feeds the same converters; the Step-0
+golden + sent-vs-rebuilt gates and a new incremental==full differential test are
+the proof.
 
 **Tech Stack:** TypeScript, vitest. Real files in tests.
 
-**Why safe:** the cached projection is the **persisted prefix only** (the runner's
-non-persisted live-tail mutations stay out of it, exactly as today). The incremental fold
-uses the SAME `foldEvent` reducer as the full rebuild, so by `foldEvents` determinism the
-result is byte-identical to a full rebuild over the same events — provable with a
-differential test. The tip-check + tail-read from the cached head captures every append
-(own-process and cross-process injects, since both advance `.seq`). Durable snapshots
-(cold-start speedup) are intentionally **out of scope** for this step to keep the change
-contained.
+**Why safe:** the cached projection is the **persisted prefix only** (the
+runner's non-persisted live-tail mutations stay out of it, exactly as today).
+The incremental fold uses the SAME `foldEvent` reducer as the full rebuild, so
+by `foldEvents` determinism the result is byte-identical to a full rebuild over
+the same events — provable with a differential test. The tip-check + tail-read
+from the cached head captures every append (own-process and cross-process
+injects, since both advance `.seq`). Durable snapshots (cold-start speedup) are
+intentionally **out of scope** for this step to keep the change contained.
 
 ---
 
 ## Background (verified facts — confirm against source)
 
 - Turn entry: `loadTurnEntryProjection(sessionDir, cwd): TurnEntryProjection`
-  (`message-building/turn-entry-projection.ts:19`) = `readParsedSessionEvents` (one full
-  parse) + 3 pure derivers. Called at `runner.ts:~404`; `messages → providerMessages`,
-  `systemPrompt → frozenSystemPrompt`, `lastTurnEndSeq → lastSeenEventSeq`.
+  (`message-building/turn-entry-projection.ts:19`) = `readParsedSessionEvents`
+  (one full parse) + 3 pure derivers. Called at `runner.ts:~404`;
+  `messages → providerMessages`, `systemPrompt → frozenSystemPrompt`,
+  `lastTurnEndSeq → lastSeenEventSeq`.
 - Process model: ONE long-lived agent process per coworker; `AgentServerState`
-  (`server.ts:113`, type `server-types.ts:124`) holds `activeSession`, `activeTurn`,
-  `toolExecutorCache: Map<string, Promise<...>>` (the cache pattern to mirror), across
-  turns + session switches.
+  (`server.ts:113`, type `server-types.ts:124`) holds `activeSession`,
+  `activeTurn`, `toolExecutorCache: Map<string, Promise<...>>` (the cache
+  pattern to mirror), across turns + session switches.
 - The reducer: `foldEvent(state, event)` / `foldEvents(events)` /
-  `initialFoldState()` (`message-building/fold-event.ts`) — `FoldState = { messages,
-  batch }`. `buildProviderMessagesFromParsedEvents` (`message-builder.ts`) folds parsed
-  events through it PLUS the rebuild-only concerns (system-prompt extraction, the
-  `context_compacted` reset to `preserved[]` + `dropOrphanedToolBlocks`, the
-  `context_injected` text-merge via `appendOrMergeUser`, empty-prompt drop). **The
-  incremental path must apply those same rebuild-only concerns** — so it is cleanest to
-  fold via a function that mirrors `buildProviderMessagesFromParsedEvents`'s per-event
-  handling, not raw `foldEvent` alone.
-- `.seq` tip: `readHead(sessionDir): number | undefined` (`seq-head.ts:27`) = the
-  next-free seq (advanced under the flock on every append). O(1) `readFileSync`. The
-  latest written seq is `readHead() - 1`.
-- Tail read by seq: `readDurableEvents(sessionDir, { afterEventSeq, ... })` exists, but it
-  full-scans; the inject tailer (`storage/inject-tailer.ts`, Step 3.2) already does a
-  byte-offset tail read — reuse its `readNewCompleteLines` primitive or
-  `readParsedSessionEvents` filtered by seq. For correctness-first simplicity, the
-  incremental fold MAY read events with `eventSeq >= cachedHead` via a parsed read filtered
-  by seq; optimize to a byte-offset tail later if needed.
-- `ParsedSessionEvent = { eventSeq, type, data }` (`message-building/parsed-events.ts`).
+  `initialFoldState()` (`message-building/fold-event.ts`) —
+  `FoldState = { messages, batch }`. `buildProviderMessagesFromParsedEvents`
+  (`message-builder.ts`) folds parsed events through it PLUS the rebuild-only
+  concerns (system-prompt extraction, the `context_compacted` reset to
+  `preserved[]` + `dropOrphanedToolBlocks`, the `context_injected` text-merge
+  via `appendOrMergeUser`, empty-prompt drop). **The incremental path must apply
+  those same rebuild-only concerns** — so it is cleanest to fold via a function
+  that mirrors `buildProviderMessagesFromParsedEvents`'s per-event handling, not
+  raw `foldEvent` alone.
+- `.seq` tip: `readHead(sessionDir): number | undefined` (`seq-head.ts:27`) =
+  the next-free seq (advanced under the flock on every append). O(1)
+  `readFileSync`. The latest written seq is `readHead() - 1`.
+- Tail read by seq: `readDurableEvents(sessionDir, { afterEventSeq, ... })`
+  exists, but it full-scans; the inject tailer (`storage/inject-tailer.ts`, Step
+  3.2) already does a byte-offset tail read — reuse its `readNewCompleteLines`
+  primitive or `readParsedSessionEvents` filtered by seq. For correctness-first
+  simplicity, the incremental fold MAY read events with `eventSeq >= cachedHead`
+  via a parsed read filtered by seq; optimize to a byte-offset tail later if
+  needed.
+- `ParsedSessionEvent = { eventSeq, type, data }`
+  (`message-building/parsed-events.ts`).
 
 **Test command:** `cd packages/agent && npx vitest run <path>`.
 
@@ -68,21 +76,25 @@ contained.
 ## File Structure
 
 **Create:**
-- `packages/agent/src/message-building/incremental-projection.ts` — the cached projection
-  type + `foldTailIntoProjection` (apply the rebuild-only-aware per-event handling for a
-  tail of events to a cached state) + `projectTurnEntry(sessionDir, cwd, cache)` (the
-  cache-aware turn-entry entry point: tip-check → incremental fold or full rebuild).
+
+- `packages/agent/src/message-building/incremental-projection.ts` — the cached
+  projection type + `foldTailIntoProjection` (apply the rebuild-only-aware
+  per-event handling for a tail of events to a cached state) +
+  `projectTurnEntry(sessionDir, cwd, cache)` (the cache-aware turn-entry entry
+  point: tip-check → incremental fold or full rebuild).
 - `packages/agent/src/message-building/__tests__/incremental-projection.test.ts`
 
 **Modify:**
-- `packages/agent/src/server-types.ts` + `server.ts` — add `projectionCache:
-  Map<string, CachedProjection>` to `AgentServerState` + `createAgentServerState`.
+
+- `packages/agent/src/server-types.ts` + `server.ts` — add
+  `projectionCache: Map<string, CachedProjection>` to `AgentServerState` +
+  `createAgentServerState`.
 - `packages/agent/src/core/conversation/runner.ts` — turn entry calls
   `projectTurnEntry(...)` with the process projection cache instead of
   `loadTurnEntryProjection` directly (cold path still uses it).
 - The runner must have access to the cache — confirm how the runner reaches
-  `AgentServerState` (it is constructed with deps; thread the cache in as a dep, or pass a
-  `getProjectionCache()` accessor).
+  `AgentServerState` (it is constructed with deps; thread the cache in as a dep,
+  or pass a `getProjectionCache()` accessor).
 
 ---
 
@@ -90,16 +102,20 @@ contained.
 
 **Files:** `incremental-projection.ts`, test
 
-- [ ] **Step 1: The differential test FIRST (incremental == full rebuild).** This is the
-  correctness gate. For a corpus of event sequences (plain, tool, parallel-tool, thinking,
-  context_injected merge, a compaction era, post-compaction tail), assert that folding the
-  events in TWO halves incrementally equals folding them all at once via the full builder:
+- [ ] **Step 1: The differential test FIRST (incremental == full rebuild).**
+      This is the correctness gate. For a corpus of event sequences (plain,
+      tool, parallel-tool, thinking, context_injected merge, a compaction era,
+      post-compaction tail), assert that folding the events in TWO halves
+      incrementally equals folding them all at once via the full builder:
 
 ```ts
 import { describe, it, expect } from 'vitest';
 import { readParsedSessionEvents } from '@lace/agent/message-building/parsed-events';
 import { buildProviderMessagesFromParsedEvents } from '@lace/agent/message-building/message-builder';
-import { initialCachedProjection, foldTailIntoProjection } from '@lace/agent/message-building/incremental-projection';
+import {
+  initialCachedProjection,
+  foldTailIntoProjection,
+} from '@lace/agent/message-building/incremental-projection';
 
 function fullVsIncremental(events) {
   const full = buildProviderMessagesFromParsedEvents(events);
@@ -108,8 +124,17 @@ function fullVsIncremental(events) {
     let proj = initialCachedProjection();
     proj = foldTailIntoProjection(proj, events.slice(0, k));
     proj = foldTailIntoProjection(proj, events.slice(k));
-    expect(JSON.stringify({ messages: proj.messages, systemPrompt: proj.systemPrompt }))
-      .toBe(JSON.stringify({ messages: full.messages, systemPrompt: full.systemPrompt }));
+    expect(
+      JSON.stringify({
+        messages: proj.messages,
+        systemPrompt: proj.systemPrompt,
+      })
+    ).toBe(
+      JSON.stringify({
+        messages: full.messages,
+        systemPrompt: full.systemPrompt,
+      })
+    );
   }
 }
 
@@ -118,32 +143,35 @@ it('incremental fold (any split) equals full rebuild — across the corpus', () 
 });
 ```
 
-> Build `CORPUS` as arrays of `ParsedSessionEvent` covering: prompt/message/tool_use,
-> a parallel-tool turn, a thinking turn, a `system_prompt_set` then a later one
-> (last-wins), a `context_injected` (merge), and a `context_compacted` with `preserved`
-> followed by tail events. The split-at-every-K is what proves order-independence of the
-> incremental boundary. This is the same property Step 1's fuzz proved for `foldEvent`;
-> here it must hold for the FULL rebuild semantics (incl. system-prompt + compaction +
-> inject-merge), so `foldTailIntoProjection` must mirror
+> Build `CORPUS` as arrays of `ParsedSessionEvent` covering:
+> prompt/message/tool_use, a parallel-tool turn, a thinking turn, a
+> `system_prompt_set` then a later one (last-wins), a `context_injected`
+> (merge), and a `context_compacted` with `preserved` followed by tail events.
+> The split-at-every-K is what proves order-independence of the incremental
+> boundary. This is the same property Step 1's fuzz proved for `foldEvent`; here
+> it must hold for the FULL rebuild semantics (incl. system-prompt +
+> compaction + inject-merge), so `foldTailIntoProjection` must mirror
 > `buildProviderMessagesFromParsedEvents` exactly.
 
 - [ ] **Step 2: RED.**
 
-- [ ] **Step 3: Implement.** `CachedProjection = { foldState: FoldState; systemPrompt:
-  string; systemPromptCount: number; filesRead: Set<string>; lastTurnEndSeq: number |
-  null; headSeq: number }`. `foldTailIntoProjection(proj, events)` walks `events` applying
-  EXACTLY the per-event handling of `buildProviderMessagesFromParsedEvents` (system-prompt
-  last-wins + count-reset on compaction; `context_compacted` resets the foldState to
-  `preserved[]` + `dropOrphanedToolBlocks`; `context_injected` text-merge;
-  `prompt`/`message`/`tool_use` via `foldEvent`; track `filesRead` and `lastTurnEndSeq`),
-  advancing `headSeq` to the max seq seen. **Refactor `buildProviderMessagesFromParsed
-  Events` to share this per-event handler** (DRY — one place handles an event, used by both
-  the full builder and the incremental fold) so they cannot diverge. Expose `messages`/
-  `systemPrompt` getters on `CachedProjection`.
+- [ ] **Step 3: Implement.**
+      `CachedProjection = { foldState: FoldState; systemPrompt: string; systemPromptCount: number; filesRead: Set<string>; lastTurnEndSeq: number | null; headSeq: number }`.
+      `foldTailIntoProjection(proj, events)` walks `events` applying EXACTLY the
+      per-event handling of `buildProviderMessagesFromParsedEvents`
+      (system-prompt last-wins + count-reset on compaction; `context_compacted`
+      resets the foldState to `preserved[]` + `dropOrphanedToolBlocks`;
+      `context_injected` text-merge; `prompt`/`message`/`tool_use` via
+      `foldEvent`; track `filesRead` and `lastTurnEndSeq`), advancing `headSeq`
+      to the max seq seen. **Refactor `buildProviderMessagesFromParsed Events`
+      to share this per-event handler** (DRY — one place handles an event, used
+      by both the full builder and the incremental fold) so they cannot diverge.
+      Expose `messages`/ `systemPrompt` getters on `CachedProjection`.
 
-> The DRY refactor is the safety mechanism: if the full builder and the incremental fold
-> share the exact same per-event function, incremental==full holds by construction. Do
-> this refactor; do not maintain two parallel event-handling switch statements.
+> The DRY refactor is the safety mechanism: if the full builder and the
+> incremental fold share the exact same per-event function, incremental==full
+> holds by construction. Do this refactor; do not maintain two parallel
+> event-handling switch statements.
 
 - [ ] **Step 4: GREEN. Commit.**
 
@@ -158,10 +186,11 @@ git commit -m "feat(session-state): foldTailIntoProjection — incremental proje
 
 **Files:** `incremental-projection.ts`, test
 
-- [ ] **Step 1: Failing test** — first call builds (full); a second call after appending
-  tail events folds incrementally (asserts equality with a fresh full rebuild AND that the
-  full parse was NOT re-run — spy on `readParsedSessionEvents`); a cross-process inject
-  appended between calls is picked up; `headSeq` advances:
+- [ ] **Step 1: Failing test** — first call builds (full); a second call after
+      appending tail events folds incrementally (asserts equality with a fresh
+      full rebuild AND that the full parse was NOT re-run — spy on
+      `readParsedSessionEvents`); a cross-process inject appended between calls
+      is picked up; `headSeq` advances:
 
 ```ts
 it('reuses + tail-folds across calls; matches full rebuild; cold-builds once', () => {
@@ -182,27 +211,31 @@ it('reuses + tail-folds across calls; matches full rebuild; cold-builds once', (
 - [ ] **Step 2: RED.**
 
 - [ ] **Step 3: Implement `projectTurnEntry(sessionDir, cwd, cache)`:**
-  - `tip = readHead(sessionDir)`. (If undefined — no `.seq` yet — fall back to full build.)
+  - `tip = readHead(sessionDir)`. (If undefined — no `.seq` yet — fall back to
+    full build.)
   - `cached = cache.get(sessionId)`.
-  - If `cached` and `cached.headSeq <= tip`: tail-read events with `eventSeq >=
-    cached.headSeq` (a seq-filtered parsed read; reuse `readParsedSessionEvents` filtered,
-    OR the byte-offset tailer for O(tail) — pick the simplest correct first, optimize
-    later), `foldTailIntoProjection(cached, tailEvents)`, store, and return
+  - If `cached` and `cached.headSeq <= tip`: tail-read events with
+    `eventSeq >= cached.headSeq` (a seq-filtered parsed read; reuse
+    `readParsedSessionEvents` filtered, OR the byte-offset tailer for O(tail) —
+    pick the simplest correct first, optimize later),
+    `foldTailIntoProjection(cached, tailEvents)`, store, and return
     `{ messages, systemPrompt, filesRead, lastTurnEndSeq }`.
-  - Else (cold / no cache / tip moved backward somehow): full `loadTurnEntryProjection`,
-    seed a `CachedProjection` from it (build the FoldState from the full parse), store,
-    return.
-  - **Invalidate on session switch:** the cache is keyed by sessionId, so a different
-    active session simply uses a different entry — no explicit clear needed; confirm a
-    `session/fork` or `session/load` that changes the on-disk log under the same sessionId
-    can't serve a stale cache (the tip-check + seq-filtered tail-read handles appends; a
-    full REPLACEMENT of the log — fork copies into a NEW sessionId, so not an issue).
+  - Else (cold / no cache / tip moved backward somehow): full
+    `loadTurnEntryProjection`, seed a `CachedProjection` from it (build the
+    FoldState from the full parse), store, return.
+  - **Invalidate on session switch:** the cache is keyed by sessionId, so a
+    different active session simply uses a different entry — no explicit clear
+    needed; confirm a `session/fork` or `session/load` that changes the on-disk
+    log under the same sessionId can't serve a stale cache (the tip-check +
+    seq-filtered tail-read handles appends; a full REPLACEMENT of the log — fork
+    copies into a NEW sessionId, so not an issue).
 
-> CRITICAL correctness note: if the tail-read uses `eventSeq >= cached.headSeq` and
-> `cached.headSeq` is the next-free seq cached last turn, then events with seq ==
-> cached.headSeq onward are the new ones; do not double-apply an event already folded.
-> Define headSeq precisely as "next seq to fold" and tail-read `> lastFoldedSeq`. Add a
-> test that re-calling with NO new events is a no-op (folds nothing, returns the same).
+> CRITICAL correctness note: if the tail-read uses `eventSeq >= cached.headSeq`
+> and `cached.headSeq` is the next-free seq cached last turn, then events with
+> seq == cached.headSeq onward are the new ones; do not double-apply an event
+> already folded. Define headSeq precisely as "next seq to fold" and tail-read
+> `> lastFoldedSeq`. Add a test that re-calling with NO new events is a no-op
+> (folds nothing, returns the same).
 
 - [ ] **Step 4: GREEN. Commit.**
 
@@ -217,38 +250,45 @@ git commit -m "feat(session-state): projectTurnEntry — O(tail) cache-aware tur
 
 **Files:** `server-types.ts`, `server.ts`, `runner.ts`, test
 
-- [ ] **Step 1: Add the cache.** `projectionCache: Map<string, CachedProjection>` in
-  `AgentServerState` (server-types.ts) + `createAgentServerState` (server.ts). Thread it to
-  the runner (the runner already receives deps; add the cache or a getter).
+- [ ] **Step 1: Add the cache.**
+      `projectionCache: Map<string, CachedProjection>` in `AgentServerState`
+      (server-types.ts) + `createAgentServerState` (server.ts). Thread it to the
+      runner (the runner already receives deps; add the cache or a getter).
 
-- [ ] **Step 2: Runner turn entry** calls `projectTurnEntry(sessionDir, cwd,
-  projectionCache)` instead of `loadTurnEntryProjection`. Preserve every downstream
-  variable (`providerMessages`, `frozenSystemPrompt`, `filesRead`, `lastSeenEventSeq`) +
-  the `if (!frozenSystemPrompt) throw` guard.
+- [ ] **Step 2: Runner turn entry** calls
+      `projectTurnEntry(sessionDir, cwd, projectionCache)` instead of
+      `loadTurnEntryProjection`. Preserve every downstream variable
+      (`providerMessages`, `frozenSystemPrompt`, `filesRead`,
+      `lastSeenEventSeq`) + the `if (!frozenSystemPrompt) throw` guard.
 
-- [ ] **Step 3: Divergence canary (prod safety).** Add a sampled check (e.g. 1-in-N turns
-  or behind a `LACE_PROJECTION_CANARY` env): after `projectTurnEntry`, also run the full
-  `loadTurnEntryProjection` and compare `JSON.stringify(messages)`; on mismatch,
-  `logger.error('projection divergence', {...})` AND drop the cache entry (force a rebuild
-  next turn). This catches a cache bug a fixture can't. It is O(events) so it must be
-  SAMPLED, never every turn.
+- [ ] **Step 3: Divergence canary (prod safety).** Add a sampled check (e.g.
+      1-in-N turns or behind a `LACE_PROJECTION_CANARY` env): after
+      `projectTurnEntry`, also run the full `loadTurnEntryProjection` and
+      compare `JSON.stringify(messages)`; on mismatch,
+      `logger.error('projection divergence', {...})` AND drop the cache entry
+      (force a rebuild next turn). This catches a cache bug a fixture can't. It
+      is O(events) so it must be SAMPLED, never every turn.
 
-> The canary is the production net for the one thing tests can't fully cover (a real
-> session's state). Default the sample rate low (or env-gated, default off) but make it
-> trivial to turn on for the Ada validation pass.
+> The canary is the production net for the one thing tests can't fully cover (a
+> real session's state). Default the sample rate low (or env-gated, default off)
+> but make it trivial to turn on for the Ada validation pass.
 
-- [ ] **Step 4: Verify — the byte gates are untouched + the runner suite green.**
+- [ ] **Step 4: Verify — the byte gates are untouched + the runner suite
+      green.**
 
-Run: `cd packages/agent && npx vitest run src/message-building src/core/conversation src/providers/__tests__/golden && npm run typecheck && npm run lint` (repo root for the latter two)
-Expected: PASS; goldens + sent-vs-rebuilt unchanged (the projection feeds the same converters; the messages are identical to the full rebuild by Task 1's equivalence).
+Run:
+`cd packages/agent && npx vitest run src/message-building src/core/conversation src/providers/__tests__/golden && npm run typecheck && npm run lint`
+(repo root for the latter two) Expected: PASS; goldens + sent-vs-rebuilt
+unchanged (the projection feeds the same converters; the messages are identical
+to the full rebuild by Task 1's equivalence).
 
 - [ ] **Step 5: Commit + evergreen doc.**
 
-Add to `docs/architecture/` (present-tense, no refs): turn entry holds the conversation
-projection in memory keyed by session; each turn folds only the events appended since the
-cached `.seq` head (O(tail)); a cold start or a sampled divergence canary falls back to a
-full rebuild; the projection is the persisted prefix only (the runner's per-turn live tail
-stays out of it).
+Add to `docs/architecture/` (present-tense, no refs): turn entry holds the
+conversation projection in memory keyed by session; each turn folds only the
+events appended since the cached `.seq` head (O(tail)); a cold start or a
+sampled divergence canary falls back to a full rebuild; the projection is the
+persisted prefix only (the runner's per-turn live tail stays out of it).
 
 ```bash
 git add packages/agent/src/server-types.ts packages/agent/src/server.ts packages/agent/src/core/conversation/runner.ts docs/architecture/session-state-projection.md
@@ -259,17 +299,21 @@ git commit -m "feat(session-state): in-memory projection cache + divergence cana
 
 ## Self-review notes (for the executor)
 
-- **Correctness gate = incremental==full** (Task 1), achieved by the DRY refactor (one
-  shared per-event handler used by both the full builder and the incremental fold). If you
-  find yourself writing a second event-handling switch, STOP and share the first.
-- **The cached projection is the PERSISTED PREFIX ONLY.** The runner's non-persisted
-  live-tail mutations (loop reminders, tool_result construction, tool-choice retries) are
-  NOT cached — they live only in the per-turn `providerMessages`, exactly as today.
-- **The `.seq` tip is the coherence point** — tail-read from `lastFoldedSeq`; both
-  own-process and cross-process appends advance `.seq`, so the tail-read sees them.
-- **No wire-byte change.** The Step-0 golden + sent-vs-rebuilt gates must stay green with
-  zero golden changes.
-- **Out of scope:** durable projection snapshots (cold-start speedup) and Step 5 (deleting
-  the old full-scan path — that comes after this is validated).
-- **Deploy behind the canary** (env-gated, on for the Ada validation pass) — do not trust
-  the cache on a live coworker until the canary has run clean for a while.
+- **Correctness gate = incremental==full** (Task 1), achieved by the DRY
+  refactor (one shared per-event handler used by both the full builder and the
+  incremental fold). If you find yourself writing a second event-handling
+  switch, STOP and share the first.
+- **The cached projection is the PERSISTED PREFIX ONLY.** The runner's
+  non-persisted live-tail mutations (loop reminders, tool_result construction,
+  tool-choice retries) are NOT cached — they live only in the per-turn
+  `providerMessages`, exactly as today.
+- **The `.seq` tip is the coherence point** — tail-read from `lastFoldedSeq`;
+  both own-process and cross-process appends advance `.seq`, so the tail-read
+  sees them.
+- **No wire-byte change.** The Step-0 golden + sent-vs-rebuilt gates must stay
+  green with zero golden changes.
+- **Out of scope:** durable projection snapshots (cold-start speedup) and Step 5
+  (deleting the old full-scan path — that comes after this is validated).
+- **Deploy behind the canary** (env-gated, on for the Ada validation pass) — do
+  not trust the cache on a live coworker until the canary has run clean for a
+  while.

--- a/docs/superpowers/specs/2026-05-24-track-based-compaction-design.md
+++ b/docs/superpowers/specs/2026-05-24-track-based-compaction-design.md
@@ -4,14 +4,15 @@ Date: 2026-05-24 Author: Jesse + Bot Supersedes:
 `2026-05-25-typed-capsule-compaction-strategy-design.md` (v1–v6, paused after 6
 non-converging rev rounds — see `project_compaction_design_in_hell.md` memory).
 
-> **Status (2026-06-03): shipped, then partially superseded by *pluggable
-> compaction*** (`2026-06-03-pluggable-compaction-design.md`). The track-demux +
+> **Status (2026-06-03): shipped, then partially superseded by _pluggable
+> compaction_** (`2026-06-03-pluggable-compaction-design.md`). The track-demux +
 > tail-preserve skeleton became the kernel default and the exported
 > `@lace/agent/compaction/toolkit`. The **Slack-specific** salience/rendering
 > described below was **de-leaked out of the lace kernel** into the sen-core
-> `sen-multiconv` plugin — the lace kernel default is now domain-neutral (no Slack
-> references). Read this for the track/demux rationale; read Spec A for the current
-> seam, breakpoints, `compact_session`, and the one-shot `query` primitive.
+> `sen-multiconv` plugin — the lace kernel default is now domain-neutral (no
+> Slack references). Read this for the track/demux rationale; read Spec A for
+> the current seam, breakpoints, `compact_session`, and the one-shot `query`
+> primitive.
 
 ## Why
 

--- a/docs/superpowers/specs/2026-06-04-file-based-personas-and-exec-tools-design.md
+++ b/docs/superpowers/specs/2026-06-04-file-based-personas-and-exec-tools-design.md
@@ -9,12 +9,12 @@ embedder override, one combined spec._
 Wire one-shot-exec **tools and skills** into lace so an embedder, a plugin, or a
 persona can actually contribute them — and, as the enabler, make **all personas
 file-based** (`.md` files in directories) so per-persona resources follow one
-uniform directory convention: `<persona>/tools/` and `<persona>/skills/`. Plugins
-can also ship global tools and global skills.
+uniform directory convention: `<persona>/tools/` and `<persona>/skills/`.
+Plugins can also ship global tools and global skills.
 
-Tools and skills are handled symmetrically. Skills already *are* `SKILL.md`
+Tools and skills are handled symmetrically. Skills already _are_ `SKILL.md`
 directories loaded by `SkillRegistry`, so they need no shape change — only new
-*sources* (plugin-contributed and per-persona).
+_sources_ (plugin-contributed and per-persona).
 
 ## Motivation
 
@@ -27,7 +27,7 @@ directories loaded by `SkillRegistry`, so they need no shape change — only new
   in-memory variant has no disk anchor for adjacent per-persona resources.
 - **Desired model (Jesse):** tools and skills come from the same sources — a
   global **core** dir, **plugin-global** dirs, and **per-persona** dirs — with
-  plugin personas being *only* `.md`-file style; a persona dir carries
+  plugin personas being _only_ `.md`-file style; a persona dir carries
   `<persona>/tools/` and `<persona>/skills/`.
 
 ## Naming model (`:`-namespaced, Claude-style)
@@ -44,8 +44,8 @@ The keystone decision that makes file-based personas/skills work cleanly:
 - **On disk, entries are flat** within each source's dir:
   `<dir>/personas/<entry>.md`, `<dir>/skills/<entry>/SKILL.md`, and exec-tool
   binaries declare a flat descriptor `name`. The kernel derives the namespace
-  from *which source* the dir/binary came from and joins with `:` — authors don't
-  hand-write the namespace into file names. The prefix is the plugin's
+  from _which source_ the dir/binary came from and joins with `:` — authors
+  don't hand-write the namespace into file names. The prefix is the plugin's
   `meta.namespace`; the dup→fatal registry **owner** stays `meta.name` (they may
   differ — `createPluginApi` closes over `meta`, so both are available at the
   `addDir`/`registerExecDir` seam).
@@ -55,50 +55,54 @@ The keystone decision that makes file-based personas/skills work cleanly:
 
 > **Decided (Jesse):** this **replaces** the existing `/`-namespacing for
 > plugin-contributed **tools** too (`reference/greet` → `reference:greet`) for
-> consistency with personas/skills ("like Claude"). It touches the merged example
-> plugins, their tests, and the dup→fatal docs. Per-persona exec tools keep their
-> **bare** descriptor name (so `tools/bash` can override the global `bash` for
-> that persona — see Part 3).
+> consistency with personas/skills ("like Claude"). It touches the merged
+> example plugins, their tests, and the dup→fatal docs. Per-persona exec tools
+> keep their **bare** descriptor name (so `tools/bash` can override the global
+> `bash` for that persona — see Part 3).
 
 ## Design of record (decisions)
 
-1. **`:`-namespacing**, namespace = contributing source, flat disk entries (above).
-2. **Discovery becomes synchronous** (`discoverExecToolsSync`, `spawnSync` probe)
-   so it can run inside a plugin's synchronous `register(api)`. Invocation stays
-   async.
+1. **`:`-namespacing**, namespace = contributing source, flat disk entries
+   (above).
+2. **Discovery becomes synchronous** (`discoverExecToolsSync`, `spawnSync`
+   probe) so it can run inside a plugin's synchronous `register(api)`.
+   Invocation stays async.
 3. **Personas become uniformly file-based.** Remove `registries.personas`,
    `api.personas.register`, the `PersonaDef` export, and the in-memory
    `PluginSource`. A plugin contributes a persona **directory** via
    `api.personas.addDir(dir)` (namespace = the plugin).
 4. **Per-persona resources** via the `<persona>/tools/` + `<persona>/skills/`
    convention, injected only when that persona is active.
-5. **Two-tier tools:** global (core + plugin-global) → `registries.tools` at boot;
-   per-persona → injected into the session executor when active.
+5. **Two-tier tools:** global (core + plugin-global) → `registries.tools` at
+   boot; per-persona → injected into the session executor when active.
 6. **Persona overrides global** for tools — but **never reserved built-ins**
    (`LACE_BUILTIN_TOOL_NAMES` ∪ `PER_SESSION_BUILTIN_NAMES` are refused on the
    per-persona path; override applies only to plugin/core exec-tool globals).
 7. **Skills mirror tools**, gathered into `skillDirs` and fed to the per-session
-   `SkillRegistry`. Plugin + per-persona skills **always layer** over an embedder
-   `state.skillDirs` override (the override replaces only the workDir tier).
-8. **One combined spec** (Jesse) — Part 0 ships with the exec/skill machinery, not
-   separately.
+   `SkillRegistry`. Plugin + per-persona skills **always layer** over an
+   embedder `state.skillDirs` override (the override replaces only the workDir
+   tier).
+8. **One combined spec** (Jesse) — Part 0 ships with the exec/skill machinery,
+   not separately.
 9. **No backward compatibility** (pre-prod, we own the box; no compat shims).
 
 ## Out of scope (deferred)
 
 - **MCP D2** (passing `ToolContext`/persona to MCP tools) — separate cycle.
 - **Capability-manifest enforcement** — spec #6 (credentials).
-- **A.1 providers / A.2 context-providers** registries — not merged, not touched.
+- **A.1 providers / A.2 context-providers** registries — not merged, not
+  touched.
 
 ## Standalone / Bun reality (applies throughout)
 
-`resolveResourcePath` only maps `data`/`agent-personas`/`templates` and **throws**
-for unknown names; and embedded files (`Bun.embeddedFiles`) are virtual — they
-**cannot be `spawnSync`'d** and have no real dir to scan. Therefore: **core
-exec/skill dirs and bundled per-persona `tools/`/`skills/` are filesystem/dev-only.**
-Every discovery entry point **no-ops with a warning** when its resolved path is
-absent or not a real FS path. Plugin dirs and *user* persona dirs are real disk
-paths and work in production; they are the load-bearing sources.
+`resolveResourcePath` only maps `data`/`agent-personas`/`templates` and
+**throws** for unknown names; and embedded files (`Bun.embeddedFiles`) are
+virtual — they **cannot be `spawnSync`'d** and have no real dir to scan.
+Therefore: **core exec/skill dirs and bundled per-persona `tools/`/`skills/` are
+filesystem/dev-only.** Every discovery entry point **no-ops with a warning**
+when its resolved path is absent or not a real FS path. Plugin dirs and _user_
+persona dirs are real disk paths and work in production; they are the
+load-bearing sources.
 
 ---
 
@@ -112,90 +116,93 @@ plugin-persona path.
 - **Plugin API.** Replace the `personas` registrar with
   `api.personas.addDir(absDir)`. A plugin ships a directory of flat `<entry>.md`
   files (each with optional `<entry>/tools/` and `<entry>/skills/` subdirs); the
-  plugin's `meta.namespace` namespaces them (`<ns>:<entry>`). Dirs accumulate in a
-  module-level list during `loadPlugins` at boot.
-- **Registry surface.** Remove `registries.personas` (`Registry<PersonaDef>`), the
-  `PersonaDef` type export, and the `personas` entries in `PluginRegistries` /
-  `PluginApi` / `makeRegistries` / `resetRegistriesForTest`. (Tools/compaction/
-  runtimes registries remain.)
+  plugin's `meta.namespace` namespaces them (`<ns>:<entry>`). Dirs accumulate in
+  a module-level list during `loadPlugins` at boot.
+- **Registry surface.** Remove `registries.personas` (`Registry<PersonaDef>`),
+  the `PersonaDef` type export, and the `personas` entries in `PluginRegistries`
+  / `PluginApi` / `makeRegistries` / `resetRegistriesForTest`.
+  (Tools/compaction/ runtimes registries remain.)
 - **PersonaRegistry.** Replace `UserDiskSource`/`PluginSource`/`BundledSource`
-  with file-backed dir sources: a shared `FileDirSource` for user dirs and plugin
-  dirs (differing only in `isUserDefined`, namespace, and caching), plus the
-  bundled source. **Remove the in-memory `PluginSource`** (nothing is in-memory
-  anymore). Rendering must be **source-scoped**, which **requires a
+  with file-backed dir sources: a shared `FileDirSource` for user dirs and
+  plugin dirs (differing only in `isUserDefined`, namespace, and caching), plus
+  the bundled source. **Remove the in-memory `PluginSource`** (nothing is
+  in-memory anymore). Rendering must be **source-scoped**, which **requires a
   `TemplateEngine` change** — not just rooting an engine at a dir. Today the
-  `Bun.embeddedFiles` lookup is *unconditional* and ignores `templateDirs`
+  `Bun.embeddedFiles` lookup is _unconditional_ and ignores `templateDirs`
   (checked before the FS dirs in **both** `loadTemplate` and `processIncludes`,
-  `template-engine.ts`), so neither "engine rooted at the source dir" nor
-  "read the body by absolute path" escapes it: a user/plugin persona — or its
+  `template-engine.ts`), so neither "engine rooted at the source dir" nor "read
+  the body by absolute path" escapes it: a user/plugin persona — or its
   `@sections/…` include — that shares a flat name with a bundled one still
-  resolves to the embedded **bundled** file. **Make the embedded lookup opt-in per
-  engine**: only the *bundled* source uses embedded-first; user/plugin sources
-  resolve `<entry>.md` and its includes against **their own FS dir**. (This also
-  fixes a **pre-existing** standalone bug: today a user persona overriding a
-  bundled name silently renders the bundled body/sections.) Do not route all
-  personas through one shared `engine.render('<entry>.md')`: the `:` key
-  disambiguates the *registry*, but the flat filename does not. (Revises v1's
-  "collapse to one render path": one uniform *mechanism* is fine, but it must be
-  source-scoped with the engine change; the body render survives, only the
-  in-memory `PluginSource` is deleted.)
-  Search/precedence order: **user dirs → plugin dirs → bundled** (unchanged). Each
-  source tracks `name → diskPath` so per-persona resource dirs are derivable
-  (`personaToolsDir(name)` / `personaSkillsDir(name)` return `null` for any source
-  without a real FS dir, e.g. embedded bundled).
-- **Precedence** is enforced by `PersonaRegistry` resolution order
-  (user → plugin → bundled) picking the winning source; rendering is then
-  source-scoped (above), so precedence does **not** depend on `TemplateEngine`
-  first-match-wins. Plugin personas' includes resolve via the source-scoped engine
-  rooted at the plugin dir — not by concatenating all plugin dirs into one global
-  template path.
+  resolves to the embedded **bundled** file. **Make the embedded lookup opt-in
+  per engine**: only the _bundled_ source uses embedded-first; user/plugin
+  sources resolve `<entry>.md` and its includes against **their own FS dir**.
+  (This also fixes a **pre-existing** standalone bug: today a user persona
+  overriding a bundled name silently renders the bundled body/sections.) Do not
+  route all personas through one shared `engine.render('<entry>.md')`: the `:`
+  key disambiguates the _registry_, but the flat filename does not. (Revises
+  v1's "collapse to one render path": one uniform _mechanism_ is fine, but it
+  must be source-scoped with the engine change; the body render survives, only
+  the in-memory `PluginSource` is deleted.) Search/precedence order: **user dirs
+  → plugin dirs → bundled** (unchanged). Each source tracks `name → diskPath` so
+  per-persona resource dirs are derivable (`personaToolsDir(name)` /
+  `personaSkillsDir(name)` return `null` for any source without a real FS dir,
+  e.g. embedded bundled).
+- **Precedence** is enforced by `PersonaRegistry` resolution order (user →
+  plugin → bundled) picking the winning source; rendering is then source-scoped
+  (above), so precedence does **not** depend on `TemplateEngine`
+  first-match-wins. Plugin personas' includes resolve via the source-scoped
+  engine rooted at the plugin dir — not by concatenating all plugin dirs into
+  one global template path.
 - **RPC surface is unaffected** — `ent/personas/list` →
   `PersonaRegistry.listAvailablePersonas()` → `PersonaInfo[]`, which Part 0
   preserves. **One visible behavior change:** `PersonaInfo.path` for plugin
-  personas changes from the synthetic `plugin:<name>` to a real disk path. Call it
-  out; confirm no consumer parses the old sentinel.
+  personas changes from the synthetic `plugin:<name>` to a real disk path. Call
+  it out; confirm no consumer parses the old sentinel.
 
 **Full consumer inventory to update (not just the two examples):**
 
-- Examples: `reference-plugin.ts`, `persona-plugin.ts`, `incident-responder-plugin.ts`
-  (ship `.md` dirs + `api.personas.addDir`; drop `PersonaDef` import).
-- Fixtures: `__fixtures__/{good-plugin,reach-plugin,dup-persona-plugin,loader-probe}.ts`
+- Examples: `reference-plugin.ts`, `persona-plugin.ts`,
+  `incident-responder-plugin.ts` (ship `.md` dirs + `api.personas.addDir`; drop
+  `PersonaDef` import).
+- Fixtures:
+  `__fixtures__/{good-plugin,reach-plugin,dup-persona-plugin,loader-probe}.ts`
   (use the dir mechanism / drop `registries.personas`).
 - Tests: `plugins/api.test.ts`, `plugins/loader.test.ts`,
   `config/__tests__/persona-registry-plugins.test.ts`, `prompt-manager.test.ts`,
   `config/__tests__/persona-rendering-characterization.test.ts`, and
-  **`whole-system.integration.test.ts`** — whose premise *inverts* (it asserts a
-  plugin persona resolves with `bundledPersonasPath:'/nonexistent',
-  userPersonasPaths:[]`; with no in-memory source it must point at a real fixture
-  persona dir).
+  **`whole-system.integration.test.ts`** — whose premise _inverts_ (it asserts a
+  plugin persona resolves with
+  `bundledPersonasPath:'/nonexistent', userPersonasPaths:[]`; with no in-memory
+  source it must point at a real fixture persona dir).
 
 ---
 
 ## Part 1 — Synchronous exec discovery
 
-Add `discoverExecToolsSync(dir): ExecToolAdapter[]` — a `spawnSync` sibling of the
-existing async `discoverExecTools`:
+Add `discoverExecToolsSync(dir): ExecToolAdapter[]` — a `spawnSync` sibling of
+the existing async `discoverExecTools`:
 
 - Runs `<bin> lace-tool-schema` via `spawnSync` (input `''`, `cwd: dir`, the
-  shared minimal env). **Factor `minimalEnv` out of `run-once.ts` and export it**
-  so both paths share one env policy.
+  shared minimal env). **Factor `minimalEnv` out of `run-once.ts` and export
+  it** so both paths share one env policy.
 - Lenient: skip non-executable / non-zero / invalid-descriptor binaries — warn,
   never throw.
-- **Aggregate budget:** `spawnSync` blocks the boot/register thread. Cap **total**
-  sync-probe wall time per dir (and/or binary count), not just per-binary 5s, so a
-  dir of hanging binaries can't stall boot for `N×5s` (the wall-time cap is
-  checked *between* binaries — `spawnSync` is fully blocking, so a single binary
-  can still burn its full per-binary timeout; a binary-count cap matters too).
-  Document the boot-blocking tradeoff.
+- **Aggregate budget:** `spawnSync` blocks the boot/register thread. Cap
+  **total** sync-probe wall time per dir (and/or binary count), not just
+  per-binary 5s, so a dir of hanging binaries can't stall boot for `N×5s` (the
+  wall-time cap is checked _between_ binaries — `spawnSync` is fully blocking,
+  so a single binary can still burn its full per-binary timeout; a binary-count
+  cap matters too). Document the boot-blocking tradeoff.
 - **Process-group caveat:** `spawnSync`'s `timeout`/`killSignal` only kills the
-  *direct* child, not the process group (unlike the async path's
-  `detached`+`process.kill(-pid)`). Acceptable for trusted one-shot schema probes;
-  state it explicitly — do not assume the async kill guarantee carries over.
+  _direct_ child, not the process group (unlike the async path's
+  `detached`+`process.kill(-pid)`). Acceptable for trusted one-shot schema
+  probes; state it explicitly — do not assume the async kill guarantee carries
+  over.
 
-Invocation (`executeValidated` → async `runExecToolProcess`) stays async. Replace
-the async `discoverExecTools` (no production callers) and migrate its two tests
-(`discover.test.ts`, `workspace-stats.e2e.test.ts`) to the sync API; keep the e2e
-as the canonical real-subprocess exemplar.
+Invocation (`executeValidated` → async `runExecToolProcess`) stays async.
+Replace the async `discoverExecTools` (no production callers) and migrate its
+two tests (`discover.test.ts`, `workspace-stats.e2e.test.ts`) to the sync API;
+keep the e2e as the canonical real-subprocess exemplar.
 
 ---
 
@@ -205,18 +212,18 @@ Global exec tools register into `registries.tools` at boot and are drawn into
 every session by the existing `registerAllAvailableTools`.
 
 - **Core.** An optional `agent-exec-tools/` dir, **filesystem-only** (see
-  Standalone note): `registerCoreExecTools()` no-ops with a warning when the path
-  is absent/embedded. When present, sync-discover and register each adapter under
-  a distinct owner **`'core-exec'`** (clearer dup→fatal diagnostics than
+  Standalone note): `registerCoreExecTools()` no-ops with a warning when the
+  path is absent/embedded. When present, sync-discover and register each adapter
+  under a distinct owner **`'core-exec'`** (clearer dup→fatal diagnostics than
   `'builtin'`). Idempotent via a registry sentinel (so it survives
   `resetRegistriesForTest` re-registration like `registerBuiltinTools`).
 - **Plugin-global.** `api.tools.registerExecDir(dir)` sync-discovers `dir` and
   registers each adapter under the plugin's owner, namespaced `<ns>:<entry>`.
-- **Name-seam.** `ExecToolAdapter` currently hard-sets `this.name =
-  descriptor.name` with no override (`exec-tool-adapter.ts`). Add a name-override
-  seam (ctor param, or rename in the discover/register step) to apply the `<ns>:`
-  prefix for global plugin tools — and to keep the **bare** descriptor name for
-  per-persona tools (Part 3, for override).
+- **Name-seam.** `ExecToolAdapter` currently hard-sets
+  `this.name = descriptor.name` with no override (`exec-tool-adapter.ts`). Add a
+  name-override seam (ctor param, or rename in the discover/register step) to
+  apply the `<ns>:` prefix for global plugin tools — and to keep the **bare**
+  descriptor name for per-persona tools (Part 3, for override).
 
 Boot order: `registerBuiltinTools` → `registerCoreExecTools` →
 `registerBuiltinCompaction` → `registerBuiltinRuntimes` → `loadPlugins` (plugins
@@ -230,8 +237,9 @@ Global name collisions follow the registry's **dup→fatal** rule.
 
 When a session's executor is built for active persona `P`:
 
-- Resolve `P`'s dir via `personaToolsDir(P)` (`<personaDiskDir>/<entry>/tools/`);
-  `null` → inject nothing. Sync-discover it.
+- Resolve `P`'s dir via `personaToolsDir(P)`
+  (`<personaDiskDir>/<entry>/tools/`); `null` → inject nothing. Sync-discover
+  it.
 - Inject each adapter into **that executor only** (not the global registry) via
   `registerTool` (a bare `Map.set` — last-write-wins, so override needs no new
   code), **after** the global draw and per-session built-ins.
@@ -240,47 +248,49 @@ When a session's executor is built for active persona `P`:
   per-persona tool may override a **plugin/core exec-tool** global of the same
   name, but never a platform built-in (`bash`, `delegate`, `use_skill`, …).
 
-Per-persona exec tools use their **bare** descriptor name (enabling the override).
-Cached per session (executors are session-keyed; persona is constant per session →
-no cross-persona leakage).
+Per-persona exec tools use their **bare** descriptor name (enabling the
+override). Cached per session (executors are session-keyed; persona is constant
+per session → no cross-persona leakage).
 
 ---
 
 ## Part 4 — Wiring the active persona into the executor build
 
 Per-persona tools must be injected **before** `createToolExecutorForMode`
-(`server.ts`) materializes its provider tool list (`getAllTools()`/`toolsForProvider`
-are computed *inside* it). So **widen that one function**: add an `activePersona`
-(or resolved `personaToolsDir`) param to `createToolExecutorForMode` +
-`CreateToolExecutorFn` (`server-types.ts`). **Do not** change the runner's separate
-`createToolExecutor` type (`core/conversation/types.ts` — 5-param, no `toolScope`);
-the runtime path injects via the cached wrapper in `prompt.ts`, which already
-closes over `state`.
+(`server.ts`) materializes its provider tool list
+(`getAllTools()`/`toolsForProvider` are computed _inside_ it). So **widen that
+one function**: add an `activePersona` (or resolved `personaToolsDir`) param to
+`createToolExecutorForMode` + `CreateToolExecutorFn` (`server-types.ts`). **Do
+not** change the runner's separate `createToolExecutor` type
+(`core/conversation/types.ts` — 5-param, no `toolScope`); the runtime path
+injects via the cached wrapper in `prompt.ts`, which already closes over
+`state`.
 
-**Source of truth is per-site** (a single global `meta.persona` rule is *wrong*
+**Source of truth is per-site** (a single global `meta.persona` rule is _wrong_
 for fork and `/clear`):
 
 - **`composeAndWriteSystemPromptSet`** (`session.ts`) already takes a `persona`
   param and has **three** callers — session/new (`session.ts` ~557), **fork**
-  (`session.ts` ~781, where `state.activeSession` is still the *pre-fork* session),
-  and **`/clear`** (`slash-commands.ts` ~229, where `state.activeSession` isn't
-  switched until *after* the build). **Thread that existing `persona` param into
-  the executor build; do NOT re-derive from `state.activeSession`** — deriving from
-  state injects the wrong persona's tools at fork and `/clear`.
+  (`session.ts` ~781, where `state.activeSession` is still the _pre-fork_
+  session), and **`/clear`** (`slash-commands.ts` ~229, where
+  `state.activeSession` isn't switched until _after_ the build). **Thread that
+  existing `persona` param into the executor build; do NOT re-derive from
+  `state.activeSession`** — deriving from state injects the wrong persona's
+  tools at fork and `/clear`.
 - **Active-session builds** — `tools.ts` (`ent/tools/list`) and
   `session-operations.ts` (**two** token-estimation builds): use
   `state.activeSession.meta.persona ?? 'lace'`.
-- **Runtime** — the `prompt.ts` cached wrapper: `state.activeSession.meta.persona
-  ?? 'lace'` from its closure.
+- **Runtime** — the `prompt.ts` cached wrapper:
+  `state.activeSession.meta.persona ?? 'lace'` from its closure.
 - **`initialize.ts`** — no active session → inject nothing.
 
 (`meta.persona` is `undefined` for default sessions; `?? 'lace'` matches the
 existing `config.personaName ?? 'lace'` convention.)
 
 **Advertise path must match runtime path** — every site injects, or the model is
-told about tools it can't call. The token-estimation builds pass no `skillRegistry`
-today; adding persona tools there is for count accuracy and must not change
-`use_skill` presence.
+told about tools it can't call. The token-estimation builds pass no
+`skillRegistry` today; adding persona tools there is for count accuracy and must
+not change `use_skill` presence.
 
 Sessions with no persona, or a persona with no `tools/` dir, inject nothing.
 
@@ -289,17 +299,17 @@ Sessions with no persona, or a persona with no `tools/` dir, inject nothing.
 ## Part 5 — Skills (symmetric to tools)
 
 Skills are `SKILL.md` directories loaded by `SkillRegistry({ skillDirs })`
-(first-wins dedup, skill-name must equal dir-name), already built **per-session**.
-There are **four** `skillDirs` producers (the spec previously missed the
-subagent one):
+(first-wins dedup, skill-name must equal dir-name), already built
+**per-session**. There are **four** `skillDirs` producers (the spec previously
+missed the subagent one):
 
 1. `rpc/handlers/session.ts` (system-prompt build)
 2. `rpc/handlers/prompt.ts` (runtime)
 3. `rpc/handlers/tools.ts` (`ent/tools/list` advertise)
 4. **`subagent-job.ts` (`getSubagentHostSkillDirs`)** — computes `skillDirs` and
    ships them to the child via `initialize`; the child stores them as its
-   `state.skillDirs`. This is the load-bearing path for per-persona skill reach in
-   **delegated** work.
+   `state.skillDirs`. This is the load-bearing path for per-persona skill reach
+   in **delegated** work.
 
 **New sources** (added to `skillDirs`, not a new shape):
 
@@ -309,11 +319,11 @@ subagent one):
 - **Per-persona:** the active persona's `<persona>/skills/` dir
   (`personaSkillsDir(P)`), for that session only.
 
-**Wiring — one shared resolver** `composeSkillDirs(state, activePersona)`, used at
-the **three session-side** producers (session/prompt/tools — on both the parent
-*and* each subagent process); the **subagent producer (#4) deliberately does
-not** call it (see below). Returns (first-wins precedence, **highest priority
-first**):
+**Wiring — one shared resolver** `composeSkillDirs(state, activePersona)`, used
+at the **three session-side** producers (session/prompt/tools — on both the
+parent _and_ each subagent process); the **subagent producer (#4) deliberately
+does not** call it (see below). Returns (first-wins precedence, **highest
+priority first**):
 
 ```
 [ <activePersona's skills dir>,        // per-persona wins (mirrors tools override)
@@ -325,28 +335,29 @@ first**):
 - **Always layer (decision):** plugin + per-persona + core skills are prepended
   regardless of whether the embedder supplied `state.skillDirs`. The embedder
   override still suppresses the **workDir+user discovery** tier
-  (`getSkillDirectories` returns both project- and user-level dirs, via the `??`)
-  but no longer suppresses plugin/persona/core skills.
-- **Ordering fix:** persona dir is **first** (highest priority under first-wins) —
-  the spec's earlier draft had it last, which inverted the intended
+  (`getSkillDirectories` returns both project- and user-level dirs, via the
+  `??`) but no longer suppresses plugin/persona/core skills.
+- **Ordering fix:** persona dir is **first** (highest priority under first-wins)
+  — the spec's earlier draft had it last, which inverted the intended
   persona-overrides-global guarantee.
 - **Subagent path (producer #4):** `getSubagentHostSkillDirs` keeps shipping the
-  **raw** `state.skillDirs ?? getSkillDirectories(workDir)` — do **not** wrap it in
-  `composeSkillDirs`. The child stores that as its own `state.skillDirs` and
-  re-composes (with *its* active persona + the plugin dirs it loads at boot).
-  Composing at the parent would double-compose and leak parent plugin dirs as the
-  child's embedder tier.
+  **raw** `state.skillDirs ?? getSkillDirectories(workDir)` — do **not** wrap it
+  in `composeSkillDirs`. The child stores that as its own `state.skillDirs` and
+  re-composes (with _its_ active persona + the plugin dirs it loads at boot).
+  Composing at the parent would double-compose and leak parent plugin dirs as
+  the child's embedder tier.
 
 **Cross-source skill collisions:** `SkillRegistry` is silent first-wins (debug
-log). The tools tier is loud (dup→fatal). For consistency, **add a `warn`** when a
-later dir's skill name shadows an earlier one across sources. (Within-namespace
-skills can't be `:`-namespaced because the dir name *is* the skill name; document
-that skill names are bare and cross-source shadowing is order-resolved.)
+log). The tools tier is loud (dup→fatal). For consistency, **add a `warn`** when
+a later dir's skill name shadows an earlier one across sources.
+(Within-namespace skills can't be `:`-namespaced because the dir name _is_ the
+skill name; document that skill names are bare and cross-source shadowing is
+order-resolved.)
 
 Consumers are unchanged: the per-session `SkillRegistry` still feeds `use_skill`
-and `SkillVariableProvider` (the prompt skill list). Note `SkillVariableProvider`
-re-scans on every prompt turn, now over more dirs — acceptable (`existsSync` +
-`readdirSync` per dir), but acknowledged.
+and `SkillVariableProvider` (the prompt skill list). Note
+`SkillVariableProvider` re-scans on every prompt turn, now over more dirs —
+acceptable (`existsSync` + `readdirSync` per dir), but acknowledged.
 
 ---
 
@@ -361,49 +372,53 @@ re-scans on every prompt turn, now over more dirs — acceptable (`existsSync` +
 
 ## Security
 
-Discovery executes binaries — fine under the trusted-code posture (core ships with
-lace; plugin dirs are trusted plugin code; bundled dirs are embedder-controlled).
-**Document:** a *user* persona's `<persona>/tools/` executes user-provided
-binaries from the user's own config — expected on a single-tenant box, called out
-so it's not a surprise. Minimal-env + (best-effort) kill isolation applies to every
-exec invocation.
+Discovery executes binaries — fine under the trusted-code posture (core ships
+with lace; plugin dirs are trusted plugin code; bundled dirs are
+embedder-controlled). **Document:** a _user_ persona's `<persona>/tools/`
+executes user-provided binaries from the user's own config — expected on a
+single-tenant box, called out so it's not a surprise. Minimal-env +
+(best-effort) kill isolation applies to every exec invocation.
 
 ## Testing strategy
 
 - **Part 0:** persona resolution from a plugin-contributed dir; `:`-namespacing
   (`ns:entry`); precedence (user > plugin > bundled); unified file-render;
-  `PersonaInfo.path` is a real disk path; the full consumer inventory updated and
-  green (incl. the inverted whole-system test pointed at a real fixture dir).
+  `PersonaInfo.path` is a real disk path; the full consumer inventory updated
+  and green (incl. the inverted whole-system test pointed at a real fixture
+  dir).
 - **Part 1:** `discoverExecToolsSync` unit tests (valid / non-zero /
   invalid-descriptor / non-executable / timeout / aggregate-budget).
 - **Part 2:** core no-op when absent; `registerExecDir` from a plugin
   (`ns:entry`, owner); global exec tool available in a session.
-- **Part 3/4:** e2e — a persona's `<persona>/tools/` tool appears in *its* session
-  and not another's; override of a plugin/core global; **reserved built-in name is
-  refused**; advertised list (tools/list) matches the runtime executor.
+- **Part 3/4:** e2e — a persona's `<persona>/tools/` tool appears in _its_
+  session and not another's; override of a plugin/core global; **reserved
+  built-in name is refused**; advertised list (tools/list) matches the runtime
+  executor.
 - **Part 5:** plugin skill dir discovered; per-persona `<persona>/skills/` skill
-  appears for *its* session (and a **subagent** running that persona) and not
+  appears for _its_ session (and a **subagent** running that persona) and not
   another's; embedder override still layers plugin/persona skills; persona-skill
   wins (ordering); cross-source shadow warns.
 - Exec tests run real subprocesses (no mocks), mirroring `workspace-stats` e2e.
 
 ## Docs to update (in the same change)
 
-Document `api.personas.addDir` / `api.skills.addDir` / `api.tools.registerExecDir`,
-the `<persona>/tools|skills/` convention, and the `:`-namespacing — including the
-removal of `api.personas.register`/`registries.personas`/`PersonaDef` and the
-`/`→`:` tool-name change — across:
+Document `api.personas.addDir` / `api.skills.addDir` /
+`api.tools.registerExecDir`, the `<persona>/tools|skills/` convention, and the
+`:`-namespacing — including the removal of
+`api.personas.register`/`registries.personas`/`PersonaDef` and the `/`→`:`
+tool-name change — across:
 
 - `docs/reference/plugins.md` — **stale-by-design**: documents `api.personas`,
-  `PersonaDef`, `registries.personas`, the `PersonaDef` reference section, and the
-  `<namespace>/<entry>` rule. Major update.
+  `PersonaDef`, `registries.personas`, the `PersonaDef` reference section, and
+  the `<namespace>/<entry>` rule. Major update.
 - `docs/writing-plugins.md` and `docs/external-tools.md` — today zero skills
   mentions; add skills + the new contribution APIs + `:`-namespacing.
-- `docs/building-agents-on-lace.md` — update genuine *plugin* tool-name
-  references; **leave MCP `<server>/<tool>` names as `/`** (MCP keeps slash and is
-  out of scope — e.g. `knowledge/grep` is an MCP tool, not a plugin tool).
-- `docs/agent-personas.md` — canonical persona doc (nothing stale, but it's where
-  `api.personas.addDir` + the `<persona>/tools|skills/` convention belong).
+- `docs/building-agents-on-lace.md` — update genuine _plugin_ tool-name
+  references; **leave MCP `<server>/<tool>` names as `/`** (MCP keeps slash and
+  is out of scope — e.g. `knowledge/grep` is an MCP tool, not a plugin tool).
+- `docs/agent-personas.md` — canonical persona doc (nothing stale, but it's
+  where `api.personas.addDir` + the `<persona>/tools|skills/` convention
+  belong).
 
 ## Open questions
 

--- a/docs/superpowers/specs/2026-06-14-async-only-delegation-design.md
+++ b/docs/superpowers/specs/2026-06-14-async-only-delegation-design.md
@@ -1,8 +1,8 @@
 # Async-Only Delegation — Design
 
 **Status:** Design (approved direction; revised after /par adversarial review)
-**Date:** 2026-06-14
-**Repos touched:** `lace` (mechanism), `sen-core-v2` (agent guidance)
+**Date:** 2026-06-14 **Repos touched:** `lace` (mechanism), `sen-core-v2` (agent
+guidance)
 
 > Line numbers below are anchors from a point-in-time read; the implementer
 > verifies the exact line against the current file before editing.
@@ -10,15 +10,15 @@
 ## Goal
 
 Remove blocking subagent waits from lace so a human-facing parent agent can
-never go deaf to its human while a subagent runs. Delegation becomes
-async-only: every `delegate` returns immediately, and the parent learns of
-completion through a durable, always-delivered notification.
+never go deaf to its human while a subagent runs. Delegation becomes async-only:
+every `delegate` returns immediately, and the parent learns of completion
+through a durable, always-delivered notification.
 
 ## The problem
 
 A Sen coworker stopped answering its human for minutes while a delegated browser
-job ran. The human prodded twice before she replied, *"Sorry — was waiting for
-the subagent."*
+job ran. The human prodded twice before she replied, _"Sorry — was waiting for
+the subagent."_
 
 Root cause, confirmed in code:
 
@@ -52,9 +52,9 @@ than expected.
 
 ### Accepted consequence: subagents are single-turn
 
-A subagent runs exactly one assistant turn, then is torn down
-(`subagent-job.ts` runs one `session/prompt` and SIGTERMs the child in its
-`finally`). With sync removed, a subagent that itself calls `delegate` gets back
+A subagent runs exactly one assistant turn, then is torn down (`subagent-job.ts`
+runs one `session/prompt` and SIGTERMs the child in its `finally`). With sync
+removed, a subagent that itself calls `delegate` gets back
 `{ jobId, status:"started" }` but has **no future turn** in which to receive the
 child's completion notification. So **nested inline delegation is not
 supported** under async-only.
@@ -84,7 +84,7 @@ The guidance rewrite states this constraint plainly.
   per_invocation workspace framing and reaping hints already live on this path
   and are preserved.
 - Rewrite the tool description: drop the "Sync mode" paragraph (`:93`) and the
-  `background` parameter doc (`:98`); present the async flow as *the* flow;
+  `background` parameter doc (`:98`); present the async flow as _the_ flow;
   remove the now-impossible `job_output(block=true)` anti-pattern note; correct
   the `resume` note that mentions "sync or background" (`:99`).
 - Keep `prompt`, `description`, `resume`, `progressIntervalMs`, `connectionId`,
@@ -105,8 +105,9 @@ The guidance rewrite states this constraint plainly.
 - Keep the tool. It remains how a parent opts into progress notifications and
   selective terminal coverage. It is **not required** for basic completion
   delivery — the always-on fallback covers that (Reliability basis).
-- Fix its description: `job_notify.ts:34` references `delegate(..., background=true)`,
-  a now-removed parameter. Reword to the async flow.
+- Fix its description: `job_notify.ts:34` references
+  `delegate(..., background=true)`, a now-removed parameter. Reword to the async
+  flow.
 
 ### lace — leave `bash` alone
 
@@ -116,9 +117,8 @@ It is unrelated to delegation and must NOT be touched.
 ### sen-core — delegation guidance (the load-bearing rewrite)
 
 Both primary guidance surfaces teach sync-only delegation and a drifted schema
-(`delegate(subagent, task, expected_response)` rather than lace's real
-`prompt` / `persona`). The same drift appears in shipped persona prompts.
-Rewrite all of:
+(`delegate(subagent, task, expected_response)` rather than lace's real `prompt`
+/ `persona`). The same drift appears in shipped persona prompts. Rewrite all of:
 
 - `agent-runtime/user/core_identity/instructions/delegating-to-subagents.md`
 - `agent-runtime/system/sen-core/skills/innate/delegating-to-subagents/SKILL.md`
@@ -141,6 +141,7 @@ The new mental model they must teach:
    `delegate(resume=jobId, ...)` to continue, or move on.
 
 Encode two constraints:
+
 - **"Silence is not success":** never subscribe with `job_notify(on=['failed'])`
   alone — a successful job then sends nothing. Rely on the fallback or subscribe
   to all terminal kinds.
@@ -149,11 +150,12 @@ Encode two constraints:
 
 ### What we deliberately do NOT change
 
-- The `ent/job/output` RPC handler's blocking path (`rpc/handlers/jobs.ts:59-70`)
-  and the `EntJobOutputRequestSchema` `block`/`timeout` fields stay. No
-  production caller reaches them (CLI and sen-core never pass `block`); they are
-  exercised only by protocol/e2e RPC tests. Leaving them keeps the protocol
-  surface and those tests stable, with zero production effect.
+- The `ent/job/output` RPC handler's blocking path
+  (`rpc/handlers/jobs.ts:59-70`) and the `EntJobOutputRequestSchema`
+  `block`/`timeout` fields stay. No production caller reaches them (CLI and
+  sen-core never pass `block`); they are exercised only by protocol/e2e RPC
+  tests. Leaving them keeps the protocol surface and those tests stable, with
+  zero production effect.
 
 ## Reliability basis (why notify-only is safe)
 
@@ -168,9 +170,9 @@ cases:
 - **Delivery does not depend on the model subscribing.** `fanoutToInject` runs
   the inject closure once as an always-on fallback when no subscription exists
   (`job-manager.ts:503-507`); that closure carries the idle-wake hooks
-  (`job-notifications.ts:118-137`), and the delegate finalize is the
-  notifying, in-process `createFinalizeJob` (`server.ts:~442`). So a finished
-  delegate wakes even an idle, unsubscribed parent. (Verified by /par.)
+  (`job-notifications.ts:118-137`), and the delegate finalize is the notifying,
+  in-process `createFinalizeJob` (`server.ts:~442`). So a finished delegate
+  wakes even an idle, unsubscribed parent. (Verified by /par.)
 - **Notifications are durable.** Each is an `appendDurableEvent`
   (`context_injected`, `priority:'immediate'`, `inject-notification.ts:61-68`),
   surviving a busy parent; the runner recomputes position from the event log.
@@ -181,7 +183,7 @@ cases:
 
 The /par review found edges where the blanket "every terminal path notifies" is
 not literally true. None is introduced by this change, but async-only makes the
-notification the *only* delivery path, so we harden the one that matters:
+notification the _only_ delivery path, so we harden the one that matters:
 
 1. **Mid-turn completion on a non-success turn exit.** The post-turn re-scan for
    pending immediate injects runs only on the normal turn return; the abort,
@@ -197,9 +199,9 @@ notification the *only* delivery path, so we harden the one that matters:
    also died on restart). **Optional hardening:** on session restore, inject a
    `job-failed` for each orphaned `running` job. Include if cheap; otherwise
    document the `jobs_list` recovery in guidance.
-3. **Clean premature child exit** (`code===0` before the child answers the
-   RPC, `subagent-job.ts:265`) leaves the parent's request hung with no
-   finalize. Pre-existing and rare; out of scope, noted for honesty.
+3. **Clean premature child exit** (`code===0` before the child answers the RPC,
+   `subagent-job.ts:265`) leaves the parent's request hung with no finalize.
+   Pre-existing and rare; out of scope, noted for honesty.
 4. **No active session** at finalize time (`job-notifications.ts:197`) drops the
    notification. Pre-existing; out of scope.
 
@@ -224,6 +226,7 @@ The change is schema + behavior + guidance. Because the `delegate` schema is
 blast radius across tests is wide. The plan must, at minimum:
 
 **lace — unit/schema tests to update or remove:**
+
 - `tools/implementations/__tests__/delegate.test.ts` — sync-mode cases and the
   sync-preamble assertion (e.g. `^delegate jobId=`); convert to async.
 - `tools/__tests__/delegate.test.ts` — `'accepts background parameter'`,
@@ -244,14 +247,16 @@ blast radius across tests is wide. The plan must, at minimum:
 **lace — e2e tests that drive the delegate TOOL's sync branch** (because the
 test-provider emits no `background`): `agent-process.delegate.e2e.test.ts`
 (notably the `delegate jobId=` + inline-output assertion that will go red),
-`.subagent.e2e.test.ts`, `.delegate-config.e2e.test.ts`, `.event-seq.e2e.test.ts`,
-`.jobs.e2e.test.ts`, `.subagent-early-stop.e2e.test.ts`,
-`.subagent-intent-text-stop.e2e.test.ts`, `credential-integration.e2e.test.ts`.
-These need the async flow: dispatch → consume the `job-completed` notification on
-a follow-up turn → assert via `job_output`. Updating the test-provider fixtures
-to drive that follow-up turn is part of the work.
+`.subagent.e2e.test.ts`, `.delegate-config.e2e.test.ts`,
+`.event-seq.e2e.test.ts`, `.jobs.e2e.test.ts`,
+`.subagent-early-stop.e2e.test.ts`, `.subagent-intent-text-stop.e2e.test.ts`,
+`credential-integration.e2e.test.ts`. These need the async flow: dispatch →
+consume the `job-completed` notification on a follow-up turn → assert via
+`job_output`. Updating the test-provider fixtures to drive that follow-up turn
+is part of the work.
 
 **lace — new tests:**
+
 - `delegate` rejects `background`; `job_output` rejects `block`/`timeoutMs`.
 - A terminal state with no subscription still injects a wake (fallback).
 - The post-turn immediate-inject re-scan fires on abort/error turn exits

--- a/docs/writing-plugins.md
+++ b/docs/writing-plugins.md
@@ -14,10 +14,13 @@ the same set, so your extensions are available everywhere automatically.
 
 You can contribute several kinds of thing:
 
-- **tools** — functions the model can call (registered by name into the tools registry)
+- **tools** — functions the model can call (registered by name into the tools
+  registry)
 - **compaction strategies** — how a long conversation gets summarized
-- **personas** — named system-prompt + config bundles for (sub)agents, contributed as a directory of `.md` files
-- **skills** — prompt skill directories, contributed as a directory of skill subdirs
+- **personas** — named system-prompt + config bundles for (sub)agents,
+  contributed as a directory of `.md` files
+- **skills** — prompt skill directories, contributed as a directory of skill
+  subdirs
 - **exec tools** — standalone executable tools discovered from a directory
 - **container runtimes** — backends that run containerized work
 
@@ -152,27 +155,27 @@ export function register(api: PluginApi): void {
 
 **Naming:** plugin-contributed personas and exec tools are named
 `<namespace>:<entry>` where `namespace` is `meta.namespace` (e.g. `acme`) and
-`entry` is the file stem (personas) or the `name` returned by
-`lace-tool-schema` (exec tools). Skills are **not** namespaced — a skill is
-named by its sub-directory name (which must match the `name` field in its
-`SKILL.md` frontmatter), bare (e.g. `researcher`, not `acme:researcher`). All
-skill sources share a single flat namespace; collisions are first-wins and emit a
-`warn`, so choose collision-safe skill names. Built-in and user-defined tool/persona
-names stay bare (no prefix). MCP tool names continue to use `<serverId>/<toolName>`
-— that slash convention is MCP-specific and unaffected.
+`entry` is the file stem (personas) or the `name` returned by `lace-tool-schema`
+(exec tools). Skills are **not** namespaced — a skill is named by its
+sub-directory name (which must match the `name` field in its `SKILL.md`
+frontmatter), bare (e.g. `researcher`, not `acme:researcher`). All skill sources
+share a single flat namespace; collisions are first-wins and emit a `warn`, so
+choose collision-safe skill names. Built-in and user-defined tool/persona names
+stay bare (no prefix). MCP tool names continue to use `<serverId>/<toolName>` —
+that slash convention is MCP-specific and unaffected.
 
 **Persona file format:** the same YAML frontmatter + Markdown body used by
 user-disk and bundled personas. See [Agent Personas](agent-personas.md) for the
-frontmatter fields. Mustache variables (`{{system.os}}`, `{{system.sessionDate}}`,
-etc.) work normally; `@path` includes resolve relative to the persona's own
-directory.
+frontmatter fields. Mustache variables (`{{system.os}}`,
+`{{system.sessionDate}}`, etc.) work normally; `@path` includes resolve relative
+to the persona's own directory.
 
 **Per-persona resources:** a persona at `personas/<entry>.md` may have a sibling
 `personas/<entry>/tools/` directory (exec tools active only when that persona is
 running) and `personas/<entry>/skills/` (skills injected only for that persona).
 Per-persona exec tool descriptor names are bare (not re-namespaced) and can
-override a same-named global plugin or core tool — but never a reserved
-kernel built-in.
+override a same-named global plugin or core tool — but never a reserved kernel
+built-in.
 
 **Precedence:** user-disk personas override plugin personas override bundled
 ones. A user who drops a file in `~/.lace/agent-personas/` with the same logical

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -22,6 +22,7 @@
     "lint:fix": "eslint src --fix",
     "format": "prettier --ignore-path ../../.prettierignore --write \"src/**/*.{ts,js,json}\" \"**/*.{json,md,yml,yaml}\"",
     "test": "vitest run --exclude 'src/__tests__/**' --exclude src/containers/apple-container.integration.test.ts --exclude src/containers/container-cleanup-validation.test.ts --exclude src/jobs/__tests__/persona-container-sharing.integration.test.ts && vitest run --no-file-parallelism src/__tests__/ src/containers/apple-container.integration.test.ts src/containers/container-cleanup-validation.test.ts src/jobs/__tests__/persona-container-sharing.integration.test.ts",
+    "test:coverage": "vitest run --coverage --coverage.reporter=lcov --coverage.reporter=text-summary --exclude 'src/__tests__/**' --exclude src/containers/apple-container.integration.test.ts --exclude src/containers/container-cleanup-validation.test.ts --exclude src/jobs/__tests__/persona-container-sharing.integration.test.ts && vitest run --no-file-parallelism src/__tests__/ src/containers/apple-container.integration.test.ts src/containers/container-cleanup-validation.test.ts src/jobs/__tests__/persona-container-sharing.integration.test.ts",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/packages/agent/src/plugins/__examples__/incident-responder-personas/incident-responder.md
+++ b/packages/agent/src/plugins/__examples__/incident-responder-personas/incident-responder.md
@@ -14,33 +14,42 @@ compaction:
     - at: 0.8
       action: notify
 ---
-You are Incident Responder, an expert production-incident commander.
-Today's date is {{system.sessionDate}}. Running on {{system.os}}/{{system.arch}}.
+
+You are Incident Responder, an expert production-incident commander. Today's
+date is {{system.sessionDate}}. Running on {{system.os}}/{{system.arch}}.
 
 ## Role
-You triage, investigate, and coordinate resolution of production incidents.
-Your job is to get to root cause fast, communicate blast radius clearly, and
-drive the team toward mitigation — not to patch things yourself.
+
+You triage, investigate, and coordinate resolution of production incidents. Your
+job is to get to root cause fast, communicate blast radius clearly, and drive
+the team toward mitigation — not to patch things yourself.
 
 ## Methodology
 
 ### 1. Triage (first 5 minutes)
+
 Immediately establish:
+
 - **Impact**: what is broken, for whom, since when?
 - **Severity**: SEV-1 (full outage / data loss risk) → SEV-4 (minor degradation)
 - **Blast radius**: how many users/systems affected?
-- **Recent changes**: any deploys, config pushes, or infra changes in the last 2h?
+- **Recent changes**: any deploys, config pushes, or infra changes in the last
+  2h?
 
 ### 2. Investigation
+
 Work systematically through the evidence:
+
 - Read logs, metrics, and traces before forming hypotheses.
 - State each hypothesis explicitly, then confirm or rule it out with evidence.
 - Do NOT skip to "let's restart the service" without a root-cause hypothesis.
-- Distinguish symptoms from causes. A 500 rate spike is a symptom; the cause
-  is what's behind it.
+- Distinguish symptoms from causes. A 500 rate spike is a symptom; the cause is
+  what's behind it.
 
 ### 3. Communication
+
 After every significant finding, emit a structured update:
+
 ```
 INCIDENT UPDATE [{{system.sessionDate}} HH:MM UTC]
 Severity: SEV-X
@@ -52,13 +61,18 @@ ETA to Mitigation: <estimate or UNKNOWN>
 ```
 
 ### 4. Mitigation vs. Root Cause Fix
+
 Distinguish:
-- **Mitigation**: stops the bleeding NOW (rollback, feature flag, traffic shift).
-- **Root Cause Fix**: the permanent fix, done POST-incident.
-Recommend mitigation first; root cause fix is a follow-up ticket.
+
+- **Mitigation**: stops the bleeding NOW (rollback, feature flag, traffic
+  shift).
+- **Root Cause Fix**: the permanent fix, done POST-incident. Recommend
+  mitigation first; root cause fix is a follow-up ticket.
 
 ### 5. Wrap-up
+
 When the incident is resolved, produce a concise post-mortem outline:
+
 - Timeline (key events with times)
 - Root cause (one sentence)
 - Blast radius (quantified)
@@ -66,10 +80,11 @@ When the incident is resolved, produce a concise post-mortem outline:
 - Follow-up action items (numbered, with owners)
 
 ## Constraints
+
 - You have read-only access. Do NOT attempt to write files, deploy changes, or
   restart services yourself — coordinate with the on-call engineer.
-- If you are missing critical information (logs, metrics), say so explicitly
-  and specify exactly what you need and from where.
+- If you are missing critical information (logs, metrics), say so explicitly and
+  specify exactly what you need and from where.
 - If the situation is beyond your current information, say "BLOCKED: need X"
   rather than guessing.
 - Concise over verbose. Bullets over paragraphs. Evidence over opinion.

--- a/packages/agent/src/plugins/__examples__/persona-example-personas/security-reviewer.md
+++ b/packages/agent/src/plugins/__examples__/persona-example-personas/security-reviewer.md
@@ -4,5 +4,8 @@ runtime:
 compaction:
   strategy: track-based
 ---
-You are Security Reviewer. Today is {{system.sessionDate}}.
-Your job is to inspect code changes for security vulnerabilities: injection flaws, secrets in source, insecure defaults, and privilege escalation. Be concise. Flag severity (critical/high/medium/low) for every finding.
+
+You are Security Reviewer. Today is {{system.sessionDate}}. Your job is to
+inspect code changes for security vulnerabilities: injection flaws, secrets in
+source, insecure defaults, and privilege escalation. Be concise. Flag severity
+(critical/high/medium/low) for every finding.

--- a/packages/agent/src/plugins/__examples__/reference-personas/scout.md
+++ b/packages/agent/src/plugins/__examples__/reference-personas/scout.md
@@ -2,4 +2,5 @@
 runtime:
   type: root
 ---
+
 You are Scout, a fast researcher.

--- a/packages/agent/src/plugins/__fixtures__/good-plugin-personas/fixture-persona.md
+++ b/packages/agent/src/plugins/__fixtures__/good-plugin-personas/fixture-persona.md
@@ -2,4 +2,5 @@
 runtime:
   type: root
 ---
+
 Fixture persona for loader tests.

--- a/packages/agent/src/plugins/__fixtures__/reach-plugin-personas/reach-persona.md
+++ b/packages/agent/src/plugins/__fixtures__/reach-plugin-personas/reach-persona.md
@@ -2,4 +2,5 @@
 runtime:
   type: root
 ---
+
 Reach persona for subagent-reach e2e tests.


### PR DESCRIPTION
CI's `format:check` has been red on main for days — ~55 files of drift in docs, example personas, and the golden request-body snapshots.

- Docs and persona markdown: reformatted (`npm run format`, plus a second pass on 3 files where prettier isn't idempotent on first pass).
- **Golden snapshots NOT reformatted**: `packages/agent/src/providers/__tests__/golden/*.json` are exact committed bytes compared via `toMatchFileSnapshot` — prettifying them breaks the golden-bytes tests. Added to `.prettierignore` instead.

Verified: `format:check` clean; provider tests 298/298; plugin tests 149/149.

Unblocks obra/lace#366 (PRI-2884), whose CI failure was entirely this pre-existing drift.