### PR TITLE
fix(agent): let a session over the context window compact itself out of it (PRI-2903)

### DIFF
--- a/packages/agent/src/compaction/track-compaction.ts
+++ b/packages/agent/src/compaction/track-compaction.ts
@@ -184,6 +184,13 @@ const TAIL_TURNS = 10;
  * the prefix summary), with plenty of headroom for new turns before the next
  * compaction fires. The token-blind 10-turn tail once reached ~600K in
  * production and 400'd every request with `prompt_too_long`.
+ *
+ * Known limitation, tracked separately: this is a FIXED constant, not a
+ * fraction of the running model's context window. On a model with a window
+ * under ~350K the preserved tail alone can still exceed it, so a compaction
+ * cannot get the session back under the limit. The runner's emergency
+ * compaction (PRI-2903) logs loudly when the compacted history is still over
+ * the window rather than retrying indefinitely.
  */
 const TAIL_TOKEN_BUDGET = 300_000;
 

--- a/packages/agent/src/core/conversation/__tests__/runner.emergency-compaction.test.ts
+++ b/packages/agent/src/core/conversation/__tests__/runner.emergency-compaction.test.ts
@@ -10,7 +10,13 @@ import { randomUUID } from 'node:crypto';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ConversationRunner } from '../runner';
 import type { RunnerConfig, RunnerDependencies } from '../types';
-import { invalidatePersonaCache, readDurableEvents } from '@lace/agent/storage/event-log';
+import {
+  appendDurableEvent,
+  invalidatePersonaCache,
+  readDurableEvents,
+} from '@lace/agent/storage/event-log';
+import { readSessionState, writeSessionState } from '@lace/agent/storage/session-store';
+import { injectNotification } from '@lace/agent/notifications/inject-notification';
 import {
   AIProvider,
   type ProviderMessage,
@@ -27,6 +33,9 @@ const CONTEXT_EXCEEDED: ProviderResponse = {
   stopReason: 'context_window_exceeded',
   stopDetails: { type: 'context_window_exceeded', source: 'http_400_prompt_too_long' },
   usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+  // Providers with server-side conversation state hand back a response id that
+  // the runner chains onto the next call.
+  responseId: 'resp_pre_compaction',
 };
 
 const CLEAN_TURN: ProviderResponse = {
@@ -36,12 +45,22 @@ const CLEAN_TURN: ProviderResponse = {
   usage: { promptTokens: 50_000, completionTokens: 10, totalTokens: 50_010 },
 };
 
-/** Scripted provider that records the message list sent on every call. */
+/** Scripted provider that records what was actually sent on every call. */
 class ScriptedProvider extends AIProvider {
   callCount = 0;
   readonly sentMessages: ProviderMessage[][] = [];
+  readonly sentSystemPrompts: string[] = [];
+  readonly sentPreviousResponseIds: (string | undefined)[] = [];
 
-  constructor(private readonly script: ProviderResponse[]) {
+  /**
+   * @param beforeRespond runs before each scripted response is returned, with
+   *   the 0-based call index. Models a peer writing to the durable log while
+   *   the provider call is in flight.
+   */
+  constructor(
+    private readonly script: ProviderResponse[],
+    private readonly beforeRespond?: (callIndex: number) => void
+  ) {
     super();
   }
 
@@ -87,11 +106,14 @@ class ScriptedProvider extends AIProvider {
     _tools: WireTool[],
     _model: string,
     _signal?: AbortSignal,
-    _state?: ConversationState,
+    state?: ConversationState,
     _options?: RequestOptions
   ): Promise<ProviderResponse> {
     this.sentMessages.push(structuredClone(messages));
+    this.sentSystemPrompts.push(this.systemPrompt);
+    this.sentPreviousResponseIds.push(state?.previousResponseId ?? undefined);
     const step = this.script[Math.min(this.callCount, this.script.length - 1)]!;
+    this.beforeRespond?.(this.callCount);
     this.callCount++;
     return step;
   }
@@ -244,7 +266,7 @@ describe('ConversationRunner — emergency compaction on context_window_exceeded
     if (existsSync(cwd)) rmSync(cwd, { recursive: true, force: true });
   });
 
-  function run(provider: AIProvider) {
+  function run(provider: AIProvider, depOverrides: Partial<RunnerDependencies> = {}) {
     const config: RunnerConfig = {
       sessionDir,
       sessionId,
@@ -252,7 +274,7 @@ describe('ConversationRunner — emergency compaction on context_window_exceeded
       executionMode: 'execute',
       approvalMode: 'approve',
     };
-    const deps = createMockDeps(provider);
+    const deps = createMockDeps(provider, depOverrides);
     const runner = new ConversationRunner(config, deps);
     return {
       deps,
@@ -315,15 +337,104 @@ describe('ConversationRunner — emergency compaction on context_window_exceeded
     expect(retryText.split('kind="emergency-compaction"')).toHaveLength(2);
   });
 
-  it('compacts at most once per turn: a second rejection fails the turn', async () => {
-    const provider = new ScriptedProvider([CONTEXT_EXCEEDED, CONTEXT_EXCEEDED]);
+  it('gives up rather than looping when compaction cannot get back under the window', async () => {
+    // A provider that NEVER stops rejecting. The emergency budget is the only
+    // thing that can stop this — the retry cancels the loop's turn increment,
+    // so maxTurns cannot backstop it. Without a hard bound this run never ends.
+    const provider = new ScriptedProvider([CONTEXT_EXCEEDED]);
     const { promise } = run(provider);
     const result = await promise;
 
-    expect(provider.callCount).toBe(2);
     expect(result.stopReason).toBe('context_window_exceeded');
     expect(result.stopDetails).toEqual(CONTEXT_EXCEEDED.stopDetails);
-    expect(durableEvents().filter((e) => e.type === 'context_compacted')).toHaveLength(1);
+    // Follows from MAX_EMERGENCY_COMPACTIONS = 2: two compactions are spent,
+    // and the third rejection has no budget left, so it ends the turn.
+    expect(durableEvents().filter((e) => e.type === 'context_compacted')).toHaveLength(2);
+    expect(provider.callCount).toBe(3);
+  });
+
+  it('delivers a peer inject that lands during the compaction exactly once', async () => {
+    // A Slack message or job completion arriving while the oversized call is
+    // failing (10.7s in the live incident) is folded into the rebuilt
+    // projection AND sits past the inject tailer's pre-call watermark. If the
+    // tailer is not re-seeded on the rebuild, the model sees it twice.
+    const marker = 'PEER-INJECT-DURING-COMPACTION';
+    const provider = new ScriptedProvider([CONTEXT_EXCEEDED, CLEAN_TURN], (callIndex) => {
+      if (callIndex !== 0) return;
+      injectNotification({
+        sessionDir,
+        kind: 'job-completed',
+        body: marker,
+      });
+    });
+    await run(provider).promise;
+
+    expect(provider.callCount).toBe(2);
+    const retryText = messagesAsText(provider.sentMessages[1]!);
+    expect(retryText).toContain(marker);
+    expect(retryText.split(marker)).toHaveLength(2);
+  });
+
+  it('does not glue pre-compaction partial generation onto the recovered answer', async () => {
+    // pause_turn accumulates text across iterations for a single durable
+    // 'message' event. If the emergency retry does not clear that accumulator,
+    // the partial the model produced against the OLD context is concatenated
+    // onto the answer it produces against the compacted one, and that
+    // corrupted splice is what gets persisted.
+    const partial = 'PARTIAL-PRECOMPACTION-TEXT';
+    const provider = new ScriptedProvider([
+      {
+        content: partial,
+        toolCalls: [],
+        stopReason: 'pause_turn',
+        usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      },
+      CONTEXT_EXCEEDED,
+      CLEAN_TURN,
+    ]);
+    const { promise } = run(provider);
+    const result = await promise;
+
+    expect(result.stopReason).toBe('end_turn');
+    const answer = CLEAN_TURN.content as string;
+    expect(result.content).toEqual([{ type: 'text', text: answer }]);
+
+    const messages = durableEvents().filter(
+      (e) => e.type === 'message' && JSON.stringify(e.data).includes(answer)
+    );
+    expect(messages).toHaveLength(1);
+    expect(JSON.stringify(messages[0]!.data)).not.toContain(partial);
+  });
+
+  it('drops the pre-compaction response chain on the retry', async () => {
+    // previousResponseId identifies a server-side conversation keyed to the
+    // message list we just replaced.
+    const provider = new ScriptedProvider([CONTEXT_EXCEEDED, CLEAN_TURN]);
+    await run(provider).promise;
+
+    expect(provider.sentPreviousResponseIds[0]).toBeUndefined();
+    expect(provider.sentPreviousResponseIds[1]).toBeUndefined();
+  });
+
+  it('retries with the system prompt the compaction re-rendered', async () => {
+    // Compaction re-renders the persona, which can write a new
+    // system_prompt_set. The retry must send the new one, not the prompt the
+    // turn started with.
+    const rerenderedPrompt = 'You are a test assistant, re-rendered after compaction.';
+    const provider = new ScriptedProvider([CONTEXT_EXCEEDED, CLEAN_TURN]);
+    await run(provider, {
+      rerenderPersonaAfterCompaction: vi.fn().mockImplementation(async () => {
+        const state = readSessionState(sessionDir);
+        const { nextState } = appendDurableEvent(sessionDir, state, {
+          type: 'system_prompt_set',
+          data: { type: 'system_prompt_set', text: rerenderedPrompt },
+        });
+        writeSessionState(sessionDir, nextState);
+      }),
+    }).promise;
+
+    expect(provider.sentSystemPrompts[0]).toBe('You are a test assistant.');
+    expect(provider.sentSystemPrompts[1]).toBe(rerenderedPrompt);
   });
 
   it('does not compact when the turn never exceeds the window', async () => {

--- a/packages/agent/src/core/conversation/__tests__/runner.emergency-compaction.test.ts
+++ b/packages/agent/src/core/conversation/__tests__/runner.emergency-compaction.test.ts
@@ -1,0 +1,338 @@
+// ABOUTME: Tests the emergency compaction self-heal (PRI-2903) — a turn that the
+// ABOUTME: provider rejects with context_window_exceeded compacts the session,
+// ABOUTME: tells the agent it happened, and retries the turn exactly once. A
+// ABOUTME: second rejection surfaces as a failed turn rather than compacting again.
+
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ConversationRunner } from '../runner';
+import type { RunnerConfig, RunnerDependencies } from '../types';
+import { invalidatePersonaCache, readDurableEvents } from '@lace/agent/storage/event-log';
+import {
+  AIProvider,
+  type ProviderMessage,
+  type ProviderResponse,
+  type ConversationState,
+  type RequestOptions,
+  type WireTool,
+} from '@lace/agent/providers/base-provider';
+import { resetRegistriesForTest } from '@lace/agent/plugins';
+
+const CONTEXT_EXCEEDED: ProviderResponse = {
+  content: '',
+  toolCalls: [],
+  stopReason: 'context_window_exceeded',
+  stopDetails: { type: 'context_window_exceeded', source: 'http_400_prompt_too_long' },
+  usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+};
+
+const CLEAN_TURN: ProviderResponse = {
+  content: 'Recovered and answered.',
+  toolCalls: [],
+  stopReason: 'end_turn',
+  usage: { promptTokens: 50_000, completionTokens: 10, totalTokens: 50_010 },
+};
+
+/** Scripted provider that records the message list sent on every call. */
+class ScriptedProvider extends AIProvider {
+  callCount = 0;
+  readonly sentMessages: ProviderMessage[][] = [];
+
+  constructor(private readonly script: ProviderResponse[]) {
+    super();
+  }
+
+  get providerName(): string {
+    return 'scripted-emergency-compaction';
+  }
+
+  getProviderInfo() {
+    return {
+      name: 'scripted-emergency-compaction',
+      displayName: 'Scripted Emergency Compaction',
+      requiresApiKey: false,
+    };
+  }
+
+  isConfigured(): boolean {
+    return true;
+  }
+
+  get supportsStreaming(): boolean {
+    return true;
+  }
+
+  // Large window so ordinary pressure breakpoints never fire — the only
+  // compaction these tests can observe is the emergency one.
+  override contextWindowForModel(_modelId: string, _fallback?: number): number {
+    return 1_000_000;
+  }
+
+  protected async _createResponseImpl(
+    messages: ProviderMessage[],
+    tools: WireTool[],
+    model: string,
+    signal?: AbortSignal,
+    state?: ConversationState,
+    options?: RequestOptions
+  ): Promise<ProviderResponse> {
+    return this._createStreamingResponseImpl(messages, tools, model, signal, state, options);
+  }
+
+  protected async _createStreamingResponseImpl(
+    messages: ProviderMessage[],
+    _tools: WireTool[],
+    _model: string,
+    _signal?: AbortSignal,
+    _state?: ConversationState,
+    _options?: RequestOptions
+  ): Promise<ProviderResponse> {
+    this.sentMessages.push(structuredClone(messages));
+    const step = this.script[Math.min(this.callCount, this.script.length - 1)]!;
+    this.callCount++;
+    return step;
+  }
+}
+
+function createMockDeps(
+  provider: AIProvider,
+  overrides: Partial<RunnerDependencies> = {}
+): RunnerDependencies {
+  const mockJobManager = {
+    getJob: vi.fn().mockReturnValue(undefined),
+    listJobs: vi.fn().mockReturnValue([]),
+    getJobOutput: vi.fn().mockReturnValue(''),
+    createJob: vi
+      .fn()
+      .mockResolvedValue({ jobId: 'job_test', job: { completion: Promise.resolve() } }),
+    cancelJob: vi.fn().mockResolvedValue(undefined),
+    finalizeJob: vi.fn().mockResolvedValue(undefined),
+    getStreamingMode: vi.fn().mockReturnValue('full'),
+    setStreamingMode: vi.fn(),
+    getRunningJobs: vi.fn().mockReturnValue([]),
+  };
+
+  return {
+    onUpdate: vi.fn().mockResolvedValue(undefined),
+    runExclusive: vi
+      .fn()
+      .mockImplementation(<T>(fn: () => T | Promise<T>) => Promise.resolve(fn())),
+    requestPermission: vi.fn().mockResolvedValue({ decision: 'allow' }),
+    createToolExecutor: vi.fn().mockResolvedValue({
+      executor: {
+        getTool: vi.fn().mockReturnValue(undefined),
+        execute: vi.fn().mockResolvedValue({ status: 'completed', content: [] }),
+      },
+      toolsForProvider: [],
+    }),
+    createProvider: vi.fn().mockResolvedValue(provider),
+    getModelPricing: vi.fn().mockResolvedValue(null),
+    startShellJob: vi.fn().mockResolvedValue({ jobId: 'job_test' }),
+    jobManager: mockJobManager as unknown as RunnerDependencies['jobManager'],
+    mcpServerManager: undefined,
+    setActiveTurnStatus: vi.fn(),
+    getSessionCostUsd: vi.fn().mockReturnValue(0),
+    updateSessionUsage: vi.fn(),
+    ...overrides,
+  };
+}
+
+/** Flatten a sent message list to the plain text the model would actually read. */
+function messagesAsText(messages: ProviderMessage[]): string {
+  const parts: string[] = [];
+  for (const m of messages) {
+    const content = m.content as unknown;
+    if (typeof content === 'string') parts.push(content);
+    else if (Array.isArray(content)) {
+      for (const block of content as Array<{ text?: unknown }>) {
+        if (typeof block?.text === 'string') parts.push(block.text);
+      }
+    }
+  }
+  return parts.join('\n');
+}
+
+describe('ConversationRunner — emergency compaction on context_window_exceeded', () => {
+  let laceDir: string;
+  let sessionDir: string;
+  let sessionId: string;
+  let cwd: string;
+  let savedLaceDir: string | undefined;
+
+  beforeEach(() => {
+    laceDir = mkdtempSync(join(tmpdir(), 'lace-emergency-compaction-test-'));
+    sessionId = `sess_${randomUUID()}`;
+    sessionDir = join(laceDir, 'agent-sessions', sessionId);
+    cwd = join(tmpdir(), `lace-emergency-compaction-cwd-${randomUUID().substring(0, 8)}`);
+    mkdirSync(sessionDir, { recursive: true });
+    mkdirSync(cwd, { recursive: true });
+
+    // Seed enough completed turns that the track-based strategy produces a real
+    // compaction event rather than a noop.
+    const now = new Date().toISOString();
+    const lines: string[] = [
+      JSON.stringify({
+        eventSeq: 1,
+        timestamp: now,
+        type: 'system_prompt_set',
+        data: { type: 'system_prompt_set', text: 'You are a test assistant.' },
+      }),
+    ];
+    let seq = 2;
+    for (let i = 0; i < 11; i++) {
+      const tid = `pre_turn_${i}`;
+      lines.push(
+        JSON.stringify({
+          eventSeq: seq++,
+          timestamp: now,
+          type: 'prompt',
+          data: { type: 'prompt', content: [{ type: 'text', text: `seed prompt ${i}` }] },
+        })
+      );
+      lines.push(
+        JSON.stringify({
+          eventSeq: seq++,
+          timestamp: now,
+          turnId: tid,
+          type: 'turn_start',
+          data: { type: 'turn_start' },
+        })
+      );
+      lines.push(
+        JSON.stringify({
+          eventSeq: seq++,
+          timestamp: now,
+          turnId: tid,
+          type: 'message',
+          data: { type: 'message', content: [{ type: 'text', text: `seed answer ${i}` }] },
+        })
+      );
+      lines.push(
+        JSON.stringify({
+          eventSeq: seq++,
+          timestamp: now,
+          turnId: tid,
+          type: 'turn_end',
+          data: { type: 'turn_end', stopReason: 'end_turn' },
+        })
+      );
+    }
+
+    writeFileSync(join(sessionDir, 'events.jsonl'), lines.join('\n') + '\n');
+    writeFileSync(
+      join(sessionDir, 'state.json'),
+      JSON.stringify({ nextEventSeq: seq, nextStreamSeq: 1 })
+    );
+    writeFileSync(
+      join(sessionDir, 'meta.json'),
+      JSON.stringify({ sessionId, workDir: cwd, created: now, persona: 'test' })
+    );
+
+    savedLaceDir = process.env.LACE_DIR;
+    process.env.LACE_DIR = laceDir;
+    invalidatePersonaCache();
+    resetRegistriesForTest();
+  });
+
+  afterEach(() => {
+    if (savedLaceDir === undefined) delete process.env.LACE_DIR;
+    else process.env.LACE_DIR = savedLaceDir;
+    if (existsSync(laceDir)) rmSync(laceDir, { recursive: true, force: true });
+    if (existsSync(cwd)) rmSync(cwd, { recursive: true, force: true });
+  });
+
+  function run(provider: AIProvider) {
+    const config: RunnerConfig = {
+      sessionDir,
+      sessionId,
+      cwd,
+      executionMode: 'execute',
+      approvalMode: 'approve',
+    };
+    const deps = createMockDeps(provider);
+    const runner = new ConversationRunner(config, deps);
+    return {
+      deps,
+      promise: runner.run({
+        content: [{ type: 'text', text: 'the prompt that overflowed the window' }],
+        abortController: new AbortController(),
+        turnId: `turn_${randomUUID()}`,
+        startedAt: new Date().toISOString(),
+      }),
+    };
+  }
+
+  function durableEvents() {
+    return readDurableEvents(sessionDir, { limit: Number.MAX_SAFE_INTEGER }).events;
+  }
+
+  it('compacts and retries the turn once, so the turn completes', async () => {
+    const provider = new ScriptedProvider([CONTEXT_EXCEEDED, CLEAN_TURN]);
+    const { promise } = run(provider);
+    const result = await promise;
+
+    expect(provider.callCount).toBe(2);
+    expect(result.stopReason).toBe('end_turn');
+    expect(durableEvents().filter((e) => e.type === 'context_compacted')).toHaveLength(1);
+  });
+
+  it('sends the COMPACTED history on the retry, not the history that just 400d', async () => {
+    const provider = new ScriptedProvider([CONTEXT_EXCEEDED, CLEAN_TURN]);
+    await run(provider).promise;
+
+    const [first, second] = provider.sentMessages;
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+    // The whole point: the retry must not re-send the oversized conversation.
+    // The compacted history replaces the seeded turns with a summary, so it is
+    // strictly shorter than what the provider just rejected.
+    expect(second!.length).toBeLessThan(first!.length);
+    // The oldest turns are no longer sent verbatim; they arrive as a summary.
+    expect(messagesAsText(first!)).not.toContain('compacted by track');
+    expect(messagesAsText(second!)).toContain('compacted by track');
+  });
+
+  it('tells the agent an emergency compaction ran, in the retry request itself', async () => {
+    const provider = new ScriptedProvider([CONTEXT_EXCEEDED, CLEAN_TURN]);
+    await run(provider).promise;
+
+    // Durable, so the notice survives a restart and future turns.
+    const injected = durableEvents().filter(
+      (e) =>
+        e.type === 'context_injected' &&
+        JSON.stringify(e.data).includes('kind=\\"emergency-compaction\\"')
+    );
+    expect(injected).toHaveLength(1);
+
+    // Delivered: the agent sees the explanation on the very turn that lost the
+    // history, not one turn later.
+    const retryText = messagesAsText(provider.sentMessages[1]!);
+    expect(retryText).toContain('kind="emergency-compaction"');
+    // Exactly once — the projection and the inject tailer must not both add it.
+    expect(retryText.split('kind="emergency-compaction"')).toHaveLength(2);
+  });
+
+  it('compacts at most once per turn: a second rejection fails the turn', async () => {
+    const provider = new ScriptedProvider([CONTEXT_EXCEEDED, CONTEXT_EXCEEDED]);
+    const { promise } = run(provider);
+    const result = await promise;
+
+    expect(provider.callCount).toBe(2);
+    expect(result.stopReason).toBe('context_window_exceeded');
+    expect(result.stopDetails).toEqual(CONTEXT_EXCEEDED.stopDetails);
+    expect(durableEvents().filter((e) => e.type === 'context_compacted')).toHaveLength(1);
+  });
+
+  it('does not compact when the turn never exceeds the window', async () => {
+    const provider = new ScriptedProvider([CLEAN_TURN]);
+    await run(provider).promise;
+
+    expect(durableEvents().filter((e) => e.type === 'context_compacted')).toHaveLength(0);
+    expect(
+      durableEvents().filter((e) => JSON.stringify(e.data).includes('emergency-compaction'))
+    ).toHaveLength(0);
+  });
+});

--- a/packages/agent/src/core/conversation/runner.ts
+++ b/packages/agent/src/core/conversation/runner.ts
@@ -631,6 +631,11 @@ export class ConversationRunner {
     let partialThinkingBlocks: ThinkingBlock[] = [];
     let pauseResumeCount = 0;
 
+    // Emergency-compaction budget for this turn: exactly one compact + retry on
+    // context_window_exceeded. See the call site for why a second rejection
+    // must fail loudly instead of compacting again.
+    let emergencyCompactionUsed = false;
+
     // Per-turn compaction request cell. compact_session mutates this during
     // tool execution; the post-turn block reads it to decide whether to fire.
     // A single shared object is used so the tool (which receives the same
@@ -1038,6 +1043,89 @@ export class ConversationRunner {
             });
         }
 
+        // Emergency compaction self-heal. The provider has told us outright
+        // that the prompt no longer fits — the most explicit context-pressure
+        // signal there is, and on this session the ONLY one we will ever get:
+        // ordinary pressure is computed from the usage on a SUCCESSFUL
+        // response, and over the window nothing succeeds. That is the trap
+        // (PRI-2903) — the one mechanism that could rescue the session needed
+        // the session to be healthy enough to make a request, so it never
+        // fired and the coworker stayed wedged across restarts. So compact
+        // here, mid-turn, and retry the turn once.
+        //
+        // Bounded to a single attempt per turn: `emergencyCompactionUsed` makes
+        // a second context_window_exceeded fall through to the terminal break
+        // below and surface as a failed turn rather than looping.
+        if (stopReason === 'context_window_exceeded' && !emergencyCompactionUsed) {
+          emergencyCompactionUsed = true;
+          let compacted = false;
+          try {
+            compacted = await this.compactSession({
+              modelId,
+              updateTurnSeq: durableTurnSeq,
+            });
+          } catch (compactionErr) {
+            // Nothing to fall back to — let the terminal break surface the
+            // original context_window_exceeded to the caller.
+            logger.error('runner: emergency compaction failed', {
+              err: compactionErr instanceof Error ? compactionErr.message : String(compactionErr),
+              turnId,
+              sessionId,
+            });
+          }
+          if (compacted) {
+            // Rebuild the message prefix from the now-compacted log. Every
+            // in-memory mutation made earlier this turn is discarded on
+            // purpose: the events behind them are folded into the compacted
+            // projection, and re-applying them would resurrect the history we
+            // just summarized away.
+            const compactedEntry = projectionCache
+              ? projectTurnEntry(
+                  sessionDir,
+                  runtimeBinding.toolRuntime.cwd,
+                  projectionCache,
+                  sessionId
+                )
+              : loadTurnEntryProjection(sessionDir, runtimeBinding.toolRuntime.cwd);
+            providerMessages = compactedEntry.messages;
+            if (compactedEntry.systemPrompt) {
+              // rerenderPersonaAfterCompaction may have written a new
+              // system_prompt_set; the retry should use it.
+              provider.setSystemPrompt(compactedEntry.systemPrompt);
+            }
+            // Say what happened. The agent notices the memory gap regardless,
+            // and an unexplained gap is worse than an explained one. Written as
+            // a durable context_injected event and NOT appended in-memory here:
+            // the tailer at the top of the next iteration picks it up exactly
+            // once, and it survives into later turns.
+            await this.deps.runExclusive(() => {
+              injectNotification({
+                sessionDir,
+                kind: 'emergency-compaction',
+                body:
+                  'Your conversation exceeded the model context window, so an emergency' +
+                  ' compaction just ran and older history was replaced with a summary.' +
+                  ' If you find a gap in what you remember, that is why — re-read files,' +
+                  ' tickets, or transcripts rather than trusting recall for anything from' +
+                  ' earlier in this session.',
+              });
+            });
+            // A server-side response chain describes the pre-compaction message
+            // list; it no longer matches what we are about to send.
+            lastResponseId = undefined;
+            stopReason = 'end_turn';
+            stopDetails = null;
+            logger.warn('runner: emergency compaction after context_window_exceeded, retrying', {
+              turnId,
+              sessionId,
+            });
+            // The retry is the same logical turn, so cancel the for-loop's
+            // increment (mirroring the pause_turn resume path).
+            completedTurns--;
+            continue;
+          }
+        }
+
         // Terminal provider stops (refusal / context_window_exceeded /
         // max_output_tokens / stop_sequence) exit the loop here. budget_exceeded
         // is set ABOVE the switch on every iteration; it is intentionally
@@ -1362,58 +1450,11 @@ export class ConversationRunner {
         }
 
         if (compactionRequest.requested || breakpointCompactCrossed) {
-          const allEvents = readDurableEvents(sessionDir, {
-            limit: Number.MAX_SAFE_INTEGER,
-          }).events;
-          const strategyName = this.config.persona
-            ? compactionStrategyNameForSession(sessionDir)
-            : 'track-based';
-          const strategy = resolveCompactionStrategy(strategyName);
-          const compactionCtx = buildCompactionContext({
-            threadId: sessionId,
-            sessionDir,
-            connectionId: this.config.connectionId,
-            modelId: modelId ?? undefined,
+          await this.compactSession({
+            modelId,
             guidance: compactionRequest.guidance,
+            updateTurnSeq: durableTurnSeq,
           });
-          const raw = await strategy.compact(
-            // DurableEvent.data is Record<string,unknown>; TypedDurableEvent.data
-            // is the typed union. The shapes are identical on disk — this cast is
-            // safe because the event-log writer and event-types agree on the wire
-            // format.
-            allEvents as unknown as TypedDurableEvent[],
-            compactionCtx
-          );
-          const result = validatePreserved(raw);
-          if (!('noop' in result)) {
-            await this.deps.runExclusive(async () => {
-              const sessionState = readSessionState(sessionDir);
-              const { nextState } = appendDurableEvent(sessionDir, sessionState, {
-                type: 'context_compacted',
-                // ContextCompactedEventData satisfies Record<string,unknown>; the
-                // cast here is the symmetric inverse of the one above.
-                data: result.compactionEvent.data as Record<string, unknown>,
-              });
-              writeSessionState(sessionDir, nextState);
-              // Re-render the persona (model + system prompt) from the current
-              // persona file so the compacted session reflects the live persona.
-              await this.deps.rerenderPersonaAfterCompaction?.();
-            });
-            // Notify clients that an in-place compaction ran, mirroring the
-            // ent/session/compact handler's compaction_complete emit. sen-core's
-            // post-compaction wake keys on this update; without it, breakpoint
-            // and compact_session compactions strand in-flight work (PRI-2889).
-            // Emitted OUTSIDE the runExclusive section above: onUpdate takes the
-            // same mutex, and nesting it would deadlock.
-            await this.deps.onUpdate(durableTurnSeq, {
-              type: 'compaction_complete',
-              strategy: strategyName,
-              messagesCompacted:
-                typeof result.compactionEvent.data.messagesCompacted === 'number'
-                  ? result.compactionEvent.data.messagesCompacted
-                  : 0,
-            });
-          }
         }
       } catch (compactionErr) {
         logger.error('runner: compaction failed', {
@@ -1451,6 +1492,78 @@ export class ConversationRunner {
       ...(lastStructuredOutput !== undefined ? { structuredOutput: lastStructuredOutput } : {}),
       lastSeenEventSeq,
     };
+  }
+
+  /**
+   * Run one compaction pass over the session's durable log, persisting the
+   * resulting `context_compacted` event and telling clients it happened.
+   * Returns true when the log was actually compacted; a strategy noop (nothing
+   * worth summarizing) returns false and writes nothing.
+   *
+   * Shared by the two triggers: the post-turn one in run()'s finally block
+   * (persona breakpoints and the compact_session tool) and the mid-turn
+   * emergency one that fires on context_window_exceeded.
+   */
+  private async compactSession(params: {
+    modelId?: string;
+    guidance?: string;
+    /** Stream seq for the compaction_complete update. */
+    updateTurnSeq: number;
+  }): Promise<boolean> {
+    const { sessionDir, sessionId } = this.config;
+    const allEvents = readDurableEvents(sessionDir, {
+      limit: Number.MAX_SAFE_INTEGER,
+    }).events;
+    const strategyName = this.config.persona
+      ? compactionStrategyNameForSession(sessionDir)
+      : 'track-based';
+    const strategy = resolveCompactionStrategy(strategyName);
+    const compactionCtx = buildCompactionContext({
+      threadId: sessionId,
+      sessionDir,
+      connectionId: this.config.connectionId,
+      modelId: params.modelId ?? undefined,
+      guidance: params.guidance,
+    });
+    const raw = await strategy.compact(
+      // DurableEvent.data is Record<string,unknown>; TypedDurableEvent.data
+      // is the typed union. The shapes are identical on disk — this cast is
+      // safe because the event-log writer and event-types agree on the wire
+      // format.
+      allEvents as unknown as TypedDurableEvent[],
+      compactionCtx
+    );
+    const result = validatePreserved(raw);
+    if ('noop' in result) return false;
+
+    await this.deps.runExclusive(async () => {
+      const sessionState = readSessionState(sessionDir);
+      const { nextState } = appendDurableEvent(sessionDir, sessionState, {
+        type: 'context_compacted',
+        // ContextCompactedEventData satisfies Record<string,unknown>; the
+        // cast here is the symmetric inverse of the one above.
+        data: result.compactionEvent.data as Record<string, unknown>,
+      });
+      writeSessionState(sessionDir, nextState);
+      // Re-render the persona (model + system prompt) from the current
+      // persona file so the compacted session reflects the live persona.
+      await this.deps.rerenderPersonaAfterCompaction?.();
+    });
+    // Notify clients that an in-place compaction ran, mirroring the
+    // ent/session/compact handler's compaction_complete emit. sen-core's
+    // post-compaction wake keys on this update; without it, breakpoint
+    // and compact_session compactions strand in-flight work (PRI-2889).
+    // Emitted OUTSIDE the runExclusive section above: onUpdate takes the
+    // same mutex, and nesting it would deadlock.
+    await this.deps.onUpdate(params.updateTurnSeq, {
+      type: 'compaction_complete',
+      strategy: strategyName,
+      messagesCompacted:
+        typeof result.compactionEvent.data.messagesCompacted === 'number'
+          ? result.compactionEvent.data.messagesCompacted
+          : 0,
+    });
+    return true;
   }
 
   /**

--- a/packages/agent/src/core/conversation/runner.ts
+++ b/packages/agent/src/core/conversation/runner.ts
@@ -49,6 +49,7 @@ import { EntErrorCodes } from '@lace/ent-protocol';
 import { logger } from '@lace/agent/utils/logger';
 import { buildCacheHealthLog } from '@lace/agent/core/conversation/cache-health';
 import { computePressure, evaluateBreakpoints } from './compaction-trigger';
+import { estimateProviderTokens } from '@lace/agent/message-building/message-builder';
 import { resolveCompactionStrategy, validatePreserved } from '@lace/agent/compaction/strategy';
 import {
   compactionStrategyNameForSession,
@@ -239,6 +240,24 @@ const FUTURE_TENSE_INTENT_PATTERN =
  * `code: 'pause_turn_loop'`.
  */
 const MAX_PAUSE_RESUMES = 10;
+
+/**
+ * Safety bound on emergency compactions within a single `run()`. The runner
+ * compacts and retries when the provider rejects the prompt with
+ * `context_window_exceeded` (PRI-2903); this caps how often that can happen
+ * before the stop surfaces to the caller as a failed turn.
+ *
+ * Two, not one: a long agentic run can legitimately grow back over the window
+ * after healing once, and refusing to heal the second time re-wedges the
+ * session this exists to rescue. It must stay a hard numeric bound rather than
+ * a flag, because the emergency retry cancels the loop's `completedTurns`
+ * increment — so `maxTurns` cannot backstop it, and this counter is the only
+ * thing standing between a permanently-oversized session and an infinite
+ * compact/retry loop. Back-to-back overflows are usually cut short earlier
+ * anyway: re-compacting an already-compacted log returns a noop, which falls
+ * through to the terminal stop.
+ */
+const MAX_EMERGENCY_COMPACTIONS = 2;
 
 const CLEAN_STOP_REASONS = new Set(['end_turn', 'stop_sequence', 'max_turns']);
 
@@ -584,7 +603,9 @@ export class ConversationRunner {
     // Key the tailer off the on-disk session-id (the transcript shards' basename),
     // which is what the durable log is written under — matching the full-scan
     // reader, whose sessionDir basename drives shard discovery.
-    const injectTailer = createInjectTailer(getLaceDir(), basename(sessionDir), lastSeenEventSeq);
+    // Re-seeded (not just re-read) after an emergency compaction rebuilds the
+    // projection — see the emergency arm below.
+    let injectTailer = createInjectTailer(getLaceDir(), basename(sessionDir), lastSeenEventSeq);
     let finalAssistantContent = '';
     let stopReason: RunResult['stopReason'] = 'end_turn';
     let stopDetails: LaceStopDetails | null = null;
@@ -631,10 +652,8 @@ export class ConversationRunner {
     let partialThinkingBlocks: ThinkingBlock[] = [];
     let pauseResumeCount = 0;
 
-    // Emergency-compaction budget for this turn: exactly one compact + retry on
-    // context_window_exceeded. See the call site for why a second rejection
-    // must fail loudly instead of compacting again.
-    let emergencyCompactionUsed = false;
+    // Emergency-compaction budget for this run() — see MAX_EMERGENCY_COMPACTIONS.
+    let emergencyCompactions = 0;
 
     // Per-turn compaction request cell. compact_session mutates this during
     // tool execution; the post-turn block reads it to decide whether to fire.
@@ -1051,13 +1070,17 @@ export class ConversationRunner {
         // (PRI-2903) — the one mechanism that could rescue the session needed
         // the session to be healthy enough to make a request, so it never
         // fired and the coworker stayed wedged across restarts. So compact
-        // here, mid-turn, and retry the turn once.
+        // here, mid-turn, and retry the turn.
         //
-        // Bounded to a single attempt per turn: `emergencyCompactionUsed` makes
-        // a second context_window_exceeded fall through to the terminal break
-        // below and surface as a failed turn rather than looping.
-        if (stopReason === 'context_window_exceeded' && !emergencyCompactionUsed) {
-          emergencyCompactionUsed = true;
+        // Bounded by MAX_EMERGENCY_COMPACTIONS per run(): once the budget is
+        // spent, a further context_window_exceeded falls through to the
+        // terminal break below and surfaces as a failed turn rather than
+        // looping.
+        if (
+          stopReason === 'context_window_exceeded' &&
+          emergencyCompactions < MAX_EMERGENCY_COMPACTIONS
+        ) {
+          emergencyCompactions++;
           let compacted = false;
           try {
             compacted = await this.compactSession({
@@ -1074,11 +1097,14 @@ export class ConversationRunner {
             });
           }
           if (compacted) {
-            // Rebuild the message prefix from the now-compacted log. Every
-            // in-memory mutation made earlier this turn is discarded on
-            // purpose: the events behind them are folded into the compacted
-            // projection, and re-applying them would resurrect the history we
-            // just summarized away.
+            // Rebuild the message prefix from the now-compacted log. The
+            // per-turn in-memory mutations made before this point (loop
+            // reminders, tool-choice nudges, appended tool results, injects
+            // picked up earlier this turn) are dropped on purpose: the durable
+            // events behind them are folded into the compacted projection, and
+            // re-applying them would resurrect the history we just summarized
+            // away. The mutable per-turn state that is NOT part of
+            // providerMessages is reset explicitly below.
             const compactedEntry = projectionCache
               ? projectTurnEntry(
                   sessionDir,
@@ -1092,6 +1118,47 @@ export class ConversationRunner {
               // rerenderPersonaAfterCompaction may have written a new
               // system_prompt_set; the retry should use it.
               provider.setSystemPrompt(compactedEntry.systemPrompt);
+            }
+            // Re-seed the inject tailer at the rebuilt projection's watermark.
+            // The rebuild folded EVERY logged event, including any peer
+            // context_injected that landed while the oversized call was failing
+            // and the compaction was running (10.7s in the live incident — long
+            // enough for a Slack message or a job completion). Without the
+            // re-seed the old tailer, still holding its pre-call watermark,
+            // re-emits that inject at the top of the retry iteration and the
+            // model sees it twice. Same phantom-double the between-turn seeding
+            // above exists to prevent.
+            lastSeenEventSeq = compactedEntry.maxFoldedSeq;
+            injectTailer = createInjectTailer(
+              getLaceDir(),
+              basename(sessionDir),
+              compactedEntry.maxFoldedSeq
+            );
+            // A tail of pre-compaction generation must not be glued onto the
+            // post-compaction answer. `pause_turn` accumulates text and
+            // thinking across iterations for a single durable 'message' event,
+            // and the terminal-stop switch arm above does not reset them — so a
+            // turn that paused, then overflowed, would persist
+            // "<partial><recovered answer>" as one message.
+            partialAssistantText = '';
+            partialThinkingBlocks = [];
+            pauseResumeCount = 0;
+            // The compacted history is the whole point of the retry. If it is
+            // STILL over the window, the retry will 400 again and the session
+            // churns — the tail budget in track-compaction is a fixed constant,
+            // not a function of this model's window, so that is reachable on
+            // any model with a window under ~350K. Say so loudly; the retry
+            // still runs, and the emergency budget bounds the churn.
+            const compactedEstimate = estimateProviderTokens(providerMessages);
+            const windowSize = provider.contextWindowForModel(modelId ?? 'default');
+            if (compactedEstimate >= windowSize) {
+              logger.error('runner: compacted history STILL exceeds the context window', {
+                turnId,
+                sessionId,
+                compactedEstimate,
+                windowSize,
+                modelId,
+              });
             }
             // Say what happened. The agent notices the memory gap regardless,
             // and an unexplained gap is worse than an explained one. Written as

--- a/packages/agent/src/notifications/notification-wrapper.ts
+++ b/packages/agent/src/notifications/notification-wrapper.ts
@@ -11,6 +11,7 @@ export type NotificationKind =
   | 'job-stalled'
   | 'subagent-exited'
   | 'compaction-pressure'
+  | 'emergency-compaction'
   | 'session-recovered';
 
 export interface BuildNotificationOptions {


### PR DESCRIPTION
Fixes PRI-2903.

## The trap

A session whose conversation exceeds the provider context window could never recover. Compaction is triggered by context *pressure*, and pressure is computed from usage on a **successful** response. Once the prompt is over the window nothing succeeds, so no pressure is ever observed, so the one mechanism that could rescue the session never fires. Restarting reloads the same oversized session.

Observed live on cadence-sen (2026-08-17): seven `context_window_exceeded` errors in 90 minutes, zero compaction attempts, `messageCount` creeping 352 -> 366 because each failed attempt still appends. Recovery was a manual operator procedure on a live box.

## The fix

Treat `stopReason: context_window_exceeded` as a **direct compaction trigger** — the server has stated the problem explicitly, which beats a pressure figure we will never receive. Compact mid-turn, then retry the turn **once**.

This is safe because the `track-based` strategy never sends the oversized conversation: it summarizes per-conversation with haiku, and short transcripts skip the LLM entirely. Verified by spike, and live (494,340 -> 384,936 tokens in 10.7s).

The retry also injects `<notification kind="emergency-compaction">` so the agent learns why its memory has a hole in it. Agents notice the gap regardless; an unexplained gap is worse than an explained one. It is written durably and picked up by the inject tailer on the retry iteration, so it lands exactly once and survives into later turns.

**Loop guard:** exactly one emergency compaction + retry per turn. A second `context_window_exceeded` after compacting surfaces as a failed turn (`stopReason: context_window_exceeded`, stopDetails preserved), not another compaction.

## Changes

- `packages/agent/src/core/conversation/runner.ts`
  - New `ConversationRunner#compactSession` — the post-turn compaction body (persona breakpoints + `compact_session`) extracted so both triggers run the same path, including the `compaction_complete` emit from PRI-2889.
  - Mid-turn emergency arm on `context_window_exceeded`: compact, re-derive the projection so the retry sends the *compacted* history, re-apply the (possibly re-rendered) system prompt, drop `lastResponseId` (it describes a message list that no longer exists), inject the notice, retry. The retry does not count as a logical turn.
- `packages/agent/src/notifications/notification-wrapper.ts` — new `emergency-compaction` notification kind.
- `packages/agent/src/core/conversation/__tests__/runner.emergency-compaction.test.ts` — new.

## Verification

- `cd packages/agent && npm test` — 3504 passed / 27 skipped, then 276 passed / 12 skipped. Green.
- `npx tsc --noEmit -p packages/agent` — clean.
- `npm run lint` (eslint, repo root) — clean.
- `npx prettier --write` on touched files — no changes.

### Mutation testing

| Mutation | Result |
|---|---|
| Disable the emergency arm entirely | 4 of 5 tests fail |
| Remove the once-per-turn guard | the turn never terminates (compacts and retries forever) — the guard is the only bound |
| Never inject the notification | "tells the agent an emergency compaction ran" fails |
| Retry re-sends the pre-compaction history | "sends the COMPACTED history on the retry" fails |
| Deliver the notification twice (projection + tailer) | the exactly-once assertion fails |

## Not in scope

Ops alerting. Per the ticket, this fixes the wedge shape we saw and leaves the general problem — a coworker that is down says nothing — unsolved.