### PR TITLE
fix(test): drop unused imports that broke lint on main

### DIFF
--- a/packages/agent/src/providers/outage-survival.test.ts
+++ b/packages/agent/src/providers/outage-survival.test.ts
@@ -7,14 +7,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   AIProvider,
-  type ProviderMessage,
-  type ProviderResponse,
-  type WireTool,
-} from './base-provider';
-import {
   OUTAGE_BUDGET_MS,
   OUTAGE_PROBE_AFTER_ATTEMPTS,
   OUTAGE_PROBE_MAX_INTERVAL_MS,
+  type ProviderResponse,
 } from './base-provider';
 
 // A provider whose operation and health probe are both scriptable, so a full


### PR DESCRIPTION
`ca129e49c` (PRI-2901) left `ProviderMessage` and `WireTool` imported but unused in `outage-survival.test.ts`, so `npm run lint` fails on `main` for everyone.

My fault: I validated that commit with prettier, tsc and the full test suite but never ran the repo's own lint. Found by a subagent working an unrelated ticket, who correctly left it alone to keep their PR scoped.

Lint is clean repo-wide with this change; the file's 10 tests still pass.