### PR TITLE
Emit compaction_complete from the runner's in-place compaction paths (PRI-2889)

### DIFF
--- a/packages/agent/src/core/conversation/__tests__/runner.breakpoints.test.ts
+++ b/packages/agent/src/core/conversation/__tests__/runner.breakpoints.test.ts
@@ -340,6 +340,111 @@ describe('ConversationRunner - configurable breakpoints', () => {
     expect(events.some((e) => e.type === 'context_compacted')).toBe(true);
   });
 
+  it('crossing a compact breakpoint emits a compaction_complete session update (PRI-2889)', async () => {
+    // The post-compaction wake in sen-core subscribes to this update; without it,
+    // in-place breakpoint compaction strands in-flight work (ada, 2026-08-14).
+    mockBreakpoints.mockReturnValue([{ at: 0.5, action: 'compact' }]);
+    seedSession(sessionDir, sessionId, cwd, 'compact-low');
+
+    const provider = new ScriptedProvider(
+      [
+        {
+          content: 'done',
+          toolCalls: [],
+          stopReason: 'stop',
+          usage: { promptTokens: 600_000, completionTokens: 10, totalTokens: 600_010 },
+        },
+      ],
+      1_000_000
+    );
+
+    const executor = new ToolExecutor();
+    executor.registerAllAvailableTools({ skillDirs: [] } as any);
+
+    const config: RunnerConfig = {
+      sessionDir,
+      sessionId,
+      cwd,
+      executionMode: 'execute',
+      approvalMode: 'approve',
+      persona: 'compact-low',
+    };
+    const deps = createMockDeps({
+      createProvider: vi.fn().mockImplementation(async () => provider),
+      createToolExecutor: vi.fn().mockReturnValue({
+        executor,
+        toolsForProvider: executor.getAllTools(),
+      }),
+    });
+
+    const runner = new ConversationRunner(config, deps);
+    await runner.run({
+      content: [{ type: 'text', text: 'hello' }],
+      abortController: new AbortController(),
+      turnId: `turn_${randomUUID()}`,
+      startedAt: new Date().toISOString(),
+    });
+
+    const compactionUpdates = (deps.onUpdate as ReturnType<typeof vi.fn>).mock.calls
+      .map(([, update]) => update)
+      .filter((u: { type: string }) => u.type === 'compaction_complete');
+    expect(compactionUpdates).toHaveLength(1);
+    expect(compactionUpdates[0]).toMatchObject({
+      type: 'compaction_complete',
+      strategy: expect.any(String),
+      messagesCompacted: expect.any(Number),
+    });
+  });
+
+  it('a notify breakpoint does not emit compaction_complete', async () => {
+    mockBreakpoints.mockReturnValue([{ at: 0.5, action: 'notify' }]);
+    seedSession(sessionDir, sessionId, cwd, 'notify-low');
+
+    const provider = new ScriptedProvider(
+      [
+        {
+          content: 'done',
+          toolCalls: [],
+          stopReason: 'stop',
+          usage: { promptTokens: 600_000, completionTokens: 10, totalTokens: 600_010 },
+        },
+      ],
+      1_000_000
+    );
+
+    const executor = new ToolExecutor();
+    executor.registerAllAvailableTools({ skillDirs: [] } as any);
+
+    const config: RunnerConfig = {
+      sessionDir,
+      sessionId,
+      cwd,
+      executionMode: 'execute',
+      approvalMode: 'approve',
+      persona: 'notify-low',
+    };
+    const deps = createMockDeps({
+      createProvider: vi.fn().mockImplementation(async () => provider),
+      createToolExecutor: vi.fn().mockReturnValue({
+        executor,
+        toolsForProvider: executor.getAllTools(),
+      }),
+    });
+
+    const runner = new ConversationRunner(config, deps);
+    await runner.run({
+      content: [{ type: 'text', text: 'hello' }],
+      abortController: new AbortController(),
+      turnId: `turn_${randomUUID()}`,
+      startedAt: new Date().toISOString(),
+    });
+
+    const compactionUpdates = (deps.onUpdate as ReturnType<typeof vi.fn>).mock.calls
+      .map(([, update]) => update)
+      .filter((u: { type: string }) => u.type === 'compaction_complete');
+    expect(compactionUpdates).toHaveLength(0);
+  });
+
   it('highestFiredBreakpointAt persists after a notify crossing', async () => {
     mockBreakpoints.mockReturnValue([{ at: 0.5, action: 'notify' }]);
     seedSession(sessionDir, sessionId, cwd, 'notify-persist');

--- a/packages/agent/src/core/conversation/runner.ts
+++ b/packages/agent/src/core/conversation/runner.ts
@@ -1365,9 +1365,10 @@ export class ConversationRunner {
           const allEvents = readDurableEvents(sessionDir, {
             limit: Number.MAX_SAFE_INTEGER,
           }).events;
-          const strategy = resolveCompactionStrategy(
-            this.config.persona ? compactionStrategyNameForSession(sessionDir) : 'track-based'
-          );
+          const strategyName = this.config.persona
+            ? compactionStrategyNameForSession(sessionDir)
+            : 'track-based';
+          const strategy = resolveCompactionStrategy(strategyName);
           const compactionCtx = buildCompactionContext({
             threadId: sessionId,
             sessionDir,
@@ -1397,6 +1398,20 @@ export class ConversationRunner {
               // Re-render the persona (model + system prompt) from the current
               // persona file so the compacted session reflects the live persona.
               await this.deps.rerenderPersonaAfterCompaction?.();
+            });
+            // Notify clients that an in-place compaction ran, mirroring the
+            // ent/session/compact handler's compaction_complete emit. sen-core's
+            // post-compaction wake keys on this update; without it, breakpoint
+            // and compact_session compactions strand in-flight work (PRI-2889).
+            // Emitted OUTSIDE the runExclusive section above: onUpdate takes the
+            // same mutex, and nesting it would deadlock.
+            await this.deps.onUpdate(durableTurnSeq, {
+              type: 'compaction_complete',
+              strategy: strategyName,
+              messagesCompacted:
+                typeof result.compactionEvent.data.messagesCompacted === 'number'
+                  ? result.compactionEvent.data.messagesCompacted
+                  : 0,
             });
           }
         }


### PR DESCRIPTION
#366 added the `compaction_complete` session update to the `ent/session/compact` RPC handler only. The runner's in-place paths — **persona pressure-breakpoint compaction** and **agent-requested `compact_session`** — appended `context_compacted` with no notification. Those are the paths production actually hits under context pressure (pressure counts cache reads: ada's turn measured 1.56M), so sen-core's post-compaction wake (PRI-2884) never fired there: ada stranded for ~90 minutes on 2026-08-14 21:23 with in-flight work after a breakpoint compaction, recreating the exact bug the wake was built to fix.

Fix: emit via `deps.onUpdate` immediately after the append/rerender `runExclusive` section — deliberately **outside** it, since `onUpdate` → `emitSessionUpdate` takes the same mutex and nesting would deadlock (the block's own comments already warn about this). `tokensReclaimed` omitted on this path: computing before/after token estimates means rebuilding provider messages twice per compaction on multi-million-token sessions, for a field the subscriber ignores.

TDD: RED (compact-breakpoint crossing emitted nothing) → GREEN; negative test that notify-breakpoints don't emit. Full suite: agent 3466 + ent-protocol 275 + cli 14 passed; typecheck, eslint, prettier clean.

Consumer: sen-core deploys with this via `sen coworker upgrade` (both repos' main). Linear: PRI-2889