### PR TITLE
fix(jobs): mark which restart interrupted a job, so the list stays readable (PRI-2902)

### DIFF
--- a/packages/agent/src/jobs/__tests__/interrupted-job-generation.test.ts
+++ b/packages/agent/src/jobs/__tests__/interrupted-job-generation.test.ts
@@ -1,0 +1,178 @@
+// ABOUTME: listJobs tags each interrupted job with whether the restart that just
+// ABOUTME: happened is what killed it. Without that flag a job orphaned thirty
+// ABOUTME: seconds ago is indistinguishable from months-old residue, and a list
+// ABOUTME: that only grows teaches an agent to ignore the one view that catches
+// ABOUTME: lost work.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { JobManager } from '../job-manager';
+
+describe('interrupted job restart generation', () => {
+  let testDir: string | null = null;
+
+  afterEach(() => {
+    if (testDir) {
+      rmSync(testDir, { recursive: true, force: true });
+      testDir = null;
+    }
+  });
+
+  /** The notice a restarting process injects; the crash-generation boundary. */
+  function recoveryMarker(timestamp: string): object {
+    return {
+      type: 'context_injected',
+      timestamp,
+      data: {
+        content: [
+          {
+            type: 'text',
+            text: '<notification kind="session-recovered">You just crashed.</notification>',
+          },
+        ],
+        priority: 'immediate',
+      },
+    };
+  }
+
+  function jobStarted(jobId: string, timestamp: string): object {
+    return {
+      type: 'job_started',
+      timestamp,
+      data: { jobId, jobType: 'delegate', description: jobId },
+    };
+  }
+
+  function managerFor(events: object[]): JobManager {
+    testDir = mkdtempSync(join(tmpdir(), 'interrupted-generation-'));
+    mkdirSync(testDir, { recursive: true });
+    writeFileSync(join(testDir, 'events.jsonl'), events.map((e) => JSON.stringify(e)).join('\n'));
+
+    // An empty in-memory map is the post-restart state: every log-running job
+    // reads as interrupted.
+    return new JobManager({
+      getActiveSession: vi.fn().mockReturnValue({ sessionId: 'sess_1', dir: testDir }),
+      persistEvent: vi.fn(),
+      emitUpdate: vi.fn(),
+      runShellProcess: vi.fn(),
+      runSubagentProcess: vi.fn(),
+    });
+  }
+
+  function flagsById(manager: JobManager): Record<string, boolean | undefined> {
+    return Object.fromEntries(
+      manager.listJobs().map((j) => [j.jobId, j.interruptedByLatestRestart])
+    );
+  }
+
+  it('separates the jobs the latest restart killed from older residue', () => {
+    // Three generations of the same box. job_old died two restarts ago and was
+    // already reported then; job_fresh is what the restart that JUST happened
+    // took down.
+    const manager = managerFor([
+      jobStarted('job_ancient', '2026-05-29T00:00:00.000Z'),
+      recoveryMarker('2026-08-11T00:00:00.000Z'),
+      jobStarted('job_old', '2026-08-12T00:00:00.000Z'),
+      recoveryMarker('2026-08-16T00:00:00.000Z'),
+      jobStarted('job_fresh', '2026-08-16T01:00:00.000Z'),
+      recoveryMarker('2026-08-17T00:00:00.000Z'),
+    ]);
+
+    expect(flagsById(manager)).toEqual({
+      job_ancient: false,
+      job_old: false,
+      job_fresh: true,
+    });
+  });
+
+  it('flags a job orphaned before the session ever recorded a restart', () => {
+    // First crash this session has seen: the marker the current process wrote
+    // is the only one, so everything before it belongs to the process that
+    // just died.
+    const manager = managerFor([
+      jobStarted('job_a', '2026-08-17T00:00:00.000Z'),
+      recoveryMarker('2026-08-17T00:05:00.000Z'),
+    ]);
+
+    expect(flagsById(manager)).toEqual({ job_a: true });
+  });
+
+  it('leaves the flag off jobs that are not interrupted', () => {
+    const manager = managerFor([
+      jobStarted('job_done', '2026-08-12T00:00:00.000Z'),
+      {
+        type: 'job_finished',
+        timestamp: '2026-08-12T00:01:00.000Z',
+        data: { jobId: 'job_done', outcome: 'completed' },
+      },
+      recoveryMarker('2026-08-17T00:00:00.000Z'),
+    ]);
+
+    const jobs = manager.listJobs();
+    expect(jobs.map((j) => j.status)).toEqual(['completed']);
+    expect(jobs[0]).not.toHaveProperty('interruptedByLatestRestart');
+  });
+
+  it('does not treat injected text that merely quotes the marker as a restart', () => {
+    // A Slack message pasting the marker string must not open a generation.
+    // If it did, this job — which the restart that just happened killed —
+    // would be counted a generation behind and demoted to residue.
+    const manager = managerFor([
+      jobStarted('job_fresh', '2026-08-16T01:00:00.000Z'),
+      {
+        type: 'context_injected',
+        timestamp: '2026-08-16T02:00:00.000Z',
+        data: {
+          content: [
+            {
+              type: 'text',
+              text: '<notification kind="slack-message">someone pasted kind="session-recovered" in chat</notification>',
+            },
+          ],
+        },
+      },
+      recoveryMarker('2026-08-17T00:00:00.000Z'),
+    ]);
+
+    expect(flagsById(manager)).toEqual({ job_fresh: true });
+  });
+
+  it('keeps the flag across the listJobs cache', () => {
+    // listJobs caches the parsed records and re-derives status on every call;
+    // the flag has to survive that path, not just the cold parse.
+    const manager = managerFor([
+      jobStarted('job_old', '2026-08-12T00:00:00.000Z'),
+      recoveryMarker('2026-08-16T00:00:00.000Z'),
+      jobStarted('job_fresh', '2026-08-16T01:00:00.000Z'),
+      recoveryMarker('2026-08-17T00:00:00.000Z'),
+    ]);
+
+    manager.listJobs();
+    expect(flagsById(manager)).toEqual({ job_old: false, job_fresh: true });
+  });
+
+  it('does not flag a job the current process is still running', () => {
+    const manager = managerFor([
+      jobStarted('job_old', '2026-08-12T00:00:00.000Z'),
+      recoveryMarker('2026-08-17T00:00:00.000Z'),
+      jobStarted('job_live', '2026-08-17T01:00:00.000Z'),
+    ]);
+    manager.addJob({
+      jobId: 'job_live',
+      type: 'delegate',
+      status: 'running',
+      startedAt: '2026-08-17T01:00:00.000Z',
+      outputPath: join(testDir!, 'job_live.log'),
+      finished: false,
+      completion: Promise.resolve(),
+      resolveCompletion: () => {},
+    });
+
+    const jobs = manager.listJobs();
+    const live = jobs.find((j) => j.jobId === 'job_live');
+    expect(live?.status).toBe('running');
+    expect(live).not.toHaveProperty('interruptedByLatestRestart');
+  });
+});

--- a/packages/agent/src/jobs/job-derivation.ts
+++ b/packages/agent/src/jobs/job-derivation.ts
@@ -9,6 +9,27 @@ import type { RuntimeExecutionBinding } from '../tools/runtime/types';
 import { readAllSessionEventLines } from '../storage/event-log';
 
 /**
+ * True when a durable event is the `session-recovered` notice a restarting
+ * process injects. That notice IS the crash-generation boundary: everything
+ * logged before it belongs to a process that has already died and been
+ * reported on.
+ *
+ * Anchored to the notification wrapper's opening tag so a quoted mention of
+ * the kind inside some other injected body (a Slack message, say) can never
+ * register as a boundary.
+ */
+export function isSessionRecoveredMarker(event: { type?: string; data?: unknown }): boolean {
+  if (event.type !== 'context_injected') return false;
+  const data = (event.data ?? {}) as Record<string, unknown>;
+  const content = Array.isArray(data.content) ? (data.content as unknown[]) : [];
+  return content.some(
+    (c) =>
+      typeof (c as { text?: unknown }).text === 'string' &&
+      /^<notification\s+kind="session-recovered"/.test((c as { text: string }).text)
+  );
+}
+
+/**
  * A derived job record from events.
  */
 export type DerivedJob = {
@@ -199,18 +220,9 @@ export function listInterruptedJobs(sessionDir: string): DerivedJob[] {
       const data = (parsed.data ?? {}) as Record<string, unknown>;
 
       if (parsed.type === 'context_injected') {
-        const content = Array.isArray(data.content) ? (data.content as unknown[]) : [];
-        // Anchored to the notification wrapper's opening tag so quoted
-        // mentions of the kind inside some other injected body can never
-        // register as a crash boundary.
-        const isRecoveryMarker = content.some(
-          (c) =>
-            typeof (c as { text?: unknown }).text === 'string' &&
-            /^<notification\s+kind="session-recovered"/.test((c as { text: string }).text)
-        );
         // Everything before this marker belongs to an earlier crash
         // generation and was already reported by it.
-        if (isRecoveryMarker) inFlight.clear();
+        if (isSessionRecoveredMarker(parsed)) inFlight.clear();
         continue;
       }
 

--- a/packages/agent/src/jobs/job-manager.ts
+++ b/packages/agent/src/jobs/job-manager.ts
@@ -9,6 +9,7 @@ import { toNonEmptyString } from '../rpc/utils';
 import { getJobOutputPath } from './job-file-utils';
 import type { RuntimeExecutionBinding } from '../tools/runtime/types';
 import { readAllSessionEventLines } from '../storage/event-log';
+import { isSessionRecoveredMarker } from './job-derivation';
 
 export type JobManagerDeps = {
   getActiveSession: () => { sessionId: string; dir: string } | null;
@@ -77,6 +78,12 @@ export type JobRecord = {
   exitCode?: number;
   subagentSessionId?: string;
   persona?: string;
+  // How many session-recovered markers preceded this job's start, i.e. which
+  // crash generation started it. Derived bookkeeping for the flag below.
+  restartGeneration?: number;
+  // Set only on 'interrupted' jobs: true when the restart that just happened
+  // is what killed this job, false when it is residue from an older one.
+  interruptedByLatestRestart?: boolean;
 };
 
 /**
@@ -87,6 +94,9 @@ type JobsCache = {
   fileSize: number;
   fileMtime: number;
   result: JobRecord[];
+  // Total session-recovered markers in the log at parse time (see
+  // applyRunningStatus).
+  restartGenerations: number;
 };
 
 /**
@@ -179,15 +189,25 @@ export class JobManager {
       this.listJobsCache.fileSize === lineCount &&
       this.listJobsCache.fileMtime === 0
     ) {
-      return this.applyRunningStatus(this.listJobsCache.result);
+      return this.applyRunningStatus(
+        this.listJobsCache.result,
+        this.listJobsCache.restartGenerations
+      );
     }
 
     const byId = new Map<string, JobRecord>();
+    // Counts the crash generations the log has seen so far, so each job can
+    // record the one it was started in.
+    let restartGenerations = 0;
 
     for (const line of lines) {
       if (!line) continue;
       try {
         const parsed = JSON.parse(line) as { type?: string; timestamp?: string; data?: unknown };
+        if (isSessionRecoveredMarker(parsed)) {
+          restartGenerations += 1;
+          continue;
+        }
         if (
           parsed.type !== 'job_started' &&
           parsed.type !== 'job_finished' &&
@@ -213,6 +233,7 @@ export class JobManager {
             command: toNonEmptyString(data.command) ?? undefined,
             startTime,
             persona: toNonEmptyString(data.persona) ?? undefined,
+            restartGeneration: restartGenerations,
           });
         } else if (parsed.type === 'job_session_assigned') {
           const existing = byId.get(jobId);
@@ -259,9 +280,10 @@ export class JobManager {
       fileSize: lineCount,
       fileMtime: 0,
       result: parsedResult,
+      restartGenerations,
     };
 
-    return this.applyRunningStatus(parsedResult);
+    return this.applyRunningStatus(parsedResult, restartGenerations);
   }
 
   /**
@@ -270,11 +292,26 @@ export class JobManager {
    * means this process restarted after the job started. We don't know how
    * the job ended — or whether its work (e.g. a delegate's container) is
    * still going — so report 'interrupted', never an invented 'failed'.
+   *
+   * Interrupted jobs are never aged out of the log, so every restart in the
+   * box's history leaves one here forever. Tag each with whether the restart
+   * that just happened is what killed it: without that, a job orphaned thirty
+   * seconds ago looks exactly like one orphaned in May, and an agent that
+   * learns to ignore the list is blind to the next real interruption.
+   *
+   * A job orphaned by the latest restart was started in the generation the
+   * restart ended — the one just before the marker this process wrote on
+   * recovery — hence `restartGenerations - 1`. Jobs started since that marker
+   * (a leak within this process, not a restart victim) count as current too.
    */
-  private applyRunningStatus(jobs: JobRecord[]): JobRecord[] {
+  private applyRunningStatus(jobs: JobRecord[], restartGenerations: number): JobRecord[] {
     return jobs.map((job) => {
       if (job.status === 'running' && !this.jobs.has(job.jobId)) {
-        return { ...job, status: 'interrupted' as JobStatus };
+        return {
+          ...job,
+          status: 'interrupted' as JobStatus,
+          interruptedByLatestRestart: (job.restartGeneration ?? 0) >= restartGenerations - 1,
+        };
       }
       return job;
     });

--- a/packages/agent/src/rpc/handlers/__tests__/job-list-interrupted-recency.test.ts
+++ b/packages/agent/src/rpc/handlers/__tests__/job-list-interrupted-recency.test.ts
@@ -1,0 +1,69 @@
+// ABOUTME: ent/job/list carries interruptedByLatestRestart out over the wire.
+// ABOUTME: The flag exists so a client can tell a job the restart that just
+// ABOUTME: happened killed from residue left by every earlier restart; dropping
+// ABOUTME: it in the handler would silently restore the old, unreadable list.
+
+import { describe, it, expect, vi } from 'vitest';
+import { registerJobHandlers } from '../jobs';
+import type { JsonRpcPeer } from '@lace/ent-protocol';
+import type { AgentServerState } from '../../../server-types';
+import type { JobRecord } from '../../../jobs/job-manager';
+
+const records: JobRecord[] = [
+  {
+    jobId: 'job_residue',
+    type: 'delegate',
+    status: 'interrupted',
+    startTime: '2026-05-29T00:00:00.000Z',
+    interruptedByLatestRestart: false,
+  },
+  {
+    jobId: 'job_fresh',
+    type: 'delegate',
+    status: 'interrupted',
+    startTime: '2026-08-17T00:00:00.000Z',
+    interruptedByLatestRestart: true,
+  },
+  {
+    jobId: 'job_done',
+    type: 'bash',
+    status: 'completed',
+    startTime: '2026-08-17T00:01:00.000Z',
+  },
+];
+
+async function listJobsOverRpc(): Promise<Array<Record<string, unknown>>> {
+  const handlers = new Map<string, (params: unknown) => Promise<unknown>>();
+  const peer = {
+    onRequest: (method: string, handler: (params: unknown) => Promise<unknown>) => {
+      handlers.set(method, handler);
+    },
+  } as unknown as JsonRpcPeer;
+
+  const state = {
+    initialized: true,
+    activeSession: { sessionId: 'sess_1', dir: '/tmp/sess' },
+    jobManager: { listJobs: vi.fn().mockReturnValue(records) },
+  } as unknown as AgentServerState;
+
+  registerJobHandlers(peer, state);
+  const result = (await handlers.get('ent/job/list')!({})) as {
+    jobs: Array<Record<string, unknown>>;
+  };
+  return result.jobs;
+}
+
+describe('ent/job/list interrupted recency', () => {
+  it('reports which interrupted jobs the latest restart killed', async () => {
+    const byId = new Map((await listJobsOverRpc()).map((j) => [j.jobId as string, j]));
+
+    expect(byId.get('job_fresh')?.interruptedByLatestRestart).toBe(true);
+    expect(byId.get('job_residue')?.interruptedByLatestRestart).toBe(false);
+  });
+
+  it('omits the flag for jobs that were never interrupted', async () => {
+    const byId = new Map((await listJobsOverRpc()).map((j) => [j.jobId as string, j]));
+
+    expect(byId.get('job_done')).not.toHaveProperty('interruptedByLatestRestart');
+  });
+});

--- a/packages/agent/src/rpc/handlers/jobs.ts
+++ b/packages/agent/src/rpc/handlers/jobs.ts
@@ -31,6 +31,9 @@ export function registerJobHandlers(peer: JsonRpcPeer, state: AgentServerState):
       command: j.command,
       startTime: j.startTime,
       ...(j.subagentSessionId ? { subagentSessionId: j.subagentSessionId } : {}),
+      ...(j.interruptedByLatestRestart !== undefined
+        ? { interruptedByLatestRestart: j.interruptedByLatestRestart }
+        : {}),
     }));
 
     return { jobs };

--- a/packages/agent/src/tools/implementations/__tests__/jobs_list-interrupted-recency.test.ts
+++ b/packages/agent/src/tools/implementations/__tests__/jobs_list-interrupted-recency.test.ts
@@ -1,0 +1,62 @@
+// ABOUTME: jobs_list carries the interruptedByLatestRestart flag through to the
+// ABOUTME: agent, so "did I lose work?" is answerable without doing timestamp
+// ABOUTME: arithmetic against every restart in the box's history.
+
+import { describe, it, expect } from 'vitest';
+import { JobsListTool } from '../jobs_list';
+import type { ToolContext } from '../../types';
+import type { JobRecord } from '../../../jobs/job-manager';
+
+const records: JobRecord[] = [
+  {
+    jobId: 'job_residue',
+    type: 'delegate',
+    status: 'interrupted',
+    description: 'orphaned months ago',
+    startTime: '2026-05-29T00:00:00.000Z',
+    interruptedByLatestRestart: false,
+  },
+  {
+    jobId: 'job_fresh',
+    type: 'delegate',
+    status: 'interrupted',
+    description: 'orphaned by the deploy just now',
+    startTime: '2026-08-17T00:00:00.000Z',
+    interruptedByLatestRestart: true,
+  },
+  {
+    jobId: 'job_done',
+    type: 'bash',
+    status: 'completed',
+    description: 'finished cleanly',
+    startTime: '2026-08-17T00:01:00.000Z',
+  },
+];
+
+async function listed(): Promise<Array<Record<string, unknown>>> {
+  const context = { jobManager: { listJobs: () => records } } as unknown as ToolContext;
+  const result = await new JobsListTool().execute({ limit: 50 }, context);
+  const text = result.content.map((c) => ('text' in c ? c.text : '')).join('');
+  return JSON.parse(text.slice(text.indexOf('['), text.lastIndexOf(']') + 1)) as Array<
+    Record<string, unknown>
+  >;
+}
+
+describe('jobs_list interrupted recency', () => {
+  it('reports which interrupted jobs the latest restart killed', async () => {
+    const byId = new Map((await listed()).map((j) => [j.jobId as string, j]));
+
+    expect(byId.get('job_fresh')?.interruptedByLatestRestart).toBe(true);
+    expect(byId.get('job_residue')?.interruptedByLatestRestart).toBe(false);
+  });
+
+  it('omits the flag for jobs that were never interrupted', async () => {
+    const byId = new Map((await listed()).map((j) => [j.jobId as string, j]));
+
+    expect(byId.get('job_done')).not.toHaveProperty('interruptedByLatestRestart');
+  });
+
+  it('tells the agent what the flag means', async () => {
+    expect(new JobsListTool().description).toContain('interruptedByLatestRestart');
+  });
+});

--- a/packages/agent/src/tools/implementations/jobs_list.ts
+++ b/packages/agent/src/tools/implementations/jobs_list.ts
@@ -21,6 +21,7 @@ export class JobsListTool extends Tool {
 
 Filter by status: \`["pending","running","completed","failed","cancelled","interrupted"]\`.
 \`interrupted\` = the job was running when this agent process last stopped; its true outcome is unknown (a delegate's container may even still be working). Treat it as "unverified", not as failed.
+Interrupted jobs are never aged out, so this list holds one for every restart in this box's history. Each carries \`interruptedByLatestRestart\`: \`true\` means the restart that just happened killed it (this is the work you may have just lost), \`false\` means it is residue from an older restart and was already reported at the time.
 Filter by type: \`["bash","delegate"]\`.
 
 Returns: \`[{ jobId, type, status, description, startTime }]\`, **most recent first**. When more jobs match than \`limit\` allows, the result says how many were withheld.`;
@@ -73,6 +74,9 @@ Returns: \`[{ jobId, type, status, description, startTime }]\`, **most recent fi
       status: j.status,
       description: j.description,
       startTime: j.startTime,
+      ...(j.interruptedByLatestRestart !== undefined
+        ? { interruptedByLatestRestart: j.interruptedByLatestRestart }
+        : {}),
     }));
 
     // Name the truncation. Silence here reads as "this is all of them".

--- a/packages/ent-protocol/src/schemas/__tests__/job-interrupted-status.test.ts
+++ b/packages/ent-protocol/src/schemas/__tests__/job-interrupted-status.test.ts
@@ -22,6 +22,27 @@ describe('interrupted job status in job RPC responses', () => {
     expect(() => EntJobListResponseSchema.parse(response)).not.toThrow();
   });
 
+  it('ent/job/list carries which restart generation interrupted a job', () => {
+    // The schema is strict: without the field declared, the recency signal
+    // never reaches the agent at all.
+    const response = {
+      jsonrpc: '2.0' as const,
+      id: 1,
+      result: {
+        jobs: [
+          {
+            jobId: 'job_orphan',
+            type: 'delegate' as const,
+            status: 'interrupted' as const,
+            startTime: '2026-08-12T00:00:00.000Z',
+            interruptedByLatestRestart: false,
+          },
+        ],
+      },
+    };
+    expect(() => EntJobListResponseSchema.parse(response)).not.toThrow();
+  });
+
   it('ent/job/output accepts status interrupted', () => {
     const response = {
       jsonrpc: '2.0' as const,

--- a/packages/ent-protocol/src/schemas/methods.ts
+++ b/packages/ent-protocol/src/schemas/methods.ts
@@ -1583,6 +1583,10 @@ const EntJobListResultSchema = z
           startTime: IsoTimestampSchema,
           parentToolUseId: NonEmptyStringSchema.optional(),
           subagentSessionId: NonEmptyStringSchema.optional(),
+          // Only on 'interrupted' jobs: true when the restart that just
+          // happened orphaned this job, false when it is residue from an
+          // older one. Interrupted jobs are never aged out of the log.
+          interruptedByLatestRestart: z.boolean().optional(),
         })
         .strict()
     ),


### PR DESCRIPTION
Fixes PRI-2902.

## The problem

`applyRunningStatus` marks any job the durable log says is `running` but the in-memory map doesn't know about as `interrupted`, and nothing ever ages those out. So every restart in a box's history leaves permanent residue in `jobs_list`. Observed live: cadence's list held entries five days old; ada's spanned 2026-05-29 to 2026-08-11.

The real risk isn't re-dispatching ancient work. It's that a list which only grows, and where a job orphaned thirty seconds ago is visually identical to one orphaned in May, teaches an agent to ignore it — and `jobs_list` is the one view that answers "did I lose work?". Same failure shape as PRI-2898, which cost eight hours.

## The fix

Make recency machine-readable instead of deleting or hiding data. Interrupted job records now carry `interruptedByLatestRestart`:

- `true` — the restart that just happened is what killed this job.
- `false` — residue from an older restart, already reported at the time.
- absent — the job was never interrupted.

It's derived from the same `<notification kind="session-recovered">` marker PRI-2893 already treats as the crash-generation boundary. `listJobs` counts markers as it parses, stamps each `job_started` with the generation it began in, and compares against the total: a job the latest restart killed was started in the generation just before the marker this process wrote on recovery.

The marker test itself moved into a shared `isSessionRecoveredMarker()` so `listInterruptedJobs` and `listJobs` can't drift on what counts as a restart (the anchored-regex guard against a Slack message quoting the marker string is now shared too).

No job's storage changes and nothing is dropped from the log. The field is optional in the ent-protocol schema (`EntJobListResultSchema` is `.strict()`, so it had to be declared there to reach clients), passed through `ent/job/list`, surfaced in the `jobs_list` tool output, and explained in that tool's description.

## Verification

- `cd packages/agent && npm test` — 353 files / 3499 tests pass, plus the serialized pass at 46 / 276.
- `cd packages/ent-protocol && npm test` — 10 files / 86 tests pass.
- `npx tsc --noEmit` clean for both packages; `prettier` and `eslint` clean on every touched file.

Tests were written first and all failed before the implementation. Each key assertion was then mutation-tested:

| Mutation | Caught by |
| --- | --- |
| `interruptedByLatestRestart` hardcoded `true` | 3 generation tests |
| marker match un-anchored (`includes` instead of the anchored regex) | new quoted-marker test + the existing PRI-2893 one |
| generation count dropped on the `listJobs` cache hit | the cache test |
| field removed from the ent-protocol schema | the schema test |
| passthrough removed from the `jobs_list` tool | the tool test |
| passthrough removed from the `ent/job/list` handler | the handler test |

## Note

`packages/agent/src/providers/outage-survival.test.ts` has two unused-import lint errors on `main` (from ca129e49c), so repo-wide `npm run lint` fails independently of this branch. Left alone to keep this PR scoped.