### PR TITLE
feat(providers): ride out provider outages on a zero-token probe (PRI-2901)

### DIFF
--- a/packages/agent/src/providers/anthropic-provider.ts
+++ b/packages/agent/src/providers/anthropic-provider.ts
@@ -470,14 +470,16 @@ export class AnthropicProvider extends AIProvider {
           ...(signal ? { signal } : {}),
         });
 
-        const stream = client.beta.messages.stream(requestPayload, {
-          signal: guard.signal,
-          timeout: STREAM_HEADERS_TIMEOUT_MS,
-        });
-
         let toolCalls: ToolCall[] = [];
 
+        // Inside the try so that a throw from stream() itself still reaches the
+        // finally: otherwise it strands the guard's interval and its listener
+        // on the caller's long-lived signal.
         try {
+          const stream = client.beta.messages.stream(requestPayload, {
+            signal: guard.signal,
+            timeout: STREAM_HEADERS_TIMEOUT_MS,
+          });
           // Handle streaming events - use the 'text' event for token-by-token streaming
           stream.on('text', (text) => {
             streamingStarted = true; // Mark that streaming has begun

--- a/packages/agent/src/providers/anthropic-provider.ts
+++ b/packages/agent/src/providers/anthropic-provider.ts
@@ -460,13 +460,17 @@ export class AnthropicProvider extends AIProvider {
 
         // PRI-2896: a dead connection produces silence rather than an error
         // once the stream is open, so guard the gap between stream events.
+        // Resolve the client first: it throws on missing credentials, and a
+        // throw between creating the guard and the try/finally would strand
+        // its interval and its listener on the caller's long-lived signal.
+        const client = this.getAnthropicClient();
         const guard = this.createStallGuard({
           idleMs: STREAM_IDLE_TIMEOUT_MS,
           pollMs: STREAM_IDLE_POLL_MS,
           ...(signal ? { signal } : {}),
         });
 
-        const stream = this.getAnthropicClient().beta.messages.stream(requestPayload, {
+        const stream = client.beta.messages.stream(requestPayload, {
           signal: guard.signal,
           timeout: STREAM_HEADERS_TIMEOUT_MS,
         });

--- a/packages/agent/src/providers/anthropic-provider.ts
+++ b/packages/agent/src/providers/anthropic-provider.ts
@@ -117,12 +117,21 @@ export class AnthropicProvider extends AIProvider {
    * hand-rolled SDK mocks in our tests), so those callers keep the ordinary
    * retry behavior rather than crashing inside the retry loop.
    */
-  protected override healthProbe(signal?: AbortSignal): Promise<void> | null {
-    const models = (
+  protected override supportsHealthProbe(): boolean {
+    return typeof this.modelsResource()?.list === 'function';
+  }
+
+  /** The SDK's `models` resource, absent on older SDKs and hand-rolled mocks. */
+  private modelsResource(): { list?: (...args: unknown[]) => Promise<unknown> } | undefined {
+    return (
       this.getAnthropicClient() as unknown as {
         models?: { list?: (...args: unknown[]) => Promise<unknown> };
       }
     ).models;
+  }
+
+  protected override healthProbe(signal?: AbortSignal): Promise<void> | null {
+    const models = this.modelsResource();
     if (!models || typeof models.list !== 'function') return null;
     return Promise.resolve(
       models.list({ limit: 1 }, { signal, timeout: HEALTH_PROBE_TIMEOUT_MS })

--- a/packages/agent/src/providers/anthropic-provider.ts
+++ b/packages/agent/src/providers/anthropic-provider.ts
@@ -54,6 +54,10 @@ const STREAM_IDLE_POLL_MS = 10_000;
 // A liveness probe that hangs is useless — it must answer well inside the
 // interval between probes (PRI-2901).
 const HEALTH_PROBE_TIMEOUT_MS = 30_000;
+// PRI-2900: a non-streaming request has no progress events, so this bounds the
+// whole call. The SDK itself refuses non-streaming work it expects to exceed
+// ten minutes, so anything longer than that is already outside its contract.
+export const NONSTREAMING_TIMEOUT_MS = 600_000;
 
 interface AnthropicProviderConfig extends ProviderConfig {
   apiKey: string | null;
@@ -335,15 +339,32 @@ export class AnthropicProvider extends AIProvider {
         // Log request with pretty formatting
         logProviderRequest('anthropic', requestPayload as unknown as Record<string, unknown>);
 
+        // PRI-2900: the non-streaming path has no events to watch, so the guard
+        // acts as a hard deadline for the whole request. Without it the body
+        // read after response headers is unbounded — the same SDK behavior that
+        // let a stalled stream hang for 40 minutes.
+        const guard = this.createStallGuard({
+          idleMs: NONSTREAMING_TIMEOUT_MS,
+          pollMs: STREAM_IDLE_POLL_MS,
+          ...(signal ? { signal } : {}),
+        });
         let response: BetaMessage;
         try {
           response = (await this.getAnthropicClient().beta.messages.create(requestPayload, {
-            signal,
+            signal: guard.signal,
+            timeout: NONSTREAMING_TIMEOUT_MS,
           })) as BetaMessage;
         } catch (providerError) {
+          const stalled = this.stallError(guard, NONSTREAMING_TIMEOUT_MS, signal);
+          if (stalled) {
+            logger.error('Request stalled', { provider: 'anthropic', error: stalled.message });
+            throw stalled;
+          }
           const classified = tryClassifyAsContextWindow(providerError, 'AnthropicProvider');
           if (classified) return classified;
           throw providerError;
+        } finally {
+          guard.dispose();
         }
 
         // Log response with pretty formatting
@@ -437,29 +458,16 @@ export class AnthropicProvider extends AIProvider {
           streaming: true,
         });
 
-        // PRI-2896: compose the caller's signal with an idle watchdog. The
-        // SDK's own timer only covers time-to-headers; once the stream is open
-        // a dead connection produces silence, not an error, until TCP gives up.
-        // The watchdog aborts a silent stream so the failure surfaces in
-        // seconds and lace's retry loop can take over.
-        const streamAbort = new AbortController();
-        const onCallerAbort = () => streamAbort.abort();
-        if (signal) {
-          if (signal.aborted) streamAbort.abort();
-          else signal.addEventListener('abort', onCallerAbort, { once: true });
-        }
-        let lastStreamEventAt = Date.now();
-        let idleTimedOut = false;
-        const idleWatchdog = setInterval(() => {
-          if (Date.now() - lastStreamEventAt > STREAM_IDLE_TIMEOUT_MS) {
-            idleTimedOut = true;
-            streamAbort.abort();
-          }
-        }, STREAM_IDLE_POLL_MS);
-        idleWatchdog.unref?.();
+        // PRI-2896: a dead connection produces silence rather than an error
+        // once the stream is open, so guard the gap between stream events.
+        const guard = this.createStallGuard({
+          idleMs: STREAM_IDLE_TIMEOUT_MS,
+          pollMs: STREAM_IDLE_POLL_MS,
+          ...(signal ? { signal } : {}),
+        });
 
         const stream = this.getAnthropicClient().beta.messages.stream(requestPayload, {
-          signal: streamAbort.signal,
+          signal: guard.signal,
           timeout: STREAM_HEADERS_TIMEOUT_MS,
         });
 
@@ -481,7 +489,7 @@ export class AnthropicProvider extends AIProvider {
 
           // Listen for progressive token usage updates and thinking blocks during streaming
           stream.on('streamEvent', (event: BetaRawMessageStreamEvent) => {
-            lastStreamEventAt = Date.now();
+            guard.noteActivity();
             if (event.type === 'message_delta' && event.usage) {
               const usage = event.usage;
               this.emit('token_usage_update', {
@@ -626,24 +634,20 @@ export class AnthropicProvider extends AIProvider {
           // context-window 400s shouldn't surface as ERROR-level noise.
           const classified = tryClassifyAsContextWindow(error, 'AnthropicProvider (streaming)');
           if (classified) return classified;
-          // PRI-2896: an idle-watchdog abort surfaces from the SDK as a
+          // PRI-2896: a stall-guard abort surfaces from the SDK as a
           // user-abort. Re-throw it as what it actually is — a timed-out
           // connection (ETIMEDOUT so withRetry classifies it retryable) — and
           // never mask a real caller abort.
-          if (idleTimedOut && !signal?.aborted) {
-            const idleError = new Error(
-              `Anthropic stream produced no events for ${STREAM_IDLE_TIMEOUT_MS}ms; aborted as stalled`
-            ) as Error & { code: string };
-            idleError.code = 'ETIMEDOUT';
-            logger.error('Streaming error from Anthropic', { error: idleError.message });
-            throw idleError;
+          const stalled = this.stallError(guard, STREAM_IDLE_TIMEOUT_MS, signal);
+          if (stalled) {
+            logger.error('Streaming error from Anthropic', { error: stalled.message });
+            throw stalled;
           }
           const errorObj = error as Error;
           logger.error('Streaming error from Anthropic', { error: errorObj.message });
           throw error;
         } finally {
-          clearInterval(idleWatchdog);
-          if (signal) signal.removeEventListener('abort', onCallerAbort);
+          guard.dispose();
         }
       },
       {

--- a/packages/agent/src/providers/anthropic-provider.ts
+++ b/packages/agent/src/providers/anthropic-provider.ts
@@ -51,6 +51,9 @@ import {
 export const STREAM_HEADERS_TIMEOUT_MS = 300_000;
 export const STREAM_IDLE_TIMEOUT_MS = 180_000;
 const STREAM_IDLE_POLL_MS = 10_000;
+// A liveness probe that hangs is useless — it must answer well inside the
+// interval between probes (PRI-2901).
+const HEALTH_PROBE_TIMEOUT_MS = 30_000;
 
 interface AnthropicProviderConfig extends ProviderConfig {
   apiKey: string | null;
@@ -103,6 +106,27 @@ export class AnthropicProvider extends AIProvider {
       this._anthropic = new Anthropic(anthropicConfig);
     }
     return this._anthropic;
+  }
+
+  /**
+   * PRI-2901: zero-token liveness probe — a one-item model list, the cheapest
+   * authenticated GET the API offers. Used only while riding out an outage, in
+   * place of re-sending the prompt.
+   *
+   * Returns null when the client has no `models` resource (older SDKs, and the
+   * hand-rolled SDK mocks in our tests), so those callers keep the ordinary
+   * retry behavior rather than crashing inside the retry loop.
+   */
+  protected override healthProbe(signal?: AbortSignal): Promise<void> | null {
+    const models = (
+      this.getAnthropicClient() as unknown as {
+        models?: { list?: (...args: unknown[]) => Promise<unknown> };
+      }
+    ).models;
+    if (!models || typeof models.list !== 'function') return null;
+    return Promise.resolve(
+      models.list({ limit: 1 }, { signal, timeout: HEALTH_PROBE_TIMEOUT_MS })
+    ).then(() => undefined);
   }
 
   /**

--- a/packages/agent/src/providers/base-provider.ts
+++ b/packages/agent/src/providers/base-provider.ts
@@ -982,11 +982,11 @@ export abstract class AIProvider extends EventEmitter {
       try {
         await probe;
       } catch (err) {
-        // An HTTP status means the server answered, so the API is reachable —
-        // a revoked key, a proxied baseURL that only forwards /v1/messages, or
-        // a rate limit would otherwise keep "failing" forever and burn the
-        // whole budget waiting for a recovery that already happened. Only a
-        // connection-level failure counts as still-down.
+        // A permanent answer (a revoked key, a proxy that only forwards
+        // /v1/messages) would otherwise keep "failing" forever and burn the
+        // whole budget waiting for a recovery that can never come. Transient
+        // statuses and connection-level failures are the outage itself and keep
+        // us probing — see probeIndicatesUnreachable.
         if (!this.probeIndicatesUnreachable(err)) {
           logger.warn('Liveness probe answered with an error; treating provider as reachable', {
             provider: this.providerName,
@@ -1011,19 +1011,25 @@ export abstract class AIProvider extends EventEmitter {
    */
   private probeIndicatesUnreachable(error: unknown): boolean {
     if (!error || typeof error !== 'object') return true;
-    const status = (error as { status?: unknown }).status;
+    const raw = error as { status?: unknown; statusCode?: unknown };
+    const status = typeof raw.status === 'number' ? raw.status : raw.statusCode;
     // No status at all means we never got an answer: APIConnectionError,
     // APIConnectionTimeoutError and APIUserAbortError all construct with an
     // undefined status, so this is the connection-level case.
     if (typeof status !== 'number') return true;
-    // 5xx and 429 ARE the outage. An overloaded_error (529) or a 503 is
-    // precisely the shape of a provider incident, and re-sending a
-    // coworker-sized prompt into one is the cost this whole mechanism exists
-    // to avoid — so keep probing. Anything else the server can tell us (401 on
-    // a revoked key, 404 from a proxy that only forwards /v1/messages) is a
-    // permanent condition that probing will never clear, so stop waiting and
-    // let the real request's own error decide the turn.
-    return status >= 500 || status === 429;
+    // A status the retry layer considers transient IS the outage: an
+    // overloaded_error (529), a 503, a 429, a 408 request timeout. Re-sending a
+    // coworker-sized prompt into one is the cost this whole mechanism exists to
+    // avoid, so keep probing. This list is kept in step with
+    // `isRetryableError` on purpose — a status the two classifiers disagree
+    // about would end the ride-out for a fault the retry loop then treats as
+    // temporary.
+    //
+    // Anything else the server can tell us (401 on a revoked key, 404 from a
+    // proxy that only forwards /v1/messages) is a permanent condition probing
+    // will never clear, so stop waiting and let the real request's own error
+    // decide the turn.
+    return status >= 500 || status === 429 || status === 408;
   }
 
   /** Resolves after `ms`, or rejects promptly if the caller aborts. */

--- a/packages/agent/src/providers/base-provider.ts
+++ b/packages/agent/src/providers/base-provider.ts
@@ -206,6 +206,13 @@ export interface RequestOptions {
 // liveness probe. The interval cap is what bounds how long a recovered API goes
 // unnoticed — probes are free, so it stays tight. The budget is the outer
 // bound: a turn may wait out a long outage, but not indefinitely.
+/** Backoff/accounting carried across every recovery wait within one withRetry call. */
+export interface OutageState {
+  intervalMs: number;
+  probes: number;
+  startedAtMs: number | undefined;
+}
+
 export const OUTAGE_PROBE_AFTER_ATTEMPTS = 3;
 export const OUTAGE_PROBE_INITIAL_INTERVAL_MS = 5_000;
 export const OUTAGE_PROBE_MAX_INTERVAL_MS = 300_000;
@@ -842,6 +849,17 @@ export abstract class AIProvider extends EventEmitter {
   }
 
   /**
+   * Whether this provider has a health probe. Must not perform I/O: it is a
+   * capability question, asked before we decide to wait. (Answering it by
+   * calling `healthProbe` and discarding the promise leaks an unhandled
+   * rejection the moment the provider is actually down, which on Node's
+   * default `--unhandled-rejections=throw` kills the agent process.)
+   */
+  protected supportsHealthProbe(): boolean {
+    return false;
+  }
+
+  /**
    * Poll `healthProbe` on exponential backoff (capped) until the provider
    * answers, the caller aborts, or `deadlineMs` passes.
    *
@@ -851,18 +869,17 @@ export abstract class AIProvider extends EventEmitter {
    * wait forever.
    */
   protected async waitForProviderRecovery(
+    state: OutageState,
     deadlineMs: number,
     signal?: AbortSignal
-  ): Promise<boolean> {
-    if (this.healthProbe(signal) === null) return false;
-
-    let interval = OUTAGE_PROBE_INITIAL_INTERVAL_MS;
-    let probes = 0;
-    const startedAt = Date.now();
-    logger.warn('Provider unreachable; entering outage mode (no prompt re-sends)', {
-      provider: this.providerName,
-      budgetMs: deadlineMs - startedAt,
-    });
+  ): Promise<void> {
+    if (state.startedAtMs === undefined) {
+      state.startedAtMs = Date.now();
+      logger.warn('Provider unreachable; entering outage mode (no prompt re-sends)', {
+        provider: this.providerName,
+        budgetMs: deadlineMs - state.startedAtMs,
+      });
+    }
 
     for (;;) {
       if (signal?.aborted) {
@@ -871,30 +888,54 @@ export abstract class AIProvider extends EventEmitter {
         throw abortError;
       }
       if (Date.now() >= deadlineMs) {
-        const elapsedMinutes = Math.round((Date.now() - startedAt) / 60_000);
+        const elapsedMinutes = Math.round((Date.now() - state.startedAtMs) / 60_000);
         throw new Error(
-          `Provider outage: ${this.providerName} did not answer ${probes} liveness probes over ${elapsedMinutes} minutes; giving up on this turn.`
+          `Provider outage: ${this.providerName} did not answer ${state.probes} liveness probes over ${elapsedMinutes} minutes; giving up on this turn.`
         );
       }
 
-      await this.sleepUnlessAborted(Math.min(interval, deadlineMs - Date.now()), signal);
-      interval = Math.min(interval * 2, OUTAGE_PROBE_MAX_INTERVAL_MS);
-      probes += 1;
+      await this.sleepUnlessAborted(Math.min(state.intervalMs, deadlineMs - Date.now()), signal);
+      state.intervalMs = Math.min(state.intervalMs * 2, OUTAGE_PROBE_MAX_INTERVAL_MS);
+      state.probes += 1;
 
+      const probe = this.healthProbe(signal);
+      if (probe === null) return;
       try {
-        const probe = this.healthProbe(signal);
-        if (probe === null) return false;
         await probe;
-        logger.warn('Provider reachable again; resuming', {
-          provider: this.providerName,
-          probes,
-          outageMinutes: Math.round((Date.now() - startedAt) / 60_000),
-        });
-        return true;
-      } catch {
-        // Still down. Keep probing — cheaply — until recovery or the budget.
+      } catch (err) {
+        // An HTTP status means the server answered, so the API is reachable —
+        // a revoked key, a proxied baseURL that only forwards /v1/messages, or
+        // a rate limit would otherwise keep "failing" forever and burn the
+        // whole budget waiting for a recovery that already happened. Only a
+        // connection-level failure counts as still-down.
+        if (!this.probeIndicatesUnreachable(err)) {
+          logger.warn('Liveness probe answered with an error; treating provider as reachable', {
+            provider: this.providerName,
+            error: err instanceof Error ? err.message.slice(0, 200) : String(err).slice(0, 200),
+          });
+          return;
+        }
+        continue;
       }
+      logger.warn('Provider reachable again; resuming', {
+        provider: this.providerName,
+        probes: state.probes,
+        outageMinutes: Math.round((Date.now() - state.startedAtMs) / 60_000),
+      });
+      return;
     }
+  }
+
+  /**
+   * True when a failed probe means we could not reach the provider at all, as
+   * opposed to reaching it and being told something (any HTTP status).
+   */
+  private probeIndicatesUnreachable(error: unknown): boolean {
+    if (!error || typeof error !== 'object') return true;
+    const err = error as { status?: unknown; response?: { status?: unknown } };
+    if (typeof err.status === 'number') return false;
+    if (typeof err.response?.status === 'number') return false;
+    return true;
   }
 
   /** Resolves after `ms`, or rejects promptly if the caller aborts. */
@@ -935,6 +976,14 @@ export abstract class AIProvider extends EventEmitter {
     const config = this.RETRY_CONFIG;
     const maxAttempts = options?.maxAttempts ?? config.maxRetries;
     const outageDeadlineMs = Date.now() + OUTAGE_BUDGET_MS;
+    // Shared across recovery cycles so the backoff keeps growing (rather than
+    // restarting at 5s every time a probe briefly succeeds) and the give-up
+    // error can report the real probe count and elapsed time.
+    const outageState: OutageState = {
+      intervalMs: OUTAGE_PROBE_INITIAL_INTERVAL_MS,
+      probes: 0,
+      startedAtMs: undefined,
+    };
     let lastError: unknown;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -987,15 +1036,16 @@ export abstract class AIProvider extends EventEmitter {
         // that is simply down, buys nothing. Switch to a zero-token liveness
         // probe until the API answers again, then re-issue the real request
         // once. Bounded by a wall-clock budget so a turn cannot hang forever.
-        if (attempt >= OUTAGE_PROBE_AFTER_ATTEMPTS) {
-          const recovered = await this.waitForProviderRecovery(outageDeadlineMs, options?.signal);
-          if (recovered) {
-            // Recovered: the next pass gets a fresh attempt budget, since the
-            // failures we just rode out were the outage, not this request.
-            attempt = 0;
-            continue;
-          }
-          // No probe for this provider — fall through to the ordinary backoff.
+        if (attempt >= OUTAGE_PROBE_AFTER_ATTEMPTS && this.supportsHealthProbe()) {
+          // Wait for the provider to answer again instead of spending an
+          // attempt on a re-send that cannot succeed. The attempt counter is
+          // deliberately NOT reset: waiting is what the budget below bounds,
+          // while `maxAttempts` keeps bounding how many times we re-send the
+          // prompt. A provider that answers the probe but keeps failing the
+          // real request ("flapping") therefore costs the same handful of
+          // re-sends it always did, not one per recovery for six hours.
+          await this.waitForProviderRecovery(outageState, outageDeadlineMs, options?.signal);
+          continue;
         }
 
         // Calculate delay for next attempt (respects rate limit headers if present)

--- a/packages/agent/src/providers/base-provider.ts
+++ b/packages/agent/src/providers/base-provider.ts
@@ -1011,10 +1011,19 @@ export abstract class AIProvider extends EventEmitter {
    */
   private probeIndicatesUnreachable(error: unknown): boolean {
     if (!error || typeof error !== 'object') return true;
-    const err = error as { status?: unknown; response?: { status?: unknown } };
-    if (typeof err.status === 'number') return false;
-    if (typeof err.response?.status === 'number') return false;
-    return true;
+    const status = (error as { status?: unknown }).status;
+    // No status at all means we never got an answer: APIConnectionError,
+    // APIConnectionTimeoutError and APIUserAbortError all construct with an
+    // undefined status, so this is the connection-level case.
+    if (typeof status !== 'number') return true;
+    // 5xx and 429 ARE the outage. An overloaded_error (529) or a 503 is
+    // precisely the shape of a provider incident, and re-sending a
+    // coworker-sized prompt into one is the cost this whole mechanism exists
+    // to avoid — so keep probing. Anything else the server can tell us (401 on
+    // a revoked key, 404 from a proxy that only forwards /v1/messages) is a
+    // permanent condition that probing will never clear, so stop waiting and
+    // let the real request's own error decide the turn.
+    return status >= 500 || status === 429;
   }
 
   /** Resolves after `ms`, or rejects promptly if the caller aborts. */

--- a/packages/agent/src/providers/base-provider.ts
+++ b/packages/agent/src/providers/base-provider.ts
@@ -206,6 +206,14 @@ export interface RequestOptions {
 // liveness probe. The interval cap is what bounds how long a recovered API goes
 // unnoticed — probes are free, so it stays tight. The budget is the outer
 // bound: a turn may wait out a long outage, but not indefinitely.
+/** A composed abort signal that fires when a request goes silent. See createStallGuard. */
+export interface StallGuard {
+  readonly signal: AbortSignal;
+  noteActivity(): void;
+  readonly stalled: boolean;
+  dispose(): void;
+}
+
 /** Backoff/accounting carried across every recovery wait within one withRetry call. */
 export interface OutageState {
   intervalMs: number;
@@ -838,6 +846,77 @@ export abstract class AIProvider extends EventEmitter {
   /**
    * Wraps an operation with retry logic
    */
+  /**
+   * PRI-2896/PRI-2900: guard against a request that goes silent. The SDK's own
+   * timeout only covers time-to-response-headers (its timer is cleared once
+   * fetch resolves), so a connection that dies after headers produces silence,
+   * not an error, until TCP eventually gives up — which is how a coworker sat
+   * unresponsive for ~40 minutes.
+   *
+   * The guard composes the caller's signal with one of its own and aborts when
+   * nothing has happened for `idleMs`. Streaming callers call `noteActivity()`
+   * on every stream event, so the window measures the gap between events;
+   * callers with no events to report (a non-streaming body read) simply never
+   * call it, and `idleMs` becomes a hard deadline for the whole request.
+   *
+   * `dispose()` must run in a `finally` — it clears the timer and unhooks the
+   * caller's (long-lived) signal.
+   */
+  protected createStallGuard(opts: {
+    idleMs: number;
+    pollMs: number;
+    signal?: AbortSignal;
+  }): StallGuard {
+    const controller = new AbortController();
+    const onCallerAbort = () => controller.abort();
+    if (opts.signal) {
+      if (opts.signal.aborted) controller.abort();
+      else opts.signal.addEventListener('abort', onCallerAbort, { once: true });
+    }
+    let lastActivityAt = Date.now();
+    let stalled = false;
+    const timer = setInterval(() => {
+      if (Date.now() - lastActivityAt > opts.idleMs) {
+        stalled = true;
+        controller.abort();
+      }
+    }, opts.pollMs);
+    timer.unref?.();
+
+    return {
+      signal: controller.signal,
+      noteActivity: () => {
+        lastActivityAt = Date.now();
+      },
+      get stalled(): boolean {
+        return stalled;
+      },
+      dispose: () => {
+        clearInterval(timer);
+        opts.signal?.removeEventListener('abort', onCallerAbort);
+      },
+    };
+  }
+
+  /**
+   * Convert a stall-guard abort into the error it actually represents: a timed
+   * out connection, retryable, rather than the user-abort the SDK reports.
+   * Returns null when the caller's own signal aborted — a real cancellation is
+   * never masked.
+   */
+  protected stallError(
+    guard: StallGuard,
+    idleMs: number,
+    callerSignal?: AbortSignal
+  ): (Error & { code: string }) | null {
+    if (!guard.stalled || callerSignal?.aborted === true) return null;
+    const error = new Error(
+      `${this.providerName} produced no activity for ${idleMs}ms; aborted as stalled`
+    ) as Error & { code: string };
+    error.code = 'ETIMEDOUT';
+    return error;
+  }
+
   /**
    * PRI-2901: a zero-token liveness check used to ride out a provider outage
    * without re-sending the prompt. Return null when the provider has no cheap

--- a/packages/agent/src/providers/base-provider.ts
+++ b/packages/agent/src/providers/base-provider.ts
@@ -199,6 +199,18 @@ export interface RequestOptions {
  * - 'thinking_delta': { text: string } - Streaming thinking content
  * - 'thinking_end': { tokens: number } - Extended thinking complete with token count
  */
+
+// PRI-2901: outage survival. A few fast retries absorb an ordinary blip; past
+// that, re-sending a coworker-sized prompt at a provider that is simply down
+// burns tokens and buys nothing, so the retry loop switches to a zero-token
+// liveness probe. The interval cap is what bounds how long a recovered API goes
+// unnoticed — probes are free, so it stays tight. The budget is the outer
+// bound: a turn may wait out a long outage, but not indefinitely.
+export const OUTAGE_PROBE_AFTER_ATTEMPTS = 3;
+export const OUTAGE_PROBE_INITIAL_INTERVAL_MS = 5_000;
+export const OUTAGE_PROBE_MAX_INTERVAL_MS = 300_000;
+export const OUTAGE_BUDGET_MS = 6 * 60 * 60 * 1_000;
+
 export abstract class AIProvider extends EventEmitter {
   protected readonly _config: ProviderConfig;
   protected _systemPrompt: string = '';
@@ -819,6 +831,98 @@ export abstract class AIProvider extends EventEmitter {
   /**
    * Wraps an operation with retry logic
    */
+  /**
+   * PRI-2901: a zero-token liveness check used to ride out a provider outage
+   * without re-sending the prompt. Return null when the provider has no cheap
+   * probe — callers then keep the ordinary retry behavior. Implementations must
+   * not consume tokens: this runs repeatedly for as long as the outage lasts.
+   */
+  protected healthProbe(_signal?: AbortSignal): Promise<void> | null {
+    return null;
+  }
+
+  /**
+   * Poll `healthProbe` on exponential backoff (capped) until the provider
+   * answers, the caller aborts, or `deadlineMs` passes.
+   *
+   * Returns true once the provider is reachable again, false immediately when
+   * this provider has no probe. Throws on abort, and on budget exhaustion —
+   * a turn that has waited out the full budget should fail loudly rather than
+   * wait forever.
+   */
+  protected async waitForProviderRecovery(
+    deadlineMs: number,
+    signal?: AbortSignal
+  ): Promise<boolean> {
+    if (this.healthProbe(signal) === null) return false;
+
+    let interval = OUTAGE_PROBE_INITIAL_INTERVAL_MS;
+    let probes = 0;
+    const startedAt = Date.now();
+    logger.warn('Provider unreachable; entering outage mode (no prompt re-sends)', {
+      provider: this.providerName,
+      budgetMs: deadlineMs - startedAt,
+    });
+
+    for (;;) {
+      if (signal?.aborted) {
+        const abortError = new Error('Aborted');
+        abortError.name = 'AbortError';
+        throw abortError;
+      }
+      if (Date.now() >= deadlineMs) {
+        const elapsedMinutes = Math.round((Date.now() - startedAt) / 60_000);
+        throw new Error(
+          `Provider outage: ${this.providerName} did not answer ${probes} liveness probes over ${elapsedMinutes} minutes; giving up on this turn.`
+        );
+      }
+
+      await this.sleepUnlessAborted(Math.min(interval, deadlineMs - Date.now()), signal);
+      interval = Math.min(interval * 2, OUTAGE_PROBE_MAX_INTERVAL_MS);
+      probes += 1;
+
+      try {
+        const probe = this.healthProbe(signal);
+        if (probe === null) return false;
+        await probe;
+        logger.warn('Provider reachable again; resuming', {
+          provider: this.providerName,
+          probes,
+          outageMinutes: Math.round((Date.now() - startedAt) / 60_000),
+        });
+        return true;
+      } catch {
+        // Still down. Keep probing — cheaply — until recovery or the budget.
+      }
+    }
+  }
+
+  /** Resolves after `ms`, or rejects promptly if the caller aborts. */
+  private sleepUnlessAborted(ms: number, signal?: AbortSignal): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      if (signal?.aborted) {
+        const abortError = new Error('Aborted');
+        abortError.name = 'AbortError';
+        reject(abortError);
+        return;
+      }
+      const onAbort = () => {
+        clearTimeout(timer);
+        const abortError = new Error('Aborted');
+        abortError.name = 'AbortError';
+        reject(abortError);
+      };
+      const timer = setTimeout(
+        () => {
+          signal?.removeEventListener('abort', onAbort);
+          resolve();
+        },
+        Math.max(0, ms)
+      );
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
+  }
+
   protected async withRetry<T>(
     operation: () => Promise<T>,
     options?: {
@@ -830,6 +934,7 @@ export abstract class AIProvider extends EventEmitter {
   ): Promise<T> {
     const config = this.RETRY_CONFIG;
     const maxAttempts = options?.maxAttempts ?? config.maxRetries;
+    const outageDeadlineMs = Date.now() + OUTAGE_BUDGET_MS;
     let lastError: unknown;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -874,6 +979,23 @@ export abstract class AIProvider extends EventEmitter {
           }
 
           throw error;
+        }
+
+        // PRI-2901: past the blip attempts, stop re-sending the prompt. Each
+        // full retry re-uploads the whole request (hundreds of thousands of
+        // cache-read tokens on a coworker's context) and, against a provider
+        // that is simply down, buys nothing. Switch to a zero-token liveness
+        // probe until the API answers again, then re-issue the real request
+        // once. Bounded by a wall-clock budget so a turn cannot hang forever.
+        if (attempt >= OUTAGE_PROBE_AFTER_ATTEMPTS) {
+          const recovered = await this.waitForProviderRecovery(outageDeadlineMs, options?.signal);
+          if (recovered) {
+            // Recovered: the next pass gets a fresh attempt budget, since the
+            // failures we just rode out were the outage, not this request.
+            attempt = 0;
+            continue;
+          }
+          // No probe for this provider — fall through to the ordinary backoff.
         }
 
         // Calculate delay for next attempt (respects rate limit headers if present)

--- a/packages/agent/src/providers/bedrock-provider.ts
+++ b/packages/agent/src/providers/bedrock-provider.ts
@@ -39,6 +39,12 @@ import {
 // 2026-07-23: `cache-diagnosis-2026-04-07` returns 400 "invalid beta flag",
 // while `model-context-window-exceeded-2025-08-26` is accepted. Filter the
 // rejected ones out of the betas[] we send on the Bedrock path.
+// PRI-2900: Bedrock streams carry the same stall exposure as the direct
+// Anthropic path — see createStallGuard. Matching values, for the same reason:
+// keepalive events make a long silence a genuine dead-connection signal.
+export const BEDROCK_STREAM_IDLE_TIMEOUT_MS = 180_000;
+const BEDROCK_STREAM_IDLE_POLL_MS = 10_000;
+
 const BEDROCK_UNSUPPORTED_BETAS: ReadonlySet<AnthropicBeta> = new Set<AnthropicBeta>([
   'cache-diagnosis-2026-04-07',
 ]);
@@ -278,7 +284,17 @@ export class BedrockProvider extends AIProvider {
           streaming: true,
         });
 
-        const stream = this.getBedrockClient().beta.messages.stream(requestPayload, { signal });
+        // PRI-2900: same stall exposure as the Anthropic streaming path — a
+        // connection that dies after headers goes silent rather than erroring.
+        const guard = this.createStallGuard({
+          idleMs: BEDROCK_STREAM_IDLE_TIMEOUT_MS,
+          pollMs: BEDROCK_STREAM_IDLE_POLL_MS,
+          ...(signal ? { signal } : {}),
+        });
+
+        const stream = this.getBedrockClient().beta.messages.stream(requestPayload, {
+          signal: guard.signal,
+        });
         streamCreated = true;
 
         let toolCalls: ToolCall[] = [];
@@ -293,6 +309,7 @@ export class BedrockProvider extends AIProvider {
           let currentBlockType: string | null = null;
 
           stream.on('streamEvent', (event: BetaRawMessageStreamEvent) => {
+            guard.noteActivity();
             if (event.type === 'message_delta' && event.usage) {
               const usage = event.usage;
               this.emit('token_usage_update', {
@@ -414,9 +431,16 @@ export class BedrockProvider extends AIProvider {
           // context-window 400s shouldn't surface as ERROR-level noise.
           const classified = tryClassifyAsContextWindow(error, 'BedrockProvider (streaming)');
           if (classified) return classified;
+          const stalled = this.stallError(guard, BEDROCK_STREAM_IDLE_TIMEOUT_MS, signal);
+          if (stalled) {
+            logger.error('Streaming error from Bedrock', { error: stalled.message });
+            throw stalled;
+          }
           const errorObj = error as Error;
           logger.error('Streaming error from Bedrock', { error: errorObj.message });
           throw error;
+        } finally {
+          guard.dispose();
         }
       },
       {

--- a/packages/agent/src/providers/bedrock-provider.ts
+++ b/packages/agent/src/providers/bedrock-provider.ts
@@ -44,6 +44,8 @@ import {
 // keepalive events make a long silence a genuine dead-connection signal.
 export const BEDROCK_STREAM_IDLE_TIMEOUT_MS = 180_000;
 const BEDROCK_STREAM_IDLE_POLL_MS = 10_000;
+// No progress events on the non-streaming path, so this bounds the whole call.
+export const BEDROCK_NONSTREAMING_TIMEOUT_MS = 600_000;
 
 const BEDROCK_UNSUPPORTED_BETAS: ReadonlySet<AnthropicBeta> = new Set<AnthropicBeta>([
   'cache-diagnosis-2026-04-07',
@@ -197,15 +199,32 @@ export class BedrockProvider extends AIProvider {
 
         logProviderRequest('bedrock', requestPayload as unknown as Record<string, unknown>);
 
+        // PRI-2900: the non-streaming path has no progress events, so the guard
+        // is a hard deadline for the whole request. Without it the body read
+        // after response headers is unbounded, which is the same exposure the
+        // streaming guard closes.
+        const guard = this.createStallGuard({
+          idleMs: BEDROCK_NONSTREAMING_TIMEOUT_MS,
+          pollMs: BEDROCK_STREAM_IDLE_POLL_MS,
+          ...(signal ? { signal } : {}),
+        });
         let response: BetaMessage;
         try {
           response = (await this.getBedrockClient().beta.messages.create(requestPayload, {
-            signal,
+            signal: guard.signal,
+            timeout: BEDROCK_NONSTREAMING_TIMEOUT_MS,
           })) as BetaMessage;
         } catch (providerError) {
+          const stalled = this.stallError(guard, BEDROCK_NONSTREAMING_TIMEOUT_MS, signal);
+          if (stalled) {
+            logger.error('Request stalled', { provider: 'bedrock', error: stalled.message });
+            throw stalled;
+          }
           const classified = tryClassifyAsContextWindow(providerError, 'BedrockProvider');
           if (classified) return classified;
           throw providerError;
+        } finally {
+          guard.dispose();
         }
 
         logProviderResponse('bedrock', response);
@@ -295,14 +314,15 @@ export class BedrockProvider extends AIProvider {
           ...(signal ? { signal } : {}),
         });
 
-        const stream = client.beta.messages.stream(requestPayload, {
-          signal: guard.signal,
-        });
-        streamCreated = true;
-
         let toolCalls: ToolCall[] = [];
 
+        // Inside the try so a throw from stream() still reaches the finally —
+        // otherwise the guard's interval and listener leak.
         try {
+          const stream = client.beta.messages.stream(requestPayload, {
+            signal: guard.signal,
+          });
+          streamCreated = true;
           stream.on('text', (text) => {
             streamingStarted = true;
             this.emit('token', { token: text });

--- a/packages/agent/src/providers/bedrock-provider.ts
+++ b/packages/agent/src/providers/bedrock-provider.ts
@@ -286,13 +286,16 @@ export class BedrockProvider extends AIProvider {
 
         // PRI-2900: same stall exposure as the Anthropic streaming path — a
         // connection that dies after headers goes silent rather than erroring.
+        // Client first: it throws on missing credentials, and a throw before
+        // the try/finally would strand the guard's interval and listener.
+        const client = this.getBedrockClient();
         const guard = this.createStallGuard({
           idleMs: BEDROCK_STREAM_IDLE_TIMEOUT_MS,
           pollMs: BEDROCK_STREAM_IDLE_POLL_MS,
           ...(signal ? { signal } : {}),
         });
 
-        const stream = this.getBedrockClient().beta.messages.stream(requestPayload, {
+        const stream = client.beta.messages.stream(requestPayload, {
           signal: guard.signal,
         });
         streamCreated = true;

--- a/packages/agent/src/providers/bedrock-stall-guard.test.ts
+++ b/packages/agent/src/providers/bedrock-stall-guard.test.ts
@@ -1,0 +1,163 @@
+// ABOUTME: PRI-2900 — Bedrock streams carry the same stall exposure as the
+// ABOUTME: direct Anthropic path: a connection that dies after response headers
+// ABOUTME: goes silent rather than erroring. A silent stream must be aborted and
+// ABOUTME: surfaced as a retryable timeout, and a slow-but-alive one left alone.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BedrockProvider, BEDROCK_STREAM_IDLE_TIMEOUT_MS } from './bedrock-provider';
+import type { ProviderMessage } from './base-provider';
+
+const mockCreate = vi.fn();
+const mockStream = vi.fn();
+const mockCountTokens = vi.fn();
+
+vi.mock('@anthropic-ai/bedrock-sdk', () => {
+  class MockAnthropicBedrockMantle {
+    beta = {
+      messages: {
+        create: mockCreate,
+        stream: mockStream,
+        countTokens: mockCountTokens,
+      },
+    };
+  }
+  return {
+    AnthropicBedrockMantle: MockAnthropicBedrockMantle,
+    default: MockAnthropicBedrockMantle,
+  };
+});
+
+const MODEL = 'anthropic.claude-sonnet-5';
+
+interface StreamHandlers {
+  [event: string]: Array<(...args: unknown[]) => void>;
+}
+
+/** A stream that emits nothing and only settles if its abort signal fires. */
+function silentStream(): {
+  stream: Record<string, unknown>;
+  setSignal: (s: AbortSignal | undefined) => void;
+} {
+  let abortSignal: AbortSignal | undefined;
+  const stream: Record<string, unknown> = {
+    on: vi.fn(() => stream),
+    finalMessage: vi.fn(
+      () =>
+        new Promise((_resolve, reject) => {
+          const rejectAborted = () => {
+            const err = new Error('Request was aborted.');
+            err.name = 'APIUserAbortError';
+            reject(err);
+          };
+          if (abortSignal?.aborted) rejectAborted();
+          else abortSignal?.addEventListener('abort', rejectAborted, { once: true });
+        })
+    ),
+  };
+  return {
+    stream,
+    setSignal: (s) => {
+      abortSignal = s;
+    },
+  };
+}
+
+describe('PRI-2900: Bedrock stream stall guard', () => {
+  let provider: BedrockProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockCreate.mockReset();
+    mockStream.mockReset();
+    provider = new BedrockProvider({
+      awsRegion: 'us-west-1',
+      awsAccessKeyId: 'AKIATEST',
+      awsSecretAccessKey: 'secret',
+    });
+    provider.on('error', () => {});
+    provider.on('retry_attempt', () => {});
+    provider.on('retry_exhausted', () => {});
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('aborts a Bedrock stream that goes silent and reports it as a timeout', async () => {
+    const silent = silentStream();
+    mockStream.mockImplementation((_payload: unknown, opts: { signal?: AbortSignal }) => {
+      silent.setSignal(opts.signal);
+      return silent.stream;
+    });
+
+    const messages: ProviderMessage[] = [{ role: 'user', content: 'Hello' }];
+    const promise = provider.createStreamingResponse(messages, [], MODEL);
+    const settled = promise.then(
+      () => 'resolved',
+      (err: Error) => err
+    );
+
+    // Enough for the guard to fire and the retry budget to be spent.
+    await vi.advanceTimersByTimeAsync(BEDROCK_STREAM_IDLE_TIMEOUT_MS * 12);
+
+    const result = await settled;
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error & { code?: string }).code).toBe('ETIMEDOUT');
+    expect(mockStream).toHaveBeenCalled();
+  });
+
+  it('leaves a slow-but-alive Bedrock stream running', async () => {
+    const handlers: StreamHandlers = {};
+    let resolveFinal!: (value: unknown) => void;
+    let abortSignal: AbortSignal | undefined;
+    const stream: Record<string, unknown> = {
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        (handlers[event] ??= []).push(handler);
+        return stream;
+      }),
+      finalMessage: vi.fn(
+        () =>
+          new Promise((resolve, reject) => {
+            resolveFinal = resolve;
+            // Must honor the signal, or an over-eager guard could not fail this.
+            abortSignal?.addEventListener(
+              'abort',
+              () => {
+                const err = new Error('Request was aborted.');
+                err.name = 'APIUserAbortError';
+                reject(err);
+              },
+              { once: true }
+            );
+          })
+      ),
+    };
+    mockStream.mockImplementation((_payload: unknown, opts: { signal?: AbortSignal }) => {
+      abortSignal = opts.signal;
+      return stream;
+    });
+
+    const messages: ProviderMessage[] = [{ role: 'user', content: 'Hello' }];
+    const promise = provider.createStreamingResponse(messages, [], MODEL);
+    promise.catch(() => {});
+
+    // Keep emitting inside the idle window: total elapsed exceeds it, but no
+    // single gap does.
+    const bump = Math.floor(BEDROCK_STREAM_IDLE_TIMEOUT_MS * 0.8);
+    for (let i = 0; i < 3; i += 1) {
+      await vi.advanceTimersByTimeAsync(bump);
+      for (const h of handlers.streamEvent ?? []) h({ type: 'message_start' });
+    }
+
+    expect(mockStream).toHaveBeenCalledTimes(1);
+
+    resolveFinal({
+      id: 'msg_bedrock',
+      content: [{ type: 'text', text: 'slow but alive' }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+      stop_reason: 'end_turn',
+    });
+    const response = await promise;
+    expect(response.content).toBe('slow but alive');
+  });
+});

--- a/packages/agent/src/providers/outage-survival.test.ts
+++ b/packages/agent/src/providers/outage-survival.test.ts
@@ -1,0 +1,179 @@
+// ABOUTME: PRI-2901 — a provider outage must not be ridden out by re-sending
+// ABOUTME: the prompt. After a few blip retries the provider switches to a
+// ABOUTME: zero-token health probe on exponential backoff (capped), re-issuing
+// ABOUTME: the real request only once the API answers again, and gives up after
+// ABOUTME: a wall-clock budget so a turn cannot hang forever.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  AIProvider,
+  type ProviderMessage,
+  type ProviderResponse,
+  type WireTool,
+} from './base-provider';
+import {
+  OUTAGE_BUDGET_MS,
+  OUTAGE_PROBE_AFTER_ATTEMPTS,
+  OUTAGE_PROBE_MAX_INTERVAL_MS,
+} from './base-provider';
+
+// A provider whose operation and health probe are both scriptable, so a full
+// outage-and-recovery can be driven deterministically under fake timers.
+class ProbeableProvider extends AIProvider {
+  operationCalls = 0;
+  probeCalls = 0;
+  operationFails = true;
+  apiIsUp = false;
+  probeSupported = true;
+
+  get providerName(): string {
+    return 'probeable';
+  }
+  get defaultModel(): string {
+    return 'test-model';
+  }
+  get supportsStreaming(): boolean {
+    return false;
+  }
+
+  protected override healthProbe(): Promise<void> | null {
+    if (!this.probeSupported) return null;
+    this.probeCalls += 1;
+    if (this.apiIsUp) return Promise.resolve();
+    const err = new Error('probe: connection refused') as Error & { code: string };
+    err.code = 'ECONNREFUSED';
+    return Promise.reject(err);
+  }
+
+  async createResponse(): Promise<ProviderResponse> {
+    throw new Error('unused');
+  }
+
+  // Drives the same retry machinery the real providers use.
+  run(options?: { signal?: AbortSignal }): Promise<string> {
+    return this.withRetry(
+      () => {
+        this.operationCalls += 1;
+        if (this.operationFails) {
+          const err = new Error('connection reset') as Error & { code: string };
+          err.code = 'ECONNRESET';
+          return Promise.reject(err);
+        }
+        return Promise.resolve('real response');
+      },
+      { signal: options?.signal }
+    );
+  }
+}
+
+function provider(): ProbeableProvider {
+  const p = new ProbeableProvider({ apiKey: 'test-key' });
+  p.on('error', () => {});
+  p.on('retry_attempt', () => {});
+  p.on('retry_exhausted', () => {});
+  return p;
+}
+
+describe('PRI-2901: provider outage survival', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('stops re-sending the prompt after the blip retries and probes instead', async () => {
+    const p = provider();
+    const promise = p.run();
+    promise.catch(() => {});
+
+    // Ride well past the point where the old code would have burned all 10
+    // attempts re-sending the full request.
+    await vi.advanceTimersByTimeAsync(30 * 60_000);
+
+    expect(p.operationCalls).toBe(OUTAGE_PROBE_AFTER_ATTEMPTS);
+    expect(p.probeCalls).toBeGreaterThan(5);
+  });
+
+  it('re-issues the real request once the probe reports the API is back', async () => {
+    const p = provider();
+    const promise = p.run();
+    promise.catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(20 * 60_000);
+    expect(p.operationCalls).toBe(OUTAGE_PROBE_AFTER_ATTEMPTS);
+
+    // Outage ends: the next probe succeeds, the real request is retried, and
+    // this time it works.
+    p.apiIsUp = true;
+    p.operationFails = false;
+    await vi.advanceTimersByTimeAsync(OUTAGE_PROBE_MAX_INTERVAL_MS + 1_000);
+
+    await expect(promise).resolves.toBe('real response');
+    expect(p.operationCalls).toBe(OUTAGE_PROBE_AFTER_ATTEMPTS + 1);
+  });
+
+  it('caps the probe interval so recovery is noticed promptly', async () => {
+    const p = provider();
+    const promise = p.run();
+    promise.catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+    const probesInOneHour = p.probeCalls;
+
+    // At the 5-minute cap an hour holds ~12 probes; a much larger number means
+    // the cap is not being applied, a much smaller one means it backs off past it.
+    expect(probesInOneHour).toBeGreaterThan(8);
+    expect(probesInOneHour).toBeLessThan(30);
+  });
+
+  it('gives up after the wall-clock budget with an accurate error', async () => {
+    const p = provider();
+    const promise = p.run();
+    const settled = promise.then(
+      () => 'resolved',
+      (err: Error) => err
+    );
+
+    await vi.advanceTimersByTimeAsync(OUTAGE_BUDGET_MS + 60_000);
+
+    const result = await settled;
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error).message).toMatch(/provider (outage|unavailable)/i);
+    // Never resumed re-sending the prompt during the outage.
+    expect(p.operationCalls).toBe(OUTAGE_PROBE_AFTER_ATTEMPTS);
+  });
+
+  it('aborts promptly when the caller cancels mid-outage', async () => {
+    const p = provider();
+    const controller = new AbortController();
+    const promise = p.run({ signal: controller.signal });
+    const settled = promise.then(
+      () => 'resolved',
+      () => 'rejected'
+    );
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(await settled).toBe('rejected');
+  });
+
+  it('keeps the pre-existing retry behavior when the provider has no probe', async () => {
+    const p = provider();
+    p.probeSupported = false;
+    const promise = p.run();
+    const settled = promise.then(
+      () => 'resolved',
+      () => 'rejected'
+    );
+
+    await vi.advanceTimersByTimeAsync(30 * 60_000);
+
+    expect(await settled).toBe('rejected');
+    // Exhausted the normal attempt budget rather than entering outage mode.
+    expect(p.operationCalls).toBeGreaterThan(OUTAGE_PROBE_AFTER_ATTEMPTS);
+    expect(p.probeCalls).toBe(0);
+  });
+});

--- a/packages/agent/src/providers/outage-survival.test.ts
+++ b/packages/agent/src/providers/outage-survival.test.ts
@@ -36,10 +36,25 @@ class ProbeableProvider extends AIProvider {
     return false;
   }
 
+  probeHttpStatus: number | undefined;
+
+  protected override supportsHealthProbe(): boolean {
+    return this.probeSupported;
+  }
+
   protected override healthProbe(): Promise<void> | null {
     if (!this.probeSupported) return null;
     this.probeCalls += 1;
     if (this.apiIsUp) return Promise.resolve();
+    if (this.probeHttpStatus !== undefined) {
+      // The server answered — a revoked key, a proxy that only forwards
+      // /v1/messages, a 429. Reachable, just unhappy.
+      const httpErr = new Error(`probe: HTTP ${this.probeHttpStatus}`) as Error & {
+        status: number;
+      };
+      httpErr.status = this.probeHttpStatus;
+      return Promise.reject(httpErr);
+    }
     const err = new Error('probe: connection refused') as Error & { code: string };
     err.code = 'ECONNREFUSED';
     return Promise.reject(err);
@@ -118,13 +133,63 @@ describe('PRI-2901: provider outage survival', () => {
     const promise = p.run();
     promise.catch(() => {});
 
+    // Measure the STEADY-STATE rate, after the exponential ramp has hit the
+    // cap. Counting the first hour cannot distinguish a capped schedule from an
+    // uncapped one: pure doubling from 5s also lands ~9 probes in hour one.
     await vi.advanceTimersByTimeAsync(60 * 60_000);
-    const probesInOneHour = p.probeCalls;
+    const afterFirstHour = p.probeCalls;
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+    const inSecondHour = p.probeCalls - afterFirstHour;
 
-    // At the 5-minute cap an hour holds ~12 probes; a much larger number means
-    // the cap is not being applied, a much smaller one means it backs off past it.
-    expect(probesInOneHour).toBeGreaterThan(8);
-    expect(probesInOneHour).toBeLessThan(30);
+    // An hour at the 5-minute cap is 12 probes. Written as a literal on
+    // purpose: deriving it from OUTAGE_PROBE_MAX_INTERVAL_MS would move both
+    // sides of the assertion together, so raising the cap could not fail this
+    // test — which is exactly the hole a mutation found in the first version.
+    expect(inSecondHour).toBeGreaterThanOrEqual(11);
+    expect(inSecondHour).toBeLessThanOrEqual(13);
+    expect(OUTAGE_PROBE_MAX_INTERVAL_MS).toBe(300_000);
+  });
+
+  it('does not turn a flapping provider into thousands of prompt re-sends', async () => {
+    // The nastiest real outage shape: /v1/models answers fine while the real
+    // endpoint keeps 5xx-ing. Riding this out must never cost more full
+    // re-sends than the ordinary retry budget would have.
+    const p = provider();
+    p.apiIsUp = true; // probe always healthy
+    p.operationFails = true; // real request never recovers
+    const promise = p.run();
+    const settled = promise.then(
+      () => 'resolved',
+      () => 'rejected'
+    );
+
+    await vi.advanceTimersByTimeAsync(OUTAGE_BUDGET_MS + 60_000);
+
+    expect(await settled).toBe('rejected');
+    // The pre-fix implementation reset the attempt counter on every successful
+    // probe and made ~8,000 full-prompt attempts here.
+    expect(p.operationCalls).toBeLessThanOrEqual(10);
+  });
+
+  it('treats a probe that gets an HTTP answer as proof the provider is reachable', async () => {
+    // A revoked key or a proxied baseURL that only forwards /v1/messages makes
+    // the probe fail forever. That must not be read as a six-hour outage.
+    const p = provider();
+    p.probeHttpStatus = 401;
+    const promise = p.run();
+    const settled = promise.then(
+      () => 'resolved',
+      () => 'rejected'
+    );
+
+    // Well short of the 6h budget: each probe answers immediately, so the
+    // attempt budget runs out in minutes rather than hours.
+    await vi.advanceTimersByTimeAsync(30 * 60_000);
+
+    expect(await settled).toBe('rejected');
+    // Failed on the real error's attempt budget rather than waiting out the
+    // outage budget — a handful of probes, not the ~72 a 6h wait would take.
+    expect(p.probeCalls).toBeLessThan(15);
   });
 
   it('gives up after the wall-clock budget with an accurate error', async () => {
@@ -150,14 +215,18 @@ describe('PRI-2901: provider outage survival', () => {
     const promise = p.run({ signal: controller.signal });
     const settled = promise.then(
       () => 'resolved',
-      () => 'rejected'
+      (err: Error) => err
     );
 
     await vi.advanceTimersByTimeAsync(10 * 60_000);
     controller.abort();
     await vi.advanceTimersByTimeAsync(1_000);
 
-    expect(await settled).toBe('rejected');
+    const result = await settled;
+    expect(result).toBeInstanceOf(Error);
+    // Specifically an abort — not the budget error arriving early, which a
+    // bare "did it reject" assertion would happily accept.
+    expect((result as Error).name).toBe('AbortError');
   });
 
   it('keeps the pre-existing retry behavior when the provider has no probe', async () => {

--- a/packages/agent/src/providers/outage-survival.test.ts
+++ b/packages/agent/src/providers/outage-survival.test.ts
@@ -171,7 +171,35 @@ describe('PRI-2901: provider outage survival', () => {
     expect(p.operationCalls).toBeLessThanOrEqual(10);
   });
 
-  it('treats a probe that gets an HTTP answer as proof the provider is reachable', async () => {
+  it('keeps riding out a 5xx — that IS the outage', async () => {
+    // An overloaded_error (529) or a 503 is the actual shape of a provider
+    // incident. Reading "the server answered" as "healthy" here would send the
+    // full prompt straight back into the outage, which is the cost this whole
+    // mechanism exists to avoid.
+    const p = provider();
+    p.probeHttpStatus = 529;
+    const promise = p.run();
+    promise.catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(30 * 60_000);
+
+    expect(p.operationCalls).toBe(OUTAGE_PROBE_AFTER_ATTEMPTS);
+    expect(p.probeCalls).toBeGreaterThan(5);
+  });
+
+  it('keeps riding out a 429', async () => {
+    const p = provider();
+    p.probeHttpStatus = 429;
+    const promise = p.run();
+    promise.catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(30 * 60_000);
+
+    expect(p.operationCalls).toBe(OUTAGE_PROBE_AFTER_ATTEMPTS);
+    expect(p.probeCalls).toBeGreaterThan(5);
+  });
+
+  it('stops waiting on a 4xx — probing will never clear a revoked key', async () => {
     // A revoked key or a proxied baseURL that only forwards /v1/messages makes
     // the probe fail forever. That must not be read as a six-hour outage.
     const p = provider();

--- a/packages/agent/src/providers/stall-guard-coverage.test.ts
+++ b/packages/agent/src/providers/stall-guard-coverage.test.ts
@@ -1,0 +1,124 @@
+// ABOUTME: PRI-2900 — the stall guard shipped for streaming Anthropic left two
+// ABOUTME: siblings exposed: the non-streaming path (whose body read after
+// ABOUTME: headers is unbounded) and the Bedrock stream. Both must now abort a
+// ABOUTME: silent request and surface it as a retryable timeout.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AnthropicProvider, NONSTREAMING_TIMEOUT_MS } from './anthropic-provider';
+import { ProviderMessage } from './base-provider';
+import { anthropicBaseMessagesTrap } from '@lace/agent/test-utils/anthropic-base-namespace-trap';
+
+const mockCreate = vi.fn();
+const mockStream = vi.fn();
+
+vi.mock('@anthropic-ai/sdk', () => {
+  const MockAnthropic = vi.fn().mockImplementation(() => ({
+    messages: anthropicBaseMessagesTrap(),
+    beta: {
+      messages: {
+        create: mockCreate,
+        stream: mockStream,
+        countTokens: vi.fn().mockResolvedValue({ input_tokens: 100 }),
+      },
+    },
+  }));
+  return { default: MockAnthropic };
+});
+
+/** A call that never settles unless the signal it was handed aborts. */
+function hangUntilAborted(): (payload: unknown, opts: { signal?: AbortSignal }) => Promise<never> {
+  return (_payload, opts) =>
+    new Promise((_resolve, reject) => {
+      const rejectAborted = () => {
+        const err = new Error('Request was aborted.');
+        err.name = 'APIUserAbortError';
+        reject(err);
+      };
+      if (opts.signal?.aborted) rejectAborted();
+      else opts.signal?.addEventListener('abort', rejectAborted, { once: true });
+    });
+}
+
+describe('PRI-2900: stall coverage on the non-streaming path', () => {
+  let provider: AnthropicProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockCreate.mockReset();
+    mockStream.mockReset();
+    provider = new AnthropicProvider({ apiKey: 'test-key' });
+    provider.on('error', () => {});
+    provider.on('retry_attempt', () => {});
+    provider.on('retry_exhausted', () => {});
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('aborts a non-streaming request that never responds', async () => {
+    // Before the fix this hung indefinitely: the SDK's timer stops at response
+    // headers, so a dead connection during the body read produced no error.
+    mockCreate.mockImplementation(hangUntilAborted());
+
+    const messages: ProviderMessage[] = [{ role: 'user', content: 'Hello' }];
+    const promise = provider.createResponse(messages, [], 'claude-3-5-haiku-20241022');
+    const settled = promise.then(
+      () => 'resolved',
+      (err: Error) => err
+    );
+
+    // Each attempt stalls for the full deadline and is retried (the error is
+    // retryable by design), so the turn fails only once the attempt budget is
+    // spent. Advance past all of them.
+    await vi.advanceTimersByTimeAsync(NONSTREAMING_TIMEOUT_MS * 12);
+
+    const result = await settled;
+    expect(result).toBeInstanceOf(Error);
+    // Retryable, so withRetry treats it as a transient fault rather than
+    // failing the turn outright.
+    expect((result as Error & { code?: string }).code).toBe('ETIMEDOUT');
+    expect(mockCreate).toHaveBeenCalled();
+  });
+
+  it('passes an explicit timeout so time-to-headers is bounded too', async () => {
+    mockCreate.mockResolvedValue({
+      id: 'msg_1',
+      content: [{ type: 'text', text: 'hi' }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+      stop_reason: 'end_turn',
+    });
+
+    const messages: ProviderMessage[] = [{ role: 'user', content: 'Hello' }];
+    await provider.createResponse(messages, [], 'claude-3-5-haiku-20241022');
+
+    const opts = mockCreate.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(opts.timeout).toBe(NONSTREAMING_TIMEOUT_MS);
+  });
+
+  it('does not abort a non-streaming request that answers in time', async () => {
+    mockCreate.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(
+            () =>
+              resolve({
+                id: 'msg_2',
+                content: [{ type: 'text', text: 'slow but fine' }],
+                usage: { input_tokens: 1, output_tokens: 1 },
+                stop_reason: 'end_turn',
+              }),
+            NONSTREAMING_TIMEOUT_MS / 2
+          );
+        })
+    );
+
+    const messages: ProviderMessage[] = [{ role: 'user', content: 'Hello' }];
+    const promise = provider.createResponse(messages, [], 'claude-3-5-haiku-20241022');
+    await vi.advanceTimersByTimeAsync(NONSTREAMING_TIMEOUT_MS / 2 + 1_000);
+
+    const response = await promise;
+    expect(response.content).toBe('slow but fine');
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

Today's PRI-2896 fix bounds a *single* attempt at 180s, but `withRetry` allows 10 attempts — and every attempt re-sends the entire prompt. On a coworker box that is ~460k cache-read tokens a pop, and against a provider that is simply down it accomplishes nothing except cost. Worst case was still ~30 minutes of silence.

Jesse's requirement: survive provider outages of up to 6 hours safely, with exponential backoff, without burning compute and tokens retrying every 1–10 minutes for six hours.

## Approach

Two phases:

1. **Blip retries (unchanged shape)** — 3 full-request attempts on the existing backoff absorb an ordinary transient failure.
2. **Outage mode** — stop re-sending the prompt entirely. Poll a **zero-token** liveness probe on exponential backoff (5s doubling, capped at 5 min) until the API answers, then re-issue the real request once. If it fails again, back to probing.

Cost during a 6-hour outage: ~72 tiny authenticated GETs, zero tokens, zero prompt re-sends. Recovery is noticed within 5 minutes. At 6 hours the turn fails with an error naming the probe count and elapsed minutes.

The probe is `client.models.list({ limit: 1 })` — the cheapest authenticated GET the API offers, with its own 30s timeout so a hanging probe can't outlast its own interval.

## Compatibility

`healthProbe()` returns `null` on the base class, so any provider without a probe keeps today's behavior exactly. The Anthropic override also returns `null` when the client has no `models` resource, which keeps our hand-rolled SDK mocks (which stub only `beta.messages`) on the old path rather than crashing inside the retry loop.

## Tests

New `outage-survival.test.ts` (6 tests): prompt re-sends stop after the blip attempts while probing continues; the real request is re-issued on probe success; the interval cap keeps ~12 probes/hour rather than hundreds or a handful; the 6h budget fails with an accurate error; a caller abort mid-outage rejects promptly; a provider with no probe keeps the old retry behavior.

Provider suite: 786 passed. Typecheck clean.

Fixes PRI-2901.