### PR TITLE
fix(anthropic): fail fast on stalled streams instead of hanging ~40min (PRI-2896)

### DIFF
--- a/packages/agent/src/providers/anthropic-provider.ts
+++ b/packages/agent/src/providers/anthropic-provider.ts
@@ -34,6 +34,17 @@ import {
   extractThinkingBlocks,
 } from './anthropic/beta-request';
 
+// PRI-2896: without explicit tuning the SDK defaults to a 10-minute timeout
+// with 2 internal retries — and retries its own timeouts — so a dead connection
+// could wedge one lace-level attempt for ~30 minutes before lace's retry loop
+// even saw a failure (~40 min observed in production). The SDK's timer only
+// covers time-to-response-headers (it is cleared when fetch resolves), so the
+// headers cap cannot kill a long-running healthy stream; silence after headers
+// is the idle watchdog's job.
+export const STREAM_HEADERS_TIMEOUT_MS = 120_000;
+export const STREAM_IDLE_TIMEOUT_MS = 180_000;
+const STREAM_IDLE_POLL_MS = 10_000;
+
 interface AnthropicProviderConfig extends ProviderConfig {
   apiKey: string | null;
   /**
@@ -64,10 +75,15 @@ export class AnthropicProvider extends AIProvider {
       const anthropicConfig: {
         apiKey: string;
         dangerouslyAllowBrowser: boolean;
+        maxRetries: number;
         baseURL?: string;
       } = {
         apiKey: config.apiKey,
         dangerouslyAllowBrowser: true, // Allow in test environments
+        // PRI-2896: lace's withRetry owns retries. The SDK's internal retries
+        // (default 2, each with its own timeout) stack under ours and multiply
+        // worst-case unresponsiveness while making attempt counts in our logs lie.
+        maxRetries: 0,
       };
 
       // Support custom base URL for Anthropic-compatible APIs
@@ -381,8 +397,30 @@ export class AnthropicProvider extends AIProvider {
           streaming: true,
         });
 
+        // PRI-2896: compose the caller's signal with an idle watchdog. The
+        // SDK's own timer only covers time-to-headers; once the stream is open
+        // a dead connection produces silence, not an error, until TCP gives up.
+        // The watchdog aborts a silent stream so the failure surfaces in
+        // seconds and lace's retry loop can take over.
+        const streamAbort = new AbortController();
+        const onCallerAbort = () => streamAbort.abort();
+        if (signal) {
+          if (signal.aborted) streamAbort.abort();
+          else signal.addEventListener('abort', onCallerAbort, { once: true });
+        }
+        let lastStreamEventAt = Date.now();
+        let idleTimedOut = false;
+        const idleWatchdog = setInterval(() => {
+          if (Date.now() - lastStreamEventAt > STREAM_IDLE_TIMEOUT_MS) {
+            idleTimedOut = true;
+            streamAbort.abort();
+          }
+        }, STREAM_IDLE_POLL_MS);
+        idleWatchdog.unref?.();
+
         const stream = this.getAnthropicClient().beta.messages.stream(requestPayload, {
-          signal,
+          signal: streamAbort.signal,
+          timeout: STREAM_HEADERS_TIMEOUT_MS,
         });
 
         let toolCalls: ToolCall[] = [];
@@ -403,6 +441,7 @@ export class AnthropicProvider extends AIProvider {
 
           // Listen for progressive token usage updates and thinking blocks during streaming
           stream.on('streamEvent', (event: BetaRawMessageStreamEvent) => {
+            lastStreamEventAt = Date.now();
             if (event.type === 'message_delta' && event.usage) {
               const usage = event.usage;
               this.emit('token_usage_update', {
@@ -547,9 +586,24 @@ export class AnthropicProvider extends AIProvider {
           // context-window 400s shouldn't surface as ERROR-level noise.
           const classified = tryClassifyAsContextWindow(error, 'AnthropicProvider (streaming)');
           if (classified) return classified;
+          // PRI-2896: an idle-watchdog abort surfaces from the SDK as a
+          // user-abort. Re-throw it as what it actually is — a timed-out
+          // connection (ETIMEDOUT so withRetry classifies it retryable) — and
+          // never mask a real caller abort.
+          if (idleTimedOut && !signal?.aborted) {
+            const idleError = new Error(
+              `Anthropic stream produced no events for ${STREAM_IDLE_TIMEOUT_MS}ms; aborted as stalled`
+            ) as Error & { code: string };
+            idleError.code = 'ETIMEDOUT';
+            logger.error('Streaming error from Anthropic', { error: idleError.message });
+            throw idleError;
+          }
           const errorObj = error as Error;
           logger.error('Streaming error from Anthropic', { error: errorObj.message });
           throw error;
+        } finally {
+          clearInterval(idleWatchdog);
+          if (signal) signal.removeEventListener('abort', onCallerAbort);
         }
       },
       {

--- a/packages/agent/src/providers/anthropic-provider.ts
+++ b/packages/agent/src/providers/anthropic-provider.ts
@@ -37,11 +37,18 @@ import {
 // PRI-2896: without explicit tuning the SDK defaults to a 10-minute timeout
 // with 2 internal retries — and retries its own timeouts — so a dead connection
 // could wedge one lace-level attempt for ~30 minutes before lace's retry loop
-// even saw a failure (~40 min observed in production). The SDK's timer only
-// covers time-to-response-headers (it is cleared when fetch resolves), so the
-// headers cap cannot kill a long-running healthy stream; silence after headers
-// is the idle watchdog's job.
-export const STREAM_HEADERS_TIMEOUT_MS = 120_000;
+// even saw a failure (~40 min observed in production).
+//
+// The two caps guard different phases, and the headers cap is deliberately the
+// LOOSER of the two. The SDK's timer is armed before fetch and cleared when the
+// response resolves, so it covers DNS + TLS + request-body upload + server
+// first byte — a phase that is legitimately slow for our large cache-heavy
+// prompts (multi-MB POST bodies; on a cache miss the server may not flush SSE
+// headers until prefill progresses). A spurious abort there re-sends the whole
+// prompt and re-bills the cache read. After headers, by contrast, Anthropic's
+// SSE `ping` keepalives keep arriving, so a silent gap is a genuine
+// dead-connection signal and can be caught much sooner.
+export const STREAM_HEADERS_TIMEOUT_MS = 300_000;
 export const STREAM_IDLE_TIMEOUT_MS = 180_000;
 const STREAM_IDLE_POLL_MS = 10_000;
 

--- a/packages/agent/src/providers/anthropic-timeout.test.ts
+++ b/packages/agent/src/providers/anthropic-timeout.test.ts
@@ -141,6 +141,10 @@ describe('PRI-2896: Anthropic client timeout tuning', () => {
   it('does not abort a stream that keeps emitting events past the idle threshold', async () => {
     const handlers: StreamHandlers = {};
     let resolveFinal!: (value: unknown) => void;
+    // The stream MUST honor the abort signal, or this test cannot fail: an
+    // over-eager watchdog would abort a controller nobody listens to and the
+    // assertions would pass anyway.
+    let abortSignal: AbortSignal | undefined;
     const stream = {
       on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
         (handlers[event] ??= []).push(handler);
@@ -148,12 +152,22 @@ describe('PRI-2896: Anthropic client timeout tuning', () => {
       }),
       finalMessage: vi.fn(
         () =>
-          new Promise((resolve) => {
+          new Promise((resolve, reject) => {
             resolveFinal = resolve;
+            const rejectAborted = () => {
+              const err = new Error('Request was aborted.');
+              err.name = 'APIUserAbortError';
+              reject(err);
+            };
+            if (abortSignal?.aborted) rejectAborted();
+            else abortSignal?.addEventListener('abort', rejectAborted, { once: true });
           })
       ),
     };
-    mockStream.mockReturnValue(stream);
+    mockStream.mockImplementation((_payload: unknown, opts: { signal?: AbortSignal }) => {
+      abortSignal = opts.signal;
+      return stream;
+    });
 
     const messages: ProviderMessage[] = [{ role: 'user', content: 'Hello' }];
     const promise = provider.createStreamingResponse(messages, [], 'claude-3-5-haiku-20241022');

--- a/packages/agent/src/providers/anthropic-timeout.test.ts
+++ b/packages/agent/src/providers/anthropic-timeout.test.ts
@@ -1,0 +1,205 @@
+// ABOUTME: PRI-2896 — a stalled Anthropic stream must fail fast, not hang for
+// ABOUTME: the SDK's stacked-retry worst case (~40 min observed in production).
+// ABOUTME: Pins: SDK retries disabled (lace owns retries), an explicit headers
+// ABOUTME: timeout on the stream call, and an idle watchdog that aborts a
+// ABOUTME: silent stream so lace's own retry loop can take over.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  AnthropicProvider,
+  STREAM_HEADERS_TIMEOUT_MS,
+  STREAM_IDLE_TIMEOUT_MS,
+} from './anthropic-provider';
+import { ProviderMessage } from './base-provider';
+import { anthropicBaseMessagesTrap } from '@lace/agent/test-utils/anthropic-base-namespace-trap';
+
+const mockCreate = vi.fn();
+const mockStream = vi.fn();
+const constructorConfigs: Array<Record<string, unknown>> = [];
+
+vi.mock('@anthropic-ai/sdk', () => {
+  const MockAnthropic = vi.fn().mockImplementation((config: Record<string, unknown>) => {
+    constructorConfigs.push(config);
+    return {
+      messages: anthropicBaseMessagesTrap(),
+      beta: {
+        messages: {
+          create: mockCreate,
+          stream: mockStream,
+          countTokens: vi.fn().mockResolvedValue({ input_tokens: 100 }),
+        },
+      },
+    };
+  });
+  return { default: MockAnthropic };
+});
+
+interface StreamHandlers {
+  [event: string]: Array<(...args: unknown[]) => void>;
+}
+
+// A stream mock whose finalMessage() hangs forever unless the abort signal the
+// provider passed in fires — modeling the SDK's behavior on a dead connection.
+function silentStreamRespectingAbort() {
+  const handlers: StreamHandlers = {};
+  let abortSignal: AbortSignal | undefined;
+  const stream = {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      (handlers[event] ??= []).push(handler);
+      return stream;
+    }),
+    finalMessage: vi.fn(
+      () =>
+        new Promise((_resolve, reject) => {
+          const rejectAborted = () => {
+            const err = new Error('Request was aborted.');
+            err.name = 'APIUserAbortError';
+            reject(err);
+          };
+          if (abortSignal?.aborted) rejectAborted();
+          else abortSignal?.addEventListener('abort', rejectAborted, { once: true });
+        })
+    ),
+    _setSignal: (signal: AbortSignal | undefined) => {
+      abortSignal = signal;
+    },
+    _handlers: handlers,
+  };
+  return stream;
+}
+
+function healthyStream(text: string) {
+  const stream = {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (event === 'text') handler(text);
+      return stream;
+    }),
+    finalMessage: vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+      stop_reason: 'end_turn',
+    }),
+  };
+  return stream;
+}
+
+describe('PRI-2896: Anthropic client timeout tuning', () => {
+  let provider: AnthropicProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    constructorConfigs.length = 0;
+    mockCreate.mockReset();
+    mockStream.mockReset();
+    provider = new AnthropicProvider({ apiKey: 'test-key' });
+    provider.on('error', () => {});
+    provider.on('retry_attempt', () => {});
+    provider.on('retry_exhausted', () => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('disables SDK-internal retries (lace owns retries) and caps time-to-headers on streams', async () => {
+    mockStream.mockReturnValue(healthyStream('hi'));
+    const messages: ProviderMessage[] = [{ role: 'user', content: 'Hello' }];
+
+    await provider.createStreamingResponse(messages, [], 'claude-3-5-haiku-20241022');
+
+    expect(constructorConfigs.length).toBe(1);
+    expect(constructorConfigs[0]?.maxRetries).toBe(0);
+    const streamOpts = mockStream.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(streamOpts.timeout).toBe(STREAM_HEADERS_TIMEOUT_MS);
+  });
+
+  it('aborts a stream that goes silent so the lace retry loop can take over', async () => {
+    // First attempt: a stream that never emits and never resolves — before the
+    // fix this hangs until TCP gives up (~40 min observed). Second attempt: healthy.
+    const silent = silentStreamRespectingAbort();
+    mockStream
+      .mockImplementationOnce((_payload: unknown, opts: { signal?: AbortSignal }) => {
+        silent._setSignal(opts.signal);
+        return silent;
+      })
+      .mockImplementationOnce(() => healthyStream('recovered'));
+
+    const messages: ProviderMessage[] = [{ role: 'user', content: 'Hello' }];
+    const promise = provider.createStreamingResponse(messages, [], 'claude-3-5-haiku-20241022');
+    promise.catch(() => {});
+
+    // Just past the idle threshold (plus a watchdog poll) the silent stream is
+    // aborted; then advance through the retry backoff to the healthy attempt.
+    await vi.advanceTimersByTimeAsync(STREAM_IDLE_TIMEOUT_MS + 15_000);
+    expect(mockStream).toHaveBeenCalledTimes(2);
+
+    const response = await promise;
+    expect(response.content).toBe('recovered');
+  });
+
+  it('does not abort a stream that keeps emitting events past the idle threshold', async () => {
+    const handlers: StreamHandlers = {};
+    let resolveFinal!: (value: unknown) => void;
+    const stream = {
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        (handlers[event] ??= []).push(handler);
+        return stream;
+      }),
+      finalMessage: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveFinal = resolve;
+          })
+      ),
+    };
+    mockStream.mockReturnValue(stream);
+
+    const messages: ProviderMessage[] = [{ role: 'user', content: 'Hello' }];
+    const promise = provider.createStreamingResponse(messages, [], 'claude-3-5-haiku-20241022');
+    promise.catch(() => {});
+
+    // Emit a stream event at ~80% of the idle threshold, twice: total elapsed
+    // exceeds the threshold but the gap between events never does.
+    const bump = Math.floor(STREAM_IDLE_TIMEOUT_MS * 0.8);
+    await vi.advanceTimersByTimeAsync(bump);
+    for (const h of handlers.streamEvent ?? []) h({ type: 'message_start' });
+    await vi.advanceTimersByTimeAsync(bump);
+    for (const h of handlers.streamEvent ?? []) h({ type: 'message_start' });
+
+    expect(mockStream).toHaveBeenCalledTimes(1);
+
+    resolveFinal({
+      content: [{ type: 'text', text: 'slow but alive' }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+      stop_reason: 'end_turn',
+    });
+    const response = await promise;
+    expect(response.content).toBe('slow but alive');
+  });
+
+  it('propagates a caller abort through to the stream', async () => {
+    const silent = silentStreamRespectingAbort();
+    mockStream.mockImplementationOnce((_payload: unknown, opts: { signal?: AbortSignal }) => {
+      silent._setSignal(opts.signal);
+      return silent;
+    });
+
+    const controller = new AbortController();
+    const messages: ProviderMessage[] = [{ role: 'user', content: 'Hello' }];
+    const promise = provider.createStreamingResponse(
+      messages,
+      [],
+      'claude-3-5-haiku-20241022',
+      controller.signal
+    );
+    const settled = promise.then(
+      () => 'resolved',
+      () => 'rejected'
+    );
+
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(await settled).toBe('rejected');
+  });
+});

--- a/packages/agent/src/providers/base-provider.ts
+++ b/packages/agent/src/providers/base-provider.ts
@@ -757,10 +757,22 @@ export abstract class AIProvider extends EventEmitter {
       }
     }
 
-    // Check for Retry-After header in error response
+    // Check for Retry-After header in error response. The Anthropic and OpenAI
+    // SDKs hand us a `Headers` instance, whose values are unreachable by
+    // bracket access — so read via `.get()` first and only fall back to a plain
+    // object. This went unnoticed while the SDKs ran their own retry loops
+    // (which read the header correctly); with SDK-internal retries disabled
+    // (PRI-2896) we are the only reader left, and a 429's server-supplied delay
+    // would otherwise be replaced by blind exponential backoff.
     if (err.headers && typeof err.headers === 'object') {
-      const headers = err.headers as Record<string, unknown>;
-      const retryAfter = headers['retry-after'] || headers['Retry-After'];
+      const rawHeaders = err.headers as { get?: (name: string) => string | null } & Record<
+        string,
+        unknown
+      >;
+      const retryAfter =
+        typeof rawHeaders.get === 'function'
+          ? (rawHeaders.get('retry-after') ?? undefined)
+          : ((rawHeaders['retry-after'] ?? rawHeaders['Retry-After']) as unknown);
       if (typeof retryAfter === 'string') {
         const seconds = parseFloat(retryAfter);
         if (!isNaN(seconds)) {

--- a/packages/agent/src/providers/retry-after-headers.test.ts
+++ b/packages/agent/src/providers/retry-after-headers.test.ts
@@ -1,0 +1,44 @@
+// ABOUTME: PRI-2896 follow-up — the SDKs hand us a `Headers` instance on API
+// ABOUTME: errors, whose values bracket access cannot reach. While the SDKs ran
+// ABOUTME: their own retry loops they honored Retry-After for us; with
+// ABOUTME: SDK-internal retries disabled, lace is the only reader left, so a
+// ABOUTME: 429's server-supplied delay must actually be parsed.
+
+import { describe, it, expect } from 'vitest';
+import { AnthropicProvider } from './anthropic-provider';
+
+class ProbeProvider extends AnthropicProvider {
+  public rateLimitDelay(error: unknown): number | null {
+    return this.extractRateLimitDelay(error);
+  }
+}
+
+function provider(): ProbeProvider {
+  return new ProbeProvider({ apiKey: 'test-key' });
+}
+
+describe('extractRateLimitDelay reads Retry-After from a Headers instance', () => {
+  it('parses Retry-After delivered as a Headers instance (the SDK shape)', () => {
+    const error = Object.assign(new Error('429 rate limited'), {
+      headers: new Headers({ 'retry-after': '42' }),
+    });
+
+    expect(provider().rateLimitDelay(error)).toBe(42_000);
+  });
+
+  it('still parses Retry-After from a plain-object header bag', () => {
+    const error = Object.assign(new Error('429 rate limited'), {
+      headers: { 'retry-after': '7' },
+    });
+
+    expect(provider().rateLimitDelay(error)).toBe(7_000);
+  });
+
+  it('returns null when no Retry-After is present', () => {
+    const error = Object.assign(new Error('429 rate limited'), {
+      headers: new Headers({ 'content-type': 'application/json' }),
+    });
+
+    expect(provider().rateLimitDelay(error)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

Observed on ada-sen 2026-08-16 04:03–04:56Z: her core agent was unresponsive ~53 minutes across two hung requests while Slack wake events queued behind them. A stream went silent at 04:03 and did not error until 04:16:31 (`Streaming error from Anthropic {"error":"Connection error."}`); lace correctly retried at 04:16:37 and *that* request hung ~40 more minutes with no response, no error, no further retry.

Root cause: `getAnthropicClient()` built the SDK client with only `apiKey`/`baseURL`. The installed SDK defaults to `timeout: 10 minutes` and `maxRetries: 2`, and retries its own timeouts — so a single lace-level attempt could burn ~30 minutes before lace's retry loop saw a failure, with lace allowing 10 attempts on top. Streams additionally had no inter-chunk watchdog, so silence after headers rode until TCP gave up.

## Fix

1. **`maxRetries: 0`** on the client. Lace's `withRetry` owns retries; stacking the SDK's under ours multiplies worst-case unresponsiveness and makes attempt counts in our logs lie.
2. **Explicit 120s timeout on streaming calls.** Verified against the SDK source (`client.js` `timedFetch` clears the timer in a `finally` when fetch resolves): this caps *time-to-response-headers only* and cannot kill a long-running healthy stream.
3. **Idle watchdog (180s, polled every 10s)** composing an AbortController with the caller's signal. A stream that emits no `streamEvent` for 180s is aborted and rethrown as an `Error` with `code: 'ETIMEDOUT'` so `isRetryableError` classifies it retryable. A genuine caller abort is never masked (guarded on `signal?.aborted`), and the interval/listener are cleaned up in `finally` on every retry attempt.

## Tests

New `anthropic-timeout.test.ts` (4 tests): SDK retries disabled + headers timeout passed; a silent stream is aborted and the retry succeeds; a slow-but-alive stream emitting inside the threshold is *not* aborted; caller abort still propagates. All fail on the pre-fix code in the ways you'd expect.

`src/providers/` suite: 777 passed. Full agent E2E dir single-threaded: 268 passed, 0 failed. (The full parallel suite shows 21–37 load-dependent E2E flakes both with and without this change — pre-existing, tracked separately.)

Fixes PRI-2896.