### PR TITLE
Fire the session-recovered notice on orphaned jobs alone, not only mid-turn crashes (PRI-2893)

### DIFF
--- a/packages/agent/src/__tests__/session-load.rehydrate-config.test.ts
+++ b/packages/agent/src/__tests__/session-load.rehydrate-config.test.ts
@@ -1596,6 +1596,74 @@ describe('session/load rehydrates connectionId+modelId from persisted state', ()
     expect(text).toContain('refactor the flux capacitor');
   });
 
+  it('names interrupted jobs even when the process died between turns (PRI-2893)', async () => {
+    // The deploy path waits for turn-idle before restarting, so the common
+    // production restart kills in-flight JOBS with no orphaned turn_start.
+    // The notice must fire on orphaned jobs alone, not only on a mid-turn
+    // crash — otherwise the loss is silent unless the agent happens to call
+    // jobs_list.
+    const setupState = createAgentServerState();
+    const { client: setupClient } = createPairedPeers((peer) =>
+      registerAgentRpcMethods(peer, setupState)
+    );
+    await setupClient.request('initialize', defaultInitializeParams());
+    const created = (await setupClient.request('session/new', {
+      cwd: tempDir,
+      mcpServers: [],
+    })) as { sessionId: string };
+
+    // Prior process died between turns: job_started with no job_finished,
+    // every turn_start properly closed (none written at all here).
+    const dir = loadSession(created.sessionId).dir;
+    appendFileSync(
+      join(dir, 'events.jsonl'),
+      JSON.stringify({
+        eventSeq: 901,
+        timestamp: '2026-08-05T00:00:01.000Z',
+        type: 'job_started',
+        data: {
+          jobId: 'job_between_turns_1',
+          jobType: 'delegate',
+          description: 'fix batch-2 attribution',
+        },
+      }) + '\n',
+      'utf8'
+    );
+
+    const loadState = createAgentServerState();
+    const { client: loadClient } = createPairedPeers((peer) =>
+      registerAgentRpcMethods(peer, loadState)
+    );
+    await loadClient.request('initialize', defaultInitializeParams());
+    await loadClient.request('session/load', {
+      sessionId: created.sessionId,
+      cwd: tempDir,
+      mcpServers: [],
+    });
+
+    const injected = [...readAllSessionEventLines(dir)]
+      .map((line) => {
+        try {
+          return JSON.parse(line) as {
+            type?: string;
+            data?: { content?: Array<{ text?: string }> };
+          };
+        } catch {
+          return undefined;
+        }
+      })
+      .filter((e) => e?.type === 'context_injected');
+    const recoveryNotice = injected.find((e) =>
+      e?.data?.content?.some((c) => (c.text ?? '').includes('kind="session-recovered"'))
+    );
+    expect(recoveryNotice).toBeDefined();
+    const text = recoveryNotice?.data?.content?.[0]?.text ?? '';
+    expect(text).toContain('job_between_turns_1');
+    expect(text).toContain('fix batch-2 attribution');
+    // The turn was NOT cut off — the notice must not claim a mid-turn crash.
+    expect(text).not.toContain('cut off');
+  });
+
   it('does NOT inject a session-recovered notice on a clean session/load', async () => {
     const setupState = createAgentServerState();
     const { client: setupClient } = createPairedPeers((peer) =>

--- a/packages/agent/src/rpc/handlers/session.ts
+++ b/packages/agent/src/rpc/handlers/session.ts
@@ -299,10 +299,17 @@ async function activateStoredSession(
   // gets left hanging. The notice sits in the durable log and is read on the
   // next turn (whatever triggers it); we deliberately do NOT force an internal
   // turn, so a restart alone never makes the agent act unprompted.
-  if (loaded.recoveredFromCrash) {
+  // The common production restart (a deploy) waits for turn-idle first, so it
+  // kills in-flight JOBS with no orphaned turn_start — recoveredFromCrash
+  // stays false and, before PRI-2893, the loss was silent unless the agent
+  // happened to call jobs_list. Orphaned jobs alone must therefore also
+  // trigger the notice. Filtering against this process's in-memory map keeps
+  // a same-process re-activation from reporting its own live jobs.
+  const inMemoryJobs = state.jobManager.getRunningJobs();
+  const interrupted = listInterruptedJobs(loaded.dir).filter((job) => !inMemoryJobs.has(job.jobId));
+  if (loaded.recoveredFromCrash || interrupted.length > 0) {
     // Name what the dead process left in flight, so the agent doesn't have
     // to reconstruct it (or guess wrong) from jobs_list.
-    const interrupted = listInterruptedJobs(loaded.dir);
     const interruptedLines =
       interrupted.length > 0
         ? '\n\nJobs that were in flight when the process died (their true ' +
@@ -315,16 +322,22 @@ async function activateStoredSession(
             )
             .join('\n')
         : '';
-    injectNotification({
-      sessionDir: loaded.dir,
-      kind: 'session-recovered',
-      body:
-        'You just crashed (or were restarted) mid-turn and have now restarted. ' +
+    const body = loaded.recoveredFromCrash
+      ? 'You just crashed (or were restarted) mid-turn and have now restarted. ' +
         'Your previous turn was cut off before it finished, so any work you were ' +
         'in the middle of may be incomplete and any reply you were about to send ' +
         'was NOT sent. Re-read the most recent messages and your open jobs to see ' +
         'where you left off. If someone was waiting on you, tell them what ' +
-        `happened and pick the work back up.${interruptedLines}`,
+        `happened and pick the work back up.${interruptedLines}`
+      : 'The agent process was restarted between turns (e.g. a deploy) while ' +
+        'background jobs were still in flight. Your conversation was not ' +
+        'interrupted, but the jobs below did not finish under the old process. ' +
+        'Check them with job_output and re-dispatch whatever still ' +
+        `matters.${interruptedLines}`;
+    injectNotification({
+      sessionDir: loaded.dir,
+      kind: 'session-recovered',
+      body,
     });
   }
 


### PR DESCRIPTION
## Gap
PRI-2871 added the `interrupted` status and a session-recovered notice naming the jobs a dead process left in flight — but the notice was gated on `recoveredFromCrash`, which is only set when the prior process died mid-turn (orphaned `turn_start`). The deploy path deliberately waits for turn-idle before restarting, so the *common* production restart kills in-flight jobs with `recoveredFromCrash=false`: no notice, and the loss is invisible unless the agent happens to call `jobs_list`.

## Fix
`activateStoredSession` now computes `listInterruptedJobs` up front and injects the notice whenever orphans exist, even on a clean-turn load. The list is filtered against this process's in-memory running-job map, so a same-process re-activation never reports its own live jobs. The between-turns body says the conversation was NOT interrupted and points at `job_output` / re-dispatch; the mid-turn crash body is unchanged. The injected notice doubles as the crash-generation marker, so subsequent loads don't re-report the same orphans.

## Tests
New test: job_started with no job_finished and no orphaned turn → notice fires, names the job, and does not claim the turn was cut off. Existing clean-load-no-notice and mid-turn tests unchanged and green (44/44 in session-load, 382/382 across jobs+rpc, typecheck + eslint clean).