### PR TITLE
fix(compaction): size the preserved tail to the model's context window (PRI-2906)

### DIFF
--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -429,11 +429,41 @@ interface CompactionContext {
     model?: string;
     signal?: AbortSignal;
   }) => Promise<{ text: string; usage?: ProviderResponse['usage'] }>;
+  // Context window of the model this session runs on. Size the verbatim tail you
+  // preserve against it — see "Sizing the preserved tail" below. Absent only when
+  // the call site has no connection/model to resolve one from.
+  readonly contextWindow?: number;
   // Free-text steering from the compact caller (compact_session / ent.session.compact
   // `guidance`, or /compact's command tail). Absent when auto-fired; built-ins ignore it.
   guidance?: string;
 }
 ```
+
+**Sizing the preserved tail.** A strategy that preserves recent turns verbatim
+must bound that tail by TOKENS, not just by turn count — a handful of large
+turns can preserve more than the whole context window, and a compaction that
+leaves the session over the limit cannot get it back under, so the next turn
+400s and every turn after it burns another compaction that also cannot help.
+The toolkit ships the primitives:
+
+```ts
+import { tailTokenBudget, trimTailToTokenBudget } from '@lace/agent/compaction/toolkit';
+
+const { earlier, tail } = trimTailToTokenBudget(
+  events,
+  TAIL_TURNS,
+  tailTokenBudget(ctx.contextWindow),
+  // Optional: measure through your own shrinking step, so the budget sees what
+  // the provider actually receives rather than the raw events.
+  trimMyToolIO
+);
+```
+
+`tailTokenBudget` returns `min(300K, 60% of the window)`, falling back to a
+conservative 200K window when `ctx.contextWindow` is absent. The fraction sits
+below the lowest default compact breakpoint on purpose: compaction has to
+relieve pressure past that breakpoint, or `highestFiredBreakpointAt` never
+resets and no further post-turn compaction fires.
 
 **Compaction is triggered three ways**, all routing through the persona-selected
 strategy and `validatePreserved`: automatically in the runner's post-turn hook

--- a/packages/agent/src/compaction/__tests__/build-context.test.ts
+++ b/packages/agent/src/compaction/__tests__/build-context.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Verifies prompt→messages mapping, model defaulting, guidance passthrough, and connection guard
 
 import { describe, it, expect, vi } from 'vitest';
-import { buildCompactionContext } from '../build-context';
+import { buildCompactionContext, buildCompactionContextForConnection } from '../build-context';
 
 describe('buildCompactionContext', () => {
   const BASE_OPTS = {
@@ -131,6 +131,34 @@ describe('buildCompactionContext', () => {
   it('forwards contextWindow so the strategy can size its tail (PRI-2906)', () => {
     const ctx = buildCompactionContext({ ...BASE_OPTS, contextWindow: 200_000 });
     expect(ctx.contextWindow).toBe(200_000);
+  });
+
+  it('buildCompactionContextForConnection resolves the window and threads it in', async () => {
+    // The composition is the unit under test. Before this existed, the resolve
+    // and the build were two lines repeated in each RPC handler, and deleting
+    // the window from either one passed the entire suite.
+    const resolveContextWindow = vi.fn().mockResolvedValue(750_000);
+    const ctx = await buildCompactionContextForConnection(BASE_OPTS, {
+      oneShotQuery: vi.fn(),
+      resolveContextWindow,
+    });
+    expect(resolveContextWindow).toHaveBeenCalledWith({
+      connectionId: BASE_OPTS.connectionId,
+      modelId: BASE_OPTS.modelId,
+    });
+    expect(ctx.contextWindow).toBe(750_000);
+  });
+
+  it('buildCompactionContextForConnection omits the window when it cannot be resolved', async () => {
+    const ctx = await buildCompactionContextForConnection(BASE_OPTS, {
+      oneShotQuery: vi.fn(),
+      resolveContextWindow: vi.fn().mockResolvedValue(undefined),
+    });
+    expect('contextWindow' in ctx).toBe(false);
+    // Everything else still arrives — a failed window lookup must not cost the
+    // caller its query binding or its guidance.
+    expect(ctx.query).toBeDefined();
+    expect(ctx.threadId).toBe(BASE_OPTS.threadId);
   });
 
   it('omits contextWindow rather than forwarding undefined', () => {

--- a/packages/agent/src/compaction/__tests__/build-context.test.ts
+++ b/packages/agent/src/compaction/__tests__/build-context.test.ts
@@ -127,4 +127,17 @@ describe('buildCompactionContext', () => {
     const ctx = buildCompactionContext(BASE_OPTS, { oneShotQuery: fakeOneShotQuery });
     expect(ctx.query).toBeDefined();
   });
+
+  it('forwards contextWindow so the strategy can size its tail (PRI-2906)', () => {
+    const ctx = buildCompactionContext({ ...BASE_OPTS, contextWindow: 200_000 });
+    expect(ctx.contextWindow).toBe(200_000);
+  });
+
+  it('omits contextWindow rather than forwarding undefined', () => {
+    // exactOptionalPropertyTypes: a present-but-undefined key and an absent one
+    // are different to a strategy that checks `in`, and the fallback path keys
+    // on absence.
+    const ctx = buildCompactionContext(BASE_OPTS);
+    expect('contextWindow' in ctx).toBe(false);
+  });
 });

--- a/packages/agent/src/compaction/__tests__/context-window.test.ts
+++ b/packages/agent/src/compaction/__tests__/context-window.test.ts
@@ -1,0 +1,167 @@
+// ABOUTME: Tests resolveContextWindow — the manual-compaction path's answer to
+// ABOUTME: "how big is this model's window", which decides how much history a
+// ABOUTME: compaction keeps. Getting it wrong is silent: too small a number just
+// ABOUTME: throws away more of the conversation than it needed to.
+
+import { describe, it, expect, vi } from 'vitest';
+import { resolveContextWindow } from '../context-window';
+import { AIProvider, type ModelInfo } from '@lace/agent/providers/base-provider';
+
+/**
+ * Provider whose catalog knows a 1M model under a dated id, so a bare alias has
+ * to be resolved to reach it — the shape that made the real bug.
+ */
+class CatalogProvider extends AIProvider {
+  constructor(private readonly models: ModelInfo[]) {
+    super();
+  }
+  get providerName(): string {
+    return 'catalog-test';
+  }
+  getProviderInfo() {
+    return { name: 'catalog-test', displayName: 'Catalog Test', requiresApiKey: false };
+  }
+  isConfigured(): boolean {
+    return true;
+  }
+  override getAvailableModels(): ModelInfo[] {
+    return this.models;
+  }
+  protected async _createResponseImpl() {
+    throw new Error('not used');
+  }
+  protected async _createStreamingResponseImpl() {
+    throw new Error('not used');
+  }
+}
+
+const model = (id: string, contextWindow: number): ModelInfo => ({
+  id,
+  displayName: id,
+  contextWindow,
+  maxOutputTokens: 8192,
+});
+
+const MODELS = [model('claude-opus-4-5-20251101', 200_000), model('claude-opus-5', 1_000_000)];
+
+function factoryFor(provider: AIProvider) {
+  return vi.fn().mockResolvedValue(provider);
+}
+
+describe('resolveContextWindow', () => {
+  it('returns the window of an exactly-named model', async () => {
+    const createProviderForTurn = factoryFor(new CatalogProvider(MODELS));
+    const window = await resolveContextWindow(
+      { connectionId: 'conn', modelId: 'claude-opus-5' },
+      { createProviderForTurn }
+    );
+    expect(window).toBe(1_000_000);
+  });
+
+  it('resolves a bare alias before looking the window up', async () => {
+    // The bug this exists to prevent: the factory resolves 'haiku' internally but
+    // never hands back what it resolved to, and the catalog lookup is an exact
+    // match — so an unresolved alias found nothing and fell through to a 200K
+    // default, silently sizing the tail for the wrong model.
+    //
+    // The window here is deliberately not 200K and not 1M, so neither the old
+    // default nor a lucky guess can produce it: only actually resolving the
+    // alias reaches this number.
+    const createProviderForTurn = factoryFor(
+      new CatalogProvider([model('claude-haiku-4-5-20251001', 512_000)])
+    );
+    const window = await resolveContextWindow(
+      { connectionId: 'conn', modelId: 'haiku' },
+      { createProviderForTurn }
+    );
+    expect(window).toBe(512_000);
+  });
+
+  it('resolves an alias to the same model the turn factory would build', async () => {
+    // Whatever this returns has to describe the model the NEXT REQUEST will use,
+    // not merely some model matching the alias — otherwise the budget is sized
+    // against a window the session never had. resolveModelAlias ranks by the
+    // date embedded in the id, so an undated id loses to a dated one; agreeing
+    // with that is the contract, even where the ranking is surprising.
+    const createProviderForTurn = factoryFor(new CatalogProvider(MODELS));
+    const window = await resolveContextWindow(
+      { connectionId: 'conn', modelId: 'opus' },
+      { createProviderForTurn }
+    );
+    expect(window).toBe(200_000); // claude-opus-4-5-20251101 outranks claude-opus-5
+  });
+
+  it('says it does not know rather than reporting a default as fact', async () => {
+    // A model absent from the catalog must not come back as 200K — the caller
+    // applies its own conservative assumption, and a wrong confident number is
+    // worse than an admitted absence.
+    const createProviderForTurn = factoryFor(new CatalogProvider(MODELS));
+    const window = await resolveContextWindow(
+      { connectionId: 'conn', modelId: 'some-model-we-never-shipped' },
+      { createProviderForTurn }
+    );
+    expect(window).toBeUndefined();
+  });
+
+  it('returns undefined without a connection or model to resolve from', async () => {
+    const createProviderForTurn = factoryFor(new CatalogProvider(MODELS));
+    expect(
+      await resolveContextWindow(
+        { connectionId: undefined, modelId: 'claude-opus-5' },
+        {
+          createProviderForTurn,
+        }
+      )
+    ).toBeUndefined();
+    expect(
+      await resolveContextWindow(
+        { connectionId: 'conn', modelId: undefined },
+        {
+          createProviderForTurn,
+        }
+      )
+    ).toBeUndefined();
+    // No provider is built when there is nothing to build one from.
+    expect(createProviderForTurn).not.toHaveBeenCalled();
+  });
+
+  it('survives a provider that cannot be created', async () => {
+    // Missing credentials or an unknown instance must degrade a compaction, not
+    // fail it — the compaction is still worth running on an assumed window.
+    const createProviderForTurn = vi.fn().mockRejectedValue(new Error('no such instance'));
+    const window = await resolveContextWindow(
+      { connectionId: 'conn', modelId: 'claude-opus-5' },
+      { createProviderForTurn }
+    );
+    expect(window).toBeUndefined();
+  });
+
+  it('always cleans the provider up, on both the success and failure paths', async () => {
+    // It owns the provider's whole lifecycle like oneShotQuery does; leaking one
+    // per manual compaction would leak an SDK client per /compact.
+    const provider = new CatalogProvider(MODELS);
+    const cleanup = vi.fn().mockResolvedValue(undefined);
+    (provider as unknown as { cleanup: () => Promise<void> }).cleanup = cleanup;
+
+    await resolveContextWindow(
+      { connectionId: 'conn', modelId: 'claude-opus-5' },
+      { createProviderForTurn: factoryFor(provider) }
+    );
+    expect(cleanup).toHaveBeenCalledTimes(1);
+
+    const exploding = new CatalogProvider(MODELS);
+    (exploding as unknown as { getAvailableModels: () => never }).getAvailableModels = () => {
+      throw new Error('catalog blew up');
+    };
+    const cleanup2 = vi.fn().mockResolvedValue(undefined);
+    (exploding as unknown as { cleanup: () => Promise<void> }).cleanup = cleanup2;
+
+    expect(
+      await resolveContextWindow(
+        { connectionId: 'conn', modelId: 'claude-opus-5' },
+        { createProviderForTurn: factoryFor(exploding) }
+      )
+    ).toBeUndefined();
+    expect(cleanup2).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agent/src/compaction/__tests__/toolkit-purity.test.ts
+++ b/packages/agent/src/compaction/__tests__/toolkit-purity.test.ts
@@ -1,0 +1,16 @@
+// ABOUTME: The toolkit is imported across checkouts by plugin strategies, so its
+// ABOUTME: header promises it is self-contained. That promise is only worth
+// ABOUTME: anything if something checks it: a stray import of the storage layer
+// ABOUTME: drags better-sqlite3 (a native module) in behind it, and a plugin
+// ABOUTME: whose node_modules resolves a differently-built copy fails at import.
+
+import { describe, it, expect } from 'vitest';
+
+describe('compaction toolkit stays importable on its own', () => {
+  it('does not pull a native database module in behind it', async () => {
+    await import('../toolkit');
+    const loaded = Object.keys(require.cache ?? {});
+    const native = loaded.filter((m) => m.includes('better-sqlite3'));
+    expect(native, `toolkit dragged in: ${native.join(', ')}`).toEqual([]);
+  });
+});

--- a/packages/agent/src/compaction/__tests__/track-compaction.test.ts
+++ b/packages/agent/src/compaction/__tests__/track-compaction.test.ts
@@ -14,9 +14,11 @@ import {
   tailTokenBudget,
   TAIL_TOKEN_BUDGET_CAP,
   TAIL_BUDGET_WINDOW_FRACTION,
+  NON_TAIL_OVERHEAD_ALLOWANCE,
   UNTRACKED,
 } from '../track-compaction';
 import { demuxByTrack } from '../toolkit';
+import { DEFAULT_BREAKPOINTS } from '@lace/agent/compaction/select';
 import { logger } from '@lace/agent/utils/logger';
 import type { CompactionContext } from '../types';
 import type { ProviderMessage } from '@lace/agent/providers/base-provider';
@@ -649,32 +651,55 @@ describe('compact()', () => {
 // A fixed 300K tail is larger than the whole window on a 200K model, so a
 // compacted session there is still over the limit and can never self-heal.
 describe('tailTokenBudget', () => {
-  it('is a fraction of the window on a model too small for the cap', () => {
-    // Literal, not derived from the constants under test — a wrong fraction or
-    // a dropped multiplication has to change this number.
-    expect(tailTokenBudget(200_000)).toBe(120_000);
-    expect(tailTokenBudget(128_000)).toBe(76_800);
+  it('is a fraction of the window, less the overhead, on a model under the cap', () => {
+    // Literal, not derived from the constants under test — a wrong fraction, a
+    // dropped multiplication, or a forgotten overhead has to change these.
+    expect(tailTokenBudget(200_000)).toBe(75_000);
+    expect(tailTokenBudget(128_000)).toBe(39_000);
   });
 
-  it('caps at 300K once the fraction of the window would exceed it', () => {
+  it('caps at 300K once the window is large enough', () => {
     expect(tailTokenBudget(1_000_000)).toBe(300_000);
-    expect(tailTokenBudget(800_000)).toBe(300_000);
+    expect(tailTokenBudget(700_000)).toBe(300_000);
   });
 
   it('switches from fraction to cap at the crossover window', () => {
-    // The fraction crosses 300K at a 500,000-token window. Just under keeps the
-    // fraction; at and above pins to the cap. Catches a min/max swap.
-    expect(tailTokenBudget(499_000)).toBe(299_400);
-    expect(tailTokenBudget(500_000)).toBe(300_000);
+    // 0.5 * w - 25_000 reaches 300_000 at a 650,000-token window. Just under
+    // keeps the fraction; at and above pins to the cap. Catches a min/max swap.
+    expect(tailTokenBudget(649_000)).toBe(299_500);
+    expect(tailTokenBudget(650_000)).toBe(300_000);
+  });
+
+  it('never returns a negative budget on a window smaller than the overhead', () => {
+    // 0.5 * 32K is under the overhead allowance. A negative budget would make
+    // trimTailToTokenBudget peel every turn it is allowed to and then log a
+    // nonsense number; zero falls through to preserve-the-in-flight-turn.
+    expect(tailTokenBudget(32_000)).toBe(0);
   });
 
   it('leaves the compacted session below the lowest compact breakpoint', () => {
-    // The reason the fraction is what it is: compaction has to relieve
-    // pressure past the LOWEST breakpoint, because highestFiredBreakpointAt
-    // only resets there. A budget at or above it leaves every breakpoint
-    // fired and no post-turn compaction ever runs again.
-    const lowestCompactBreakpoint = 0.6;
-    expect(TAIL_BUDGET_WINDOW_FRACTION).toBeLessThanOrEqual(lowestCompactBreakpoint);
+    // This is the whole reason the numbers are what they are, and it is the
+    // invariant that actually matters — not the fraction in isolation.
+    //
+    // computePressure divides the model's report of the ENTIRE input by the
+    // window, while the budget bounds only the verbatim tail. So the pressure a
+    // compaction leaves behind is (tail + everything else) / window, and
+    // "everything else" — system prompt, tool schemas, prefix summary, images —
+    // is exactly what the estimator cannot see. evaluateBreakpoints resets
+    // `highestFiredBreakpointAt` only when pressure is STRICTLY below the
+    // lowest breakpoint, so landing at it is as bad as landing above it: every
+    // breakpoint stays fired and no post-turn compaction runs again.
+    //
+    // Reads the real DEFAULT_BREAKPOINTS rather than a copy of the number, so
+    // that retuning them without retuning this fails here instead of in
+    // production six months later.
+    const lowestCompact = Math.min(
+      ...DEFAULT_BREAKPOINTS.filter((b) => b.action === 'compact').map((b) => b.at)
+    );
+    for (const window of [128_000, 200_000, 400_000, 1_000_000]) {
+      const worstCasePressure = (tailTokenBudget(window) + NON_TAIL_OVERHEAD_ALLOWANCE) / window;
+      expect(worstCasePressure).toBeLessThan(lowestCompact);
+    }
   });
 
   it('assumes the provider fallback window when the window is unknown', () => {
@@ -682,13 +707,14 @@ describe('tailTokenBudget', () => {
     // contextWindow absent. Falling back to the old 300K constant would keep
     // the wedge on every small model; fall back to the same 200K the provider
     // itself assumes, which is safe on every model we ship.
-    expect(tailTokenBudget(undefined)).toBe(120_000);
-    expect(tailTokenBudget(0)).toBe(120_000);
+    expect(tailTokenBudget(undefined)).toBe(75_000);
+    expect(tailTokenBudget(0)).toBe(75_000);
   });
 
-  it('pins the cap and fraction to the values the docs and tickets quote', () => {
+  it('pins the constants to the values the docs and tickets quote', () => {
     expect(TAIL_TOKEN_BUDGET_CAP).toBe(300_000);
-    expect(TAIL_BUDGET_WINDOW_FRACTION).toBe(0.6);
+    expect(TAIL_BUDGET_WINDOW_FRACTION).toBe(0.5);
+    expect(NON_TAIL_OVERHEAD_ALLOWANCE).toBe(25_000);
   });
 });
 
@@ -763,6 +789,34 @@ describe('trimTailToTokenBudget', () => {
     }
   });
 
+  it('measures the tail through the caller’s transform, not the raw events', () => {
+    // sen-multiconv caps tool IO before preserving its tail, so the raw events
+    // are far bigger than what the provider receives. Measuring the raw tail
+    // would peel turns that would have fit once trimmed — silently discarding
+    // history to satisfy a budget the real payload never exceeded.
+    const events = buildSession(Array(12).fill(20_000)); // ~5k tokens/turn raw
+
+    const rawSplit = trimTailToTokenBudget(events, 10, 12_000);
+    // A transform that shrinks every message to almost nothing.
+    const shrink = (tail: TypedDurableEvent[]): TypedDurableEvent[] =>
+      tail.map((e) =>
+        e.type === 'message'
+          ? ({ ...e, data: { ...e.data, content: 'x' } } as TypedDurableEvent)
+          : e
+      );
+    const shrunkSplit = trimTailToTokenBudget(events, 10, 12_000, shrink);
+
+    // Same budget, same events — but the transformed tail fits, so nothing is
+    // peeled and the full 10-turn tail survives.
+    expect(shrunkSplit.tail.length).toBeGreaterThan(rawSplit.tail.length);
+    expect(shrunkSplit.earlier.length).toBeLessThan(rawSplit.earlier.length);
+    // The returned split is the UNTRANSFORMED events — the caller applies its
+    // own transform downstream, and getting shrunken events back here would
+    // silently destroy the history it was about to preserve.
+    const preservedText = JSON.stringify(shrunkSplit.tail);
+    expect(preservedText).toContain('x'.repeat(20_000));
+  });
+
   it('is deterministic: same input → same split', () => {
     const events = buildSession(Array(12).fill(20_000));
     const a = trimTailToTokenBudget(events, 10, 12_000);
@@ -824,11 +878,11 @@ describe('trimTailToTokenBudget', () => {
     if (!('compactionEvent' in result)) throw new Error('expected a compaction');
 
     const preserved = result.compactionEvent.data.preserved as ProviderMessage[];
-    // 120_000 is the budget at a 200K window; the prefix summary rides on top.
-    // Requiring the whole compacted history to clear 65% of the window leaves
-    // real room for the system prompt, tool schemas, and output reserve that
-    // the estimator never counts.
-    expect(estimateProviderTokens(preserved)).toBeLessThanOrEqual(130_000);
+    // 75_000 is the budget at a 200K window; the prefix summary rides on top.
+    // Requiring the whole compacted history to clear half the window leaves the
+    // room the system prompt, tool schemas, and output reserve need — none of
+    // which the estimator counts.
+    expect(estimateProviderTokens(preserved)).toBeLessThanOrEqual(100_000);
   });
 });
 

--- a/packages/agent/src/compaction/__tests__/track-compaction.test.ts
+++ b/packages/agent/src/compaction/__tests__/track-compaction.test.ts
@@ -11,6 +11,9 @@ import {
   splitAtTailBoundary,
   trimTailToTokenBudget,
   estimateTailTokens,
+  tailTokenBudget,
+  TAIL_TOKEN_BUDGET_CAP,
+  TAIL_BUDGET_WINDOW_FRACTION,
   UNTRACKED,
 } from '../track-compaction';
 import { demuxByTrack } from '../toolkit';
@@ -640,6 +643,44 @@ describe('compact()', () => {
 // oldest tail turns back into `earlier` (compressed into the prefix) until the
 // verbatim tail fits a token budget, always keeping ≥1 (the in-flight) turn.
 
+// PRI-2906: the budget itself must follow the running model's context window.
+// A fixed 300K tail is larger than the whole window on a 200K model, so a
+// compacted session there is still over the limit and can never self-heal.
+describe('tailTokenBudget', () => {
+  it('is 90% of the window on a model too small for the cap', () => {
+    // Literal, not derived from the constants under test — a wrong fraction or
+    // a dropped multiplication has to change this number.
+    expect(tailTokenBudget(200_000)).toBe(180_000);
+    expect(tailTokenBudget(128_000)).toBe(115_200);
+  });
+
+  it('caps at 300K once 90% of the window would exceed it', () => {
+    expect(tailTokenBudget(1_000_000)).toBe(300_000);
+    expect(tailTokenBudget(400_000)).toBe(300_000);
+  });
+
+  it('switches from fraction to cap at the crossover window', () => {
+    // 90% crosses 300K at a 333,334-token window. Just under keeps the
+    // fraction; just over pins to the cap. Catches a min/max swap.
+    expect(tailTokenBudget(333_000)).toBe(299_700);
+    expect(tailTokenBudget(334_000)).toBe(300_000);
+  });
+
+  it('assumes the provider fallback window when the window is unknown', () => {
+    // buildCompactionContext callers that cannot resolve a provider leave
+    // contextWindow absent. Falling back to the old 300K constant would keep
+    // the wedge on every small model; fall back to the same 200K the provider
+    // itself assumes, which is safe on every model we ship.
+    expect(tailTokenBudget(undefined)).toBe(180_000);
+    expect(tailTokenBudget(0)).toBe(180_000);
+  });
+
+  it('pins the cap and fraction to the values the docs and tickets quote', () => {
+    expect(TAIL_TOKEN_BUDGET_CAP).toBe(300_000);
+    expect(TAIL_BUDGET_WINDOW_FRACTION).toBe(0.9);
+  });
+});
+
 describe('trimTailToTokenBudget', () => {
   // A turn whose assistant message carries `chars` characters of text.
   const sizedTurn = (startSeq: number, t: number, chars: number): TypedDurableEvent[] => {
@@ -730,6 +771,32 @@ describe('trimTailToTokenBudget', () => {
     if (!('compactionEvent' in result)) return;
     // Plain turn-count split would compact only the first 2 turns (8 events).
     expect(result.compactionEvent.data.messagesCompacted).toBeGreaterThan(8);
+  });
+
+  it('compact() preserves a smaller tail on a small-window model than a large one', async () => {
+    // The end-to-end behavior PRI-2906 is about: the same history compacted for
+    // a 200K model must give up more of its tail than for a 1M model, because
+    // the 1M model's 300K tail would not fit a 200K window at all.
+    const events = buildSession(Array(12).fill(200_000)); // ~50k tokens/turn
+
+    const big = await compact(events, { threadId: 's_big', contextWindow: 1_000_000 });
+    const small = await compact(events, { threadId: 's_small', contextWindow: 200_000 });
+
+    expect('compactionEvent' in big && 'compactionEvent' in small).toBe(true);
+    if (!('compactionEvent' in big) || !('compactionEvent' in small)) return;
+
+    expect(small.compactionEvent.data.messagesCompacted).toBeGreaterThan(
+      big.compactionEvent.data.messagesCompacted ?? 0
+    );
+  });
+
+  it('compact() keeps the preserved tail under the small model window', async () => {
+    // Not just "smaller" — actually under budget, which is the whole point:
+    // a compaction that leaves the session over the window cannot self-heal it.
+    const events = buildSession(Array(12).fill(200_000));
+    const split = trimTailToTokenBudget(events, 10, tailTokenBudget(200_000));
+    expect(estimateTailTokens(split.tail)).toBeLessThanOrEqual(180_000);
+    expect(estimateTailTokens(split.tail)).toBeLessThan(200_000);
   });
 });
 

--- a/packages/agent/src/compaction/__tests__/track-compaction.test.ts
+++ b/packages/agent/src/compaction/__tests__/track-compaction.test.ts
@@ -19,6 +19,8 @@ import {
 import { demuxByTrack } from '../toolkit';
 import { logger } from '@lace/agent/utils/logger';
 import type { CompactionContext } from '../types';
+import type { ProviderMessage } from '@lace/agent/providers/base-provider';
+import { estimateProviderTokens } from '@lace/agent/message-building/message-builder';
 import type { DurableEventData, TypedDurableEvent } from '@lace/agent/storage/event-types';
 
 const event = (
@@ -647,37 +649,46 @@ describe('compact()', () => {
 // A fixed 300K tail is larger than the whole window on a 200K model, so a
 // compacted session there is still over the limit and can never self-heal.
 describe('tailTokenBudget', () => {
-  it('is 90% of the window on a model too small for the cap', () => {
+  it('is a fraction of the window on a model too small for the cap', () => {
     // Literal, not derived from the constants under test — a wrong fraction or
     // a dropped multiplication has to change this number.
-    expect(tailTokenBudget(200_000)).toBe(180_000);
-    expect(tailTokenBudget(128_000)).toBe(115_200);
+    expect(tailTokenBudget(200_000)).toBe(120_000);
+    expect(tailTokenBudget(128_000)).toBe(76_800);
   });
 
-  it('caps at 300K once 90% of the window would exceed it', () => {
+  it('caps at 300K once the fraction of the window would exceed it', () => {
     expect(tailTokenBudget(1_000_000)).toBe(300_000);
-    expect(tailTokenBudget(400_000)).toBe(300_000);
+    expect(tailTokenBudget(800_000)).toBe(300_000);
   });
 
   it('switches from fraction to cap at the crossover window', () => {
-    // 90% crosses 300K at a 333,334-token window. Just under keeps the
-    // fraction; just over pins to the cap. Catches a min/max swap.
-    expect(tailTokenBudget(333_000)).toBe(299_700);
-    expect(tailTokenBudget(334_000)).toBe(300_000);
+    // The fraction crosses 300K at a 500,000-token window. Just under keeps the
+    // fraction; at and above pins to the cap. Catches a min/max swap.
+    expect(tailTokenBudget(499_000)).toBe(299_400);
+    expect(tailTokenBudget(500_000)).toBe(300_000);
+  });
+
+  it('leaves the compacted session below the lowest compact breakpoint', () => {
+    // The reason the fraction is what it is: compaction has to relieve
+    // pressure past the LOWEST breakpoint, because highestFiredBreakpointAt
+    // only resets there. A budget at or above it leaves every breakpoint
+    // fired and no post-turn compaction ever runs again.
+    const lowestCompactBreakpoint = 0.6;
+    expect(TAIL_BUDGET_WINDOW_FRACTION).toBeLessThanOrEqual(lowestCompactBreakpoint);
   });
 
   it('assumes the provider fallback window when the window is unknown', () => {
-    // buildCompactionContext callers that cannot resolve a provider leave
+    // A call site with no connection or model to resolve one from leaves
     // contextWindow absent. Falling back to the old 300K constant would keep
     // the wedge on every small model; fall back to the same 200K the provider
     // itself assumes, which is safe on every model we ship.
-    expect(tailTokenBudget(undefined)).toBe(180_000);
-    expect(tailTokenBudget(0)).toBe(180_000);
+    expect(tailTokenBudget(undefined)).toBe(120_000);
+    expect(tailTokenBudget(0)).toBe(120_000);
   });
 
   it('pins the cap and fraction to the values the docs and tickets quote', () => {
     expect(TAIL_TOKEN_BUDGET_CAP).toBe(300_000);
-    expect(TAIL_BUDGET_WINDOW_FRACTION).toBe(0.9);
+    expect(TAIL_BUDGET_WINDOW_FRACTION).toBe(0.6);
   });
 });
 
@@ -790,13 +801,34 @@ describe('trimTailToTokenBudget', () => {
     );
   });
 
-  it('compact() keeps the preserved tail under the small model window', async () => {
-    // Not just "smaller" — actually under budget, which is the whole point:
-    // a compaction that leaves the session over the window cannot self-heal it.
+  it('compact() emits a preserved history that fits the small model window', async () => {
+    // Not just "smaller" — under the window, which is the whole point: a
+    // compaction that leaves the session over the limit cannot self-heal it.
+    // Measured on what compact() actually emits (summary prefix included), not
+    // on a budget number handed back to the function that was given it.
     const events = buildSession(Array(12).fill(200_000));
-    const split = trimTailToTokenBudget(events, 10, tailTokenBudget(200_000));
-    expect(estimateTailTokens(split.tail)).toBeLessThanOrEqual(180_000);
-    expect(estimateTailTokens(split.tail)).toBeLessThan(200_000);
+    const result = await compact(events, { threadId: 's_fits', contextWindow: 200_000 });
+    expect('compactionEvent' in result).toBe(true);
+    if (!('compactionEvent' in result)) return;
+
+    const preserved = result.compactionEvent.data.preserved as ProviderMessage[];
+    expect(estimateProviderTokens(preserved)).toBeLessThan(200_000);
+  });
+
+  it('compact() leaves real headroom, not just a hair under the window', async () => {
+    // A fraction of 0.99 would satisfy "under the window" while leaving nothing
+    // for the system prompt, tool schemas, or the next turn — i.e. the wedge
+    // restored under a passing test. Pin the actual headroom.
+    const events = buildSession(Array(12).fill(200_000));
+    const result = await compact(events, { threadId: 's_headroom', contextWindow: 200_000 });
+    if (!('compactionEvent' in result)) throw new Error('expected a compaction');
+
+    const preserved = result.compactionEvent.data.preserved as ProviderMessage[];
+    // 120_000 is the budget at a 200K window; the prefix summary rides on top.
+    // Requiring the whole compacted history to clear 65% of the window leaves
+    // real room for the system prompt, tool schemas, and output reserve that
+    // the estimator never counts.
+    expect(estimateProviderTokens(preserved)).toBeLessThanOrEqual(130_000);
   });
 });
 

--- a/packages/agent/src/compaction/build-context.ts
+++ b/packages/agent/src/compaction/build-context.ts
@@ -4,6 +4,7 @@
 
 import type { ProviderMessage, ProviderResponse } from '@lace/agent/providers/base-provider';
 import { oneShotQuery as defaultOneShotQuery } from '@lace/agent/conversation/one-shot-query';
+import { resolveContextWindow as defaultResolveContextWindow } from './context-window';
 import type { CompactionContext } from './types';
 
 type OneShotQuery = typeof defaultOneShotQuery;
@@ -30,6 +31,44 @@ interface BuildContextDeps {
  * When `connectionId` or `modelId` is falsy, `ctx.query` is omitted entirely
  * rather than bound to a function that will always throw InvalidParams.
  */
+/**
+ * Build a CompactionContext for a call site that holds a connection and a model
+ * but no live provider — the manual compaction paths (`ent/session/compact`,
+ * `/compact`). Resolves the model's context window and threads it in.
+ *
+ * This exists as one function rather than two lines repeated at each call site
+ * because the two-line version was invisible to tests: deleting the window from
+ * either handler passed the entire suite. Composed here, the composition itself
+ * is testable, and the handlers are left with a single call that either happens
+ * or does not.
+ */
+export async function buildCompactionContextForConnection(
+  opts: {
+    threadId: string;
+    sessionDir: string;
+    connectionId?: string;
+    modelId?: string;
+    guidance?: string;
+    referenceTimestamp?: string;
+  },
+  deps?: BuildContextDeps & {
+    resolveContextWindow?: (o: {
+      connectionId?: string;
+      modelId?: string;
+    }) => Promise<number | undefined>;
+  }
+): Promise<CompactionContext> {
+  const resolve = deps?.resolveContextWindow ?? defaultResolveContextWindow;
+  const contextWindow = await resolve({
+    connectionId: opts.connectionId,
+    modelId: opts.modelId,
+  });
+  return buildCompactionContext(
+    { ...opts, ...(contextWindow !== undefined ? { contextWindow } : {}) },
+    deps
+  );
+}
+
 export function buildCompactionContext(
   opts: {
     threadId: string;

--- a/packages/agent/src/compaction/build-context.ts
+++ b/packages/agent/src/compaction/build-context.ts
@@ -38,6 +38,7 @@ export function buildCompactionContext(
     modelId?: string;
     guidance?: string;
     referenceTimestamp?: string;
+    contextWindow?: number;
   },
   deps?: BuildContextDeps
 ): CompactionContext {
@@ -48,6 +49,7 @@ export function buildCompactionContext(
     threadId: opts.threadId,
     sessionDir: opts.sessionDir,
     referenceTimestamp: opts.referenceTimestamp ?? new Date().toISOString(),
+    ...(opts.contextWindow !== undefined ? { contextWindow: opts.contextWindow } : {}),
     ...(opts.guidance !== undefined ? { guidance: opts.guidance } : {}),
   };
 

--- a/packages/agent/src/compaction/context-window.ts
+++ b/packages/agent/src/compaction/context-window.ts
@@ -1,0 +1,45 @@
+// ABOUTME: Resolves the running model's context window for compaction call sites
+// ABOUTME: that hold a connection + model id but no live provider reference.
+
+import type { AIProvider } from '@lace/agent/providers/base-provider';
+import { createProviderForTurn as defaultCreateProviderForTurn } from '@lace/agent/providers/turn-factory';
+import { logger } from '@lace/agent/utils/logger';
+
+type CreateProviderForTurn = typeof defaultCreateProviderForTurn;
+
+/**
+ * The context window compaction should size its preserved tail against.
+ *
+ * The runner already holds a live provider and reads this directly. The manual
+ * compaction paths (`ent/session/compact`, `/compact`) hold only a connection
+ * and a model id, so they resolve it here — through the SAME factory the turn
+ * itself uses, so the number is the one the next request will actually be
+ * measured against. Reading it out of the static catalog instead would diverge
+ * for any model whose window a dynamic catalog synthesizes.
+ *
+ * Owns the provider's whole lifecycle, like `oneShotQuery`: callers never hold
+ * a reference. Returns undefined rather than throwing — a compaction is worth
+ * running on an assumed window, and is not worth failing over a lookup.
+ */
+export async function resolveContextWindow(
+  opts: { connectionId?: string; modelId?: string },
+  deps?: { createProviderForTurn?: CreateProviderForTurn }
+): Promise<number | undefined> {
+  if (!opts.connectionId || !opts.modelId) return undefined;
+
+  const factory = deps?.createProviderForTurn ?? defaultCreateProviderForTurn;
+  let provider: AIProvider | undefined;
+  try {
+    provider = await factory({ connectionId: opts.connectionId, modelId: opts.modelId });
+    return provider.contextWindowForModel(opts.modelId);
+  } catch (err) {
+    logger.warn('compaction: could not resolve the model context window', {
+      connectionId: opts.connectionId,
+      modelId: opts.modelId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return undefined;
+  } finally {
+    await provider?.cleanup?.();
+  }
+}

--- a/packages/agent/src/compaction/context-window.ts
+++ b/packages/agent/src/compaction/context-window.ts
@@ -3,6 +3,7 @@
 
 import type { AIProvider } from '@lace/agent/providers/base-provider';
 import { createProviderForTurn as defaultCreateProviderForTurn } from '@lace/agent/providers/turn-factory';
+import { resolveModelAlias } from '@lace/agent/providers/catalog/alias-resolver';
 import { logger } from '@lace/agent/utils/logger';
 
 type CreateProviderForTurn = typeof defaultCreateProviderForTurn;
@@ -31,7 +32,26 @@ export async function resolveContextWindow(
   let provider: AIProvider | undefined;
   try {
     provider = await factory({ connectionId: opts.connectionId, modelId: opts.modelId });
-    return provider.contextWindowForModel(opts.modelId);
+    // Resolve the id the same way the factory did before looking it up. The
+    // factory resolves a bare alias ('opus', 'sonnet') internally but does not
+    // hand the resolved id back, and `contextWindowForModel` does an exact match
+    // — so passing the alias straight through misses every catalog entry and
+    // silently returns the 200K default. On a 1M model that would cut the
+    // preserved tail to a fraction of what fits, which is the regression this
+    // whole plumbing exists to avoid.
+    const models = provider.getAvailableModels();
+    const resolvedId = resolveModelAlias(opts.modelId, models);
+    const model = models.find((m) => m.id === resolvedId);
+    if (!model) {
+      // Better to say "I don't know" than to report a default as if it were
+      // this model's real window.
+      logger.warn('compaction: model is absent from the provider catalog', {
+        modelId: opts.modelId,
+        resolvedId,
+      });
+      return undefined;
+    }
+    return model.contextWindow;
   } catch (err) {
     logger.warn('compaction: could not resolve the model context window', {
       connectionId: opts.connectionId,

--- a/packages/agent/src/compaction/toolkit.ts
+++ b/packages/agent/src/compaction/toolkit.ts
@@ -7,6 +7,8 @@ import type { ContentBlock, ThinkingBlock } from '@lace/agent/providers/base-pro
 import type { ToolCall as CoreToolCall, ToolResult as CoreToolResult } from '../tools/types';
 import type { ToolResult as ProtocolToolResult } from '@lace/ent-protocol';
 import { foldEvents } from '@lace/agent/message-building/fold-event';
+import { estimateProviderTokens } from '@lace/agent/message-building/message-builder';
+import { logger } from '@lace/agent/utils/logger';
 import type { FoldEventInput } from '@lace/agent/message-building/fold-event';
 
 // ---------------------------------------------------------------------------
@@ -554,4 +556,137 @@ export function buildPreservedWithPrefix(
   };
 
   return [mergedFirst, ...tail.slice(1)];
+}
+
+// ---------------------------------------------------------------------------
+// Token-budgeting the preserved tail
+// ---------------------------------------------------------------------------
+// Shared by every strategy that preserves a verbatim tail, because the size of
+// that tail is a property of the MODEL, not of how a given strategy chooses to
+// summarize (PRI-2906).
+
+/**
+ * Ceiling on the verbatim tail we preserve through a compaction, in estimated
+ * tokens. `TAIL_TURNS` caps the tail by *turn count*; this caps it by *size*,
+ * so a handful of very large recent turns (long messages + big tool / subagent
+ * outputs) can't blow past the model's context window even right after
+ * compacting.
+ *
+ * 300K is the ceiling rather than the answer: on a 1M-token window it leaves
+ * ample room (far under the ~950K usable after system prompt + output reserve +
+ * the prefix summary) with plenty of headroom for new turns before the next
+ * compaction fires. The token-blind 10-turn tail once reached ~600K in
+ * production and 400'd every request with `prompt_too_long`.
+ */
+export const TAIL_TOKEN_BUDGET_CAP = 300_000;
+
+/**
+ * Fraction of the model's context window the preserved tail may occupy.
+ *
+ * The tail is only part of what gets sent. The prefix summary, the system
+ * prompt, the tool schemas, and the output reserve all ride alongside it, and
+ * `estimateProviderTokens` counts none of them — it measures message text and
+ * skips images entirely. So the fraction has to leave room for a payload it
+ * cannot see.
+ *
+ * 0.6 rather than something closer to the line, because of what compaction is
+ * FOR. The default breakpoints compact at 0.6 and 0.9, and
+ * `highestFiredBreakpointAt` only resets once pressure falls below the LOWEST
+ * of them. A compaction that lands the session back at 0.9 leaves every
+ * breakpoint still fired, so no post-turn compaction ever runs again and the
+ * session sits pinned at the limit — the same wedge one notch further along.
+ * Landing under the lowest compact breakpoint is what makes compaction
+ * self-healing rather than a one-shot.
+ *
+ * On any model at or above a 500K window the 300K cap binds first, so this
+ * fraction only takes effect where the wedge actually lives: small windows.
+ */
+export const TAIL_BUDGET_WINDOW_FRACTION = 0.6;
+
+/**
+ * The window we assume when the call site couldn't tell us one. Matches
+ * `BaseProvider.contextWindowForModel`'s own fallback, so an unplumbed caller
+ * degrades to a tail that is safe on every model we ship rather than to the
+ * 300K ceiling, which is larger than the entire window on a 200K model.
+ */
+const ASSUMED_CONTEXT_WINDOW = 200_000;
+
+/**
+ * Token budget for the preserved tail on a model with this context window.
+ *
+ * Before PRI-2906 this was a flat 300K with no relationship to the running
+ * model. On any window under ~333K that budget exceeded the window itself, so
+ * a compacted session was still over the limit — PRI-2903's emergency
+ * self-heal would compact, retry, 400 again, and every later turn would burn
+ * another compaction that also could not help. We only failed to notice
+ * because the fleet runs ~1M-window models.
+ */
+export function tailTokenBudget(contextWindow?: number): number {
+  const window =
+    contextWindow !== undefined && Number.isFinite(contextWindow) && contextWindow > 0
+      ? contextWindow
+      : ASSUMED_CONTEXT_WINDOW;
+  return Math.min(TAIL_TOKEN_BUDGET_CAP, Math.floor(window * TAIL_BUDGET_WINDOW_FRACTION));
+}
+
+/**
+ * Estimate the on-wire token size of the verbatim tail by building the exact
+ * PreservedMessage stream the provider will replay and running it through the
+ * same estimator the auto-compaction trigger and message-builder use. Pure and
+ * deterministic — no model call.
+ */
+export function estimateTailTokens(tail: TypedDurableEvent[]): number {
+  return estimateProviderTokens(buildPreservedTail(tail));
+}
+
+/**
+ * Apply a token budget to the turn-based split. Starting from the turn-count
+ * split, while the verbatim tail's estimated tokens exceed `budget` AND the
+ * tail still holds more than one turn, peel the OLDEST tail turn back into
+ * `earlier` (where it gets compressed into the prefix) and re-estimate.
+ *
+ * Always preserves at least the most recent turn — we can't compress the
+ * in-flight turn. If that single remaining turn still exceeds the budget it is
+ * preserved anyway and a warning is logged (the tool-result-truncation work
+ * addresses that residual case).
+ *
+ * Re-derives `{earlier, tail}` via `splitAtTailBoundary` at the reduced turn
+ * count so the unchanged prefix-compression and `buildPreservedTail` logic runs
+ * over the adjusted split.
+ */
+export function trimTailToTokenBudget(
+  events: TypedDurableEvent[],
+  tailTurns: number,
+  budget: number,
+  /**
+   * Optional transform applied before measuring, for strategies that shrink the
+   * tail before preserving it (sen-multiconv caps tool IO). Measuring the raw
+   * tail would peel turns that would have fit once trimmed, so the budget has
+   * to see what the provider will actually receive. The returned split is
+   * always the untransformed events — the caller still applies its own
+   * transform downstream.
+   */
+  prepareTail?: (tail: TypedDurableEvent[]) => TypedDurableEvent[]
+): { earlier: TypedDurableEvent[]; tail: TypedDurableEvent[] } {
+  const measure = (tail: TypedDurableEvent[]) => estimateTailTokens(prepareTail?.(tail) ?? tail);
+  let split = splitAtTailBoundary(events, tailTurns);
+  let turns = tailTurns;
+
+  while (turns > 1 && measure(split.tail) > budget) {
+    turns -= 1;
+    split = splitAtTailBoundary(events, turns);
+  }
+
+  if (measure(split.tail) > budget) {
+    logger.warn(
+      'compaction: preserved tail exceeds token budget with a single turn — preserving it anyway',
+      {
+        budget,
+        estimatedTailTokens: measure(split.tail),
+        tailTurns: turns,
+      }
+    );
+  }
+
+  return split;
 }

--- a/packages/agent/src/compaction/toolkit.ts
+++ b/packages/agent/src/compaction/toolkit.ts
@@ -7,7 +7,7 @@ import type { ContentBlock, ThinkingBlock } from '@lace/agent/providers/base-pro
 import type { ToolCall as CoreToolCall, ToolResult as CoreToolResult } from '../tools/types';
 import type { ToolResult as ProtocolToolResult } from '@lace/ent-protocol';
 import { foldEvents } from '@lace/agent/message-building/fold-event';
-import { estimateProviderTokens } from '@lace/agent/message-building/message-builder';
+import { estimateProviderTokens } from '@lace/agent/utils/token-estimation';
 import { logger } from '@lace/agent/utils/logger';
 import type { FoldEventInput } from '@lace/agent/message-building/fold-event';
 
@@ -589,19 +589,44 @@ export const TAIL_TOKEN_BUDGET_CAP = 300_000;
  * skips images entirely. So the fraction has to leave room for a payload it
  * cannot see.
  *
- * 0.6 rather than something closer to the line, because of what compaction is
- * FOR. The default breakpoints compact at 0.6 and 0.9, and
- * `highestFiredBreakpointAt` only resets once pressure falls below the LOWEST
- * of them. A compaction that lands the session back at 0.9 leaves every
- * breakpoint still fired, so no post-turn compaction ever runs again and the
- * session sits pinned at the limit — the same wedge one notch further along.
- * Landing under the lowest compact breakpoint is what makes compaction
+ * The value tracks the lowest default compact breakpoint, because of what
+ * compaction is FOR. `highestFiredBreakpointAt` only resets once pressure
+ * falls back BELOW the lowest breakpoint (strictly below —
+ * `evaluateBreakpoints` computes `pressure < minAt`). A compaction that lands
+ * the session at or above it leaves every breakpoint still fired, so no
+ * post-turn compaction ever runs again and the session sits pinned at the
+ * limit, carried only by emergency compactions — the same wedge one notch
+ * further along. Landing under that breakpoint is what makes compaction
  * self-healing rather than a one-shot.
  *
- * On any model at or above a 500K window the 300K cap binds first, so this
- * fraction only takes effect where the wedge actually lives: small windows.
+ * So this is not "how much of the window the tail may use" — it is the
+ * PRESSURE the session should sit at once compaction finishes, tail plus
+ * everything that rides along with it. 0.5 leaves real margin under the 0.6
+ * breakpoint, which matters because the reset is strict and the overhead is
+ * an estimate. Sizing the tail itself at 0.6 would land pressure at 0.6 or
+ * above and re-latch every time.
  */
-export const TAIL_BUDGET_WINDOW_FRACTION = 0.6;
+export const TAIL_BUDGET_WINDOW_FRACTION = 0.5;
+
+/**
+ * Tokens reserved for everything that ships alongside the preserved tail and
+ * is invisible to the budget.
+ *
+ * `estimateProviderTokens` counts message text, tool calls, and tool results.
+ * It does not count the system prompt, the tool schemas, or images — and the
+ * prefix summary is merged on afterwards. But `computePressure` divides the
+ * model's report of the WHOLE input by the window. So a tail sized to exactly
+ * 60% of the window produces a turn whose measured pressure is 60% plus all of
+ * that, which lands back at or above the breakpoint and re-latches it.
+ *
+ * lace's builtin tool schemas alone measure ~7K tokens before any MCP or skill
+ * tools are registered; a persona system prompt and a prefix summary are each
+ * a few thousand more. 25K is chosen to cover that with room for a fleet
+ * that adds tools, and it is an absolute figure rather than a fraction because
+ * the overhead is absolute — it does not shrink with the window, which is
+ * precisely why small-window models were the ones that wedged.
+ */
+export const NON_TAIL_OVERHEAD_ALLOWANCE = 25_000;
 
 /**
  * The window we assume when the call site couldn't tell us one. Matches
@@ -626,7 +651,12 @@ export function tailTokenBudget(contextWindow?: number): number {
     contextWindow !== undefined && Number.isFinite(contextWindow) && contextWindow > 0
       ? contextWindow
       : ASSUMED_CONTEXT_WINDOW;
-  return Math.min(TAIL_TOKEN_BUDGET_CAP, Math.floor(window * TAIL_BUDGET_WINDOW_FRACTION));
+  const fromWindow = Math.floor(window * TAIL_BUDGET_WINDOW_FRACTION) - NON_TAIL_OVERHEAD_ALLOWANCE;
+  // Never negative. On a window too small to hold the overhead at all, the
+  // budget collapses to zero and `trimTailToTokenBudget` falls through to its
+  // preserve-the-in-flight-turn-anyway path, which is the right degenerate
+  // answer: there is no tail size that would fit.
+  return Math.max(0, Math.min(TAIL_TOKEN_BUDGET_CAP, fromWindow));
 }
 
 /**

--- a/packages/agent/src/compaction/track-compaction.ts
+++ b/packages/agent/src/compaction/track-compaction.ts
@@ -26,6 +26,7 @@ export { UNTRACKED, splitAtTailBoundary };
 export {
   TAIL_TOKEN_BUDGET_CAP,
   TAIL_BUDGET_WINDOW_FRACTION,
+  NON_TAIL_OVERHEAD_ALLOWANCE,
   tailTokenBudget,
   estimateTailTokens,
   trimTailToTokenBudget,

--- a/packages/agent/src/compaction/track-compaction.ts
+++ b/packages/agent/src/compaction/track-compaction.ts
@@ -3,13 +3,13 @@
 
 import { isEventOfType } from '@lace/agent/storage/event-types';
 import type { TypedDurableEvent } from '@lace/agent/storage/event-types';
-import { estimateProviderTokens } from '@lace/agent/message-building/message-builder';
-import { logger } from '@lace/agent/utils/logger';
 import { renderCompactionPrefix } from './track-render';
 import type { CompactionContext, CompactResult } from './types';
 import {
   UNTRACKED,
   splitAtTailBoundary,
+  tailTokenBudget,
+  trimTailToTokenBudget,
   demuxByTrack,
   buildPreservedTail,
   buildPreservedWithPrefix,
@@ -19,8 +19,17 @@ import {
   type TrackBlock,
 } from './toolkit';
 
-// Re-export so the existing test imports keep working.
+// Re-export so the existing test imports keep working. The tail-budget
+// primitives live in the toolkit because every strategy that preserves a
+// verbatim tail needs them, not just this one.
 export { UNTRACKED, splitAtTailBoundary };
+export {
+  TAIL_TOKEN_BUDGET_CAP,
+  TAIL_BUDGET_WINDOW_FRACTION,
+  tailTokenBudget,
+  estimateTailTokens,
+  trimTailToTokenBudget,
+} from './toolkit';
 
 /**
  * Walk events and map each `turn_start.turnId` to the track of the
@@ -171,108 +180,6 @@ export function salienceForTrack(trackId: string, events: TypedDurableEvent[]): 
 // ---------------------------------------------------------------------------
 
 const TAIL_TURNS = 10;
-
-/**
- * Ceiling on the verbatim tail we preserve through a compaction, in estimated
- * tokens. `TAIL_TURNS` caps the tail by *turn count*; this caps it by *size*,
- * so a handful of very large recent turns (long messages + big tool / subagent
- * outputs) can't blow past the model's context window even right after
- * compacting.
- *
- * 300K is the ceiling rather than the answer: on a 1M-token window it leaves
- * ample room (far under the ~950K usable after system prompt + output reserve +
- * the prefix summary) with plenty of headroom for new turns before the next
- * compaction fires. The token-blind 10-turn tail once reached ~600K in
- * production and 400'd every request with `prompt_too_long`.
- */
-export const TAIL_TOKEN_BUDGET_CAP = 300_000;
-
-/**
- * Fraction of the model's context window the preserved tail may occupy. The
- * remaining 10% is the room compaction needs to be worth anything: the prefix
- * summary, the system prompt, and at least one new turn all have to fit
- * alongside the tail or the session is still over the window the moment it
- * finishes compacting.
- */
-export const TAIL_BUDGET_WINDOW_FRACTION = 0.9;
-
-/**
- * The window we assume when the call site couldn't tell us one. Matches
- * `BaseProvider.contextWindowForModel`'s own fallback, so an unplumbed caller
- * degrades to a tail that is safe on every model we ship rather than to the
- * 300K ceiling, which is larger than the entire window on a 200K model.
- */
-const ASSUMED_CONTEXT_WINDOW = 200_000;
-
-/**
- * Token budget for the preserved tail on a model with this context window.
- *
- * Before PRI-2906 this was a flat 300K with no relationship to the running
- * model. On any window under ~333K that budget exceeded the window itself, so
- * a compacted session was still over the limit — PRI-2903's emergency
- * self-heal would compact, retry, 400 again, and every later turn would burn
- * another compaction that also could not help. We only failed to notice
- * because the fleet runs ~1M-window models.
- */
-export function tailTokenBudget(contextWindow?: number): number {
-  const window =
-    contextWindow !== undefined && Number.isFinite(contextWindow) && contextWindow > 0
-      ? contextWindow
-      : ASSUMED_CONTEXT_WINDOW;
-  return Math.min(TAIL_TOKEN_BUDGET_CAP, Math.floor(window * TAIL_BUDGET_WINDOW_FRACTION));
-}
-
-/**
- * Estimate the on-wire token size of the verbatim tail by building the exact
- * PreservedMessage stream the provider will replay and running it through the
- * same estimator the auto-compaction trigger and message-builder use. Pure and
- * deterministic — no model call.
- */
-export function estimateTailTokens(tail: TypedDurableEvent[]): number {
-  return estimateProviderTokens(buildPreservedTail(tail));
-}
-
-/**
- * Apply a token budget to the turn-based split. Starting from the turn-count
- * split, while the verbatim tail's estimated tokens exceed `budget` AND the
- * tail still holds more than one turn, peel the OLDEST tail turn back into
- * `earlier` (where it gets compressed into the prefix) and re-estimate.
- *
- * Always preserves at least the most recent turn — we can't compress the
- * in-flight turn. If that single remaining turn still exceeds the budget it is
- * preserved anyway and a warning is logged (the tool-result-truncation work
- * addresses that residual case).
- *
- * Re-derives `{earlier, tail}` via `splitAtTailBoundary` at the reduced turn
- * count so the unchanged prefix-compression and `buildPreservedTail` logic runs
- * over the adjusted split.
- */
-export function trimTailToTokenBudget(
-  events: TypedDurableEvent[],
-  tailTurns: number,
-  budget: number
-): { earlier: TypedDurableEvent[]; tail: TypedDurableEvent[] } {
-  let split = splitAtTailBoundary(events, tailTurns);
-  let turns = tailTurns;
-
-  while (turns > 1 && estimateTailTokens(split.tail) > budget) {
-    turns -= 1;
-    split = splitAtTailBoundary(events, turns);
-  }
-
-  if (estimateTailTokens(split.tail) > budget) {
-    logger.warn(
-      'compaction: preserved tail exceeds token budget with a single turn — preserving it anyway',
-      {
-        budget,
-        estimatedTailTokens: estimateTailTokens(split.tail),
-        tailTurns: turns,
-      }
-    );
-  }
-
-  return split;
-}
 
 /**
  * Track-based compaction orchestrator. Pure: returns the event the caller

--- a/packages/agent/src/compaction/track-compaction.ts
+++ b/packages/agent/src/compaction/track-compaction.ts
@@ -173,26 +173,54 @@ export function salienceForTrack(trackId: string, events: TypedDurableEvent[]): 
 const TAIL_TURNS = 10;
 
 /**
- * Upper bound (in estimated tokens) on the verbatim tail we preserve through a
- * compaction. `TAIL_TURNS` caps the tail by *turn count*; this caps it by
- * *size*, so a handful of very large recent turns (long messages + big tool /
- * subagent outputs) can't blow past the model's context window even right after
+ * Ceiling on the verbatim tail we preserve through a compaction, in estimated
+ * tokens. `TAIL_TURNS` caps the tail by *turn count*; this caps it by *size*,
+ * so a handful of very large recent turns (long messages + big tool / subagent
+ * outputs) can't blow past the model's context window even right after
  * compacting.
  *
- * 300K is deliberately conservative: it leaves ample room under a 1M-token
- * window (far under the ~950K usable after system prompt + output reserve +
- * the prefix summary), with plenty of headroom for new turns before the next
+ * 300K is the ceiling rather than the answer: on a 1M-token window it leaves
+ * ample room (far under the ~950K usable after system prompt + output reserve +
+ * the prefix summary) with plenty of headroom for new turns before the next
  * compaction fires. The token-blind 10-turn tail once reached ~600K in
  * production and 400'd every request with `prompt_too_long`.
- *
- * Known limitation, tracked separately: this is a FIXED constant, not a
- * fraction of the running model's context window. On a model with a window
- * under ~350K the preserved tail alone can still exceed it, so a compaction
- * cannot get the session back under the limit. The runner's emergency
- * compaction (PRI-2903) logs loudly when the compacted history is still over
- * the window rather than retrying indefinitely.
  */
-const TAIL_TOKEN_BUDGET = 300_000;
+export const TAIL_TOKEN_BUDGET_CAP = 300_000;
+
+/**
+ * Fraction of the model's context window the preserved tail may occupy. The
+ * remaining 10% is the room compaction needs to be worth anything: the prefix
+ * summary, the system prompt, and at least one new turn all have to fit
+ * alongside the tail or the session is still over the window the moment it
+ * finishes compacting.
+ */
+export const TAIL_BUDGET_WINDOW_FRACTION = 0.9;
+
+/**
+ * The window we assume when the call site couldn't tell us one. Matches
+ * `BaseProvider.contextWindowForModel`'s own fallback, so an unplumbed caller
+ * degrades to a tail that is safe on every model we ship rather than to the
+ * 300K ceiling, which is larger than the entire window on a 200K model.
+ */
+const ASSUMED_CONTEXT_WINDOW = 200_000;
+
+/**
+ * Token budget for the preserved tail on a model with this context window.
+ *
+ * Before PRI-2906 this was a flat 300K with no relationship to the running
+ * model. On any window under ~333K that budget exceeded the window itself, so
+ * a compacted session was still over the limit — PRI-2903's emergency
+ * self-heal would compact, retry, 400 again, and every later turn would burn
+ * another compaction that also could not help. We only failed to notice
+ * because the fleet runs ~1M-window models.
+ */
+export function tailTokenBudget(contextWindow?: number): number {
+  const window =
+    contextWindow !== undefined && Number.isFinite(contextWindow) && contextWindow > 0
+      ? contextWindow
+      : ASSUMED_CONTEXT_WINDOW;
+  return Math.min(TAIL_TOKEN_BUDGET_CAP, Math.floor(window * TAIL_BUDGET_WINDOW_FRACTION));
+}
 
 /**
  * Estimate the on-wire token size of the verbatim tail by building the exact
@@ -252,9 +280,13 @@ export function trimTailToTokenBudget(
  */
 export async function compact(
   events: TypedDurableEvent[],
-  _ctx: CompactionContext
+  ctx: CompactionContext
 ): Promise<CompactResult> {
-  const { earlier, tail } = trimTailToTokenBudget(events, TAIL_TURNS, TAIL_TOKEN_BUDGET);
+  const { earlier, tail } = trimTailToTokenBudget(
+    events,
+    TAIL_TURNS,
+    tailTokenBudget(ctx.contextWindow)
+  );
 
   if (earlier.length === 0) {
     return { noop: true };

--- a/packages/agent/src/compaction/types.ts
+++ b/packages/agent/src/compaction/types.ts
@@ -32,6 +32,15 @@ export interface CompactionContext {
     signal?: AbortSignal;
   }) => Promise<{ text: string; usage?: ProviderResponse['usage'] }>;
   /**
+   * Context window (in tokens) of the model this session runs on, when the
+   * call site can resolve it. Strategies size the history they preserve
+   * against it: a tail larger than the window leaves the session over the
+   * limit the moment compaction finishes, which is the wedge PRI-2906
+   * describes. Absent when the caller holds no provider; strategies then
+   * assume the provider's own conservative fallback.
+   */
+  readonly contextWindow?: number;
+  /**
    * Free-text steering hint forwarded from the compact caller:
    * - compact_session / ent.session.compact passes the request's `guidance` field
    * - /compact passes the remainder of the command line

--- a/packages/agent/src/conversation/slash-commands.ts
+++ b/packages/agent/src/conversation/slash-commands.ts
@@ -12,8 +12,7 @@ import {
 import { validatePersonaName } from '@lace/agent/storage/transcript-paths';
 import { resolveCompactionStrategy, validatePreserved } from '@lace/agent/compaction/strategy';
 import { compactionStrategyNameForSession } from '@lace/agent/compaction/select';
-import { buildCompactionContext } from '@lace/agent/compaction/build-context';
-import { resolveContextWindow } from '@lace/agent/compaction/context-window';
+import { buildCompactionContextForConnection } from '@lace/agent/compaction/build-context';
 import { readDurableEvents } from '@lace/agent/storage/event-log';
 import type { TypedDurableEvent } from '@lace/agent/storage/event-types';
 import {
@@ -158,15 +157,11 @@ export async function handleSlashCommand(
         const name = compactionStrategyNameForSession(sessionDir);
         // args is the free-text tail after /compact — thread as guidance.
         const guidance = args.trim() || undefined;
-        const compactionCtx = buildCompactionContext({
+        const compactionCtx = await buildCompactionContextForConnection({
           threadId: sessionId,
           sessionDir,
           connectionId: effectiveConfig.connectionId,
           modelId: effectiveConfig.modelId,
-          contextWindow: await resolveContextWindow({
-            connectionId: effectiveConfig.connectionId,
-            modelId: effectiveConfig.modelId,
-          }),
           guidance,
         });
         const raw = await resolveCompactionStrategy(name).compact(events, compactionCtx);

--- a/packages/agent/src/conversation/slash-commands.ts
+++ b/packages/agent/src/conversation/slash-commands.ts
@@ -13,6 +13,7 @@ import { validatePersonaName } from '@lace/agent/storage/transcript-paths';
 import { resolveCompactionStrategy, validatePreserved } from '@lace/agent/compaction/strategy';
 import { compactionStrategyNameForSession } from '@lace/agent/compaction/select';
 import { buildCompactionContext } from '@lace/agent/compaction/build-context';
+import { resolveContextWindow } from '@lace/agent/compaction/context-window';
 import { readDurableEvents } from '@lace/agent/storage/event-log';
 import type { TypedDurableEvent } from '@lace/agent/storage/event-types';
 import {
@@ -162,6 +163,10 @@ export async function handleSlashCommand(
           sessionDir,
           connectionId: effectiveConfig.connectionId,
           modelId: effectiveConfig.modelId,
+          contextWindow: await resolveContextWindow({
+            connectionId: effectiveConfig.connectionId,
+            modelId: effectiveConfig.modelId,
+          }),
           guidance,
         });
         const raw = await resolveCompactionStrategy(name).compact(events, compactionCtx);

--- a/packages/agent/src/core/conversation/__tests__/runner.breakpoints.test.ts
+++ b/packages/agent/src/core/conversation/__tests__/runner.breakpoints.test.ts
@@ -27,6 +27,7 @@ import type { Tool } from '@lace/agent/tools/tool';
 import { ToolExecutor } from '@lace/agent/tools/executor';
 import { registerBuiltinTools } from '@lace/agent/tools/builtins';
 import { resetRegistriesForTest } from '@lace/agent/plugins';
+import { estimateProviderTokens } from '@lace/agent/message-building/message-builder';
 
 // ---------------------------------------------------------------------------
 // Mock compactionBreakpointsForSession so persona file loading is not required
@@ -201,6 +202,56 @@ function seedSession(sessionDir: string, sessionId: string, cwd: string, persona
   );
 }
 
+/**
+ * Like seedSession, but with turns big enough that the compaction's TOKEN
+ * budget — not its turn count — decides where the tail split lands.
+ */
+function seedLargeTurns(
+  sessionDir: string,
+  sessionId: string,
+  cwd: string,
+  persona: string,
+  count: number,
+  chars: number
+): void {
+  const now = new Date().toISOString();
+  const lines: string[] = [
+    JSON.stringify({
+      eventSeq: 1,
+      timestamp: now,
+      type: 'system_prompt_set',
+      data: { type: 'system_prompt_set', text: 'You are a test assistant.' },
+    }),
+  ];
+  let seq = 2;
+  for (let i = 0; i < count; i++) {
+    const tid = `big_turn_${i}`;
+    const push = (type: string, data: Record<string, unknown>, turnId?: string) =>
+      lines.push(
+        JSON.stringify({
+          eventSeq: seq++,
+          timestamp: now,
+          ...(turnId ? { turnId } : {}),
+          type,
+          data: { type, ...data },
+        })
+      );
+    push('prompt', { content: [{ type: 'text', text: `big prompt ${i}` }] });
+    push('turn_start', {}, tid);
+    push('message', { content: [{ type: 'text', text: 'x'.repeat(chars) }] }, tid);
+    push('turn_end', { stopReason: 'end_turn' }, tid);
+  }
+  writeFileSync(join(sessionDir, 'events.jsonl'), lines.join('\n') + '\n');
+  writeFileSync(
+    join(sessionDir, 'state.json'),
+    JSON.stringify({ nextEventSeq: seq, nextStreamSeq: 1 })
+  );
+  writeFileSync(
+    join(sessionDir, 'meta.json'),
+    JSON.stringify({ sessionId, workDir: cwd, created: now, persona })
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -338,6 +389,73 @@ describe('ConversationRunner - configurable breakpoints', () => {
 
     const { events } = readDurableEvents(sessionDir, {});
     expect(events.some((e) => e.type === 'context_compacted')).toBe(true);
+  });
+
+  it('sizes a breakpoint compaction to the model window, not a fixed 300K (PRI-2906)', async () => {
+    // The post-turn trigger is the common case — breakpoints and the
+    // compact_session tool both land here — so it is the one that most needs
+    // to hand the strategy the right window. A compaction sized for a 1M model
+    // leaves a 200K session still over its limit, which is the wedge.
+    mockBreakpoints.mockReturnValue([{ at: 0.5, action: 'compact' }]);
+
+    const compactedUnderWindow = async (window: number) => {
+      seedLargeTurns(sessionDir, sessionId, cwd, 'compact-low', 12, 200_000);
+      const provider = new ScriptedProvider(
+        [
+          {
+            content: 'done',
+            toolCalls: [],
+            stopReason: 'stop',
+            usage: {
+              promptTokens: Math.floor(window * 0.6),
+              completionTokens: 10,
+              totalTokens: Math.floor(window * 0.6) + 10,
+            },
+          },
+        ],
+        window
+      );
+      const executor = new ToolExecutor();
+      executor.registerAllAvailableTools({ skillDirs: [] } as any);
+      const runner = new ConversationRunner(
+        {
+          sessionDir,
+          sessionId,
+          cwd,
+          executionMode: 'execute',
+          approvalMode: 'approve',
+          persona: 'compact-low',
+        },
+        createMockDeps({
+          createProvider: vi.fn().mockImplementation(async () => provider),
+          createToolExecutor: vi.fn().mockReturnValue({
+            executor,
+            toolsForProvider: executor.getAllTools(),
+          }),
+        })
+      );
+      await runner.run({
+        content: [{ type: 'text', text: 'hello' }],
+        abortController: new AbortController(),
+        turnId: `turn_${randomUUID()}`,
+        startedAt: new Date().toISOString(),
+      });
+      const { events } = readDurableEvents(sessionDir, { limit: Number.MAX_SAFE_INTEGER });
+      const compacted = events.filter((e) => e.type === 'context_compacted');
+      expect(compacted.length).toBeGreaterThan(0);
+      const preserved = (compacted.at(-1)!.data as { preserved: ProviderMessage[] }).preserved;
+      return estimateProviderTokens(preserved);
+    };
+
+    const narrow = await compactedUnderWindow(200_000);
+    const wide = await compactedUnderWindow(1_000_000);
+
+    // The 200K session's compacted history actually fits its window...
+    expect(narrow).toBeLessThan(200_000);
+    // ...and it is genuinely a different, smaller history than the 1M one,
+    // which keeps the 300K ceiling. Equal values mean the window never reached
+    // the strategy.
+    expect(narrow).toBeLessThan(wide);
   });
 
   it('crossing a compact breakpoint emits a compaction_complete session update (PRI-2889)', async () => {

--- a/packages/agent/src/core/conversation/__tests__/runner.emergency-compaction.test.ts
+++ b/packages/agent/src/core/conversation/__tests__/runner.emergency-compaction.test.ts
@@ -26,6 +26,7 @@ import {
   type WireTool,
 } from '@lace/agent/providers/base-provider';
 import { resetRegistriesForTest } from '@lace/agent/plugins';
+import { estimateProviderTokens } from '@lace/agent/message-building/message-builder';
 
 const CONTEXT_EXCEEDED: ProviderResponse = {
   content: '',
@@ -290,6 +291,77 @@ describe('ConversationRunner — emergency compaction on context_window_exceeded
   function durableEvents() {
     return readDurableEvents(sessionDir, { limit: Number.MAX_SAFE_INTEGER }).events;
   }
+
+  /**
+   * Replace the seeded log with `count` completed turns whose answers are
+   * `chars` long, so the preserved tail is big enough for the token budget —
+   * not the turn count — to decide where the split lands.
+   */
+  function seedLargeTurns(count: number, chars: number) {
+    const now = new Date().toISOString();
+    const lines: string[] = [
+      JSON.stringify({
+        eventSeq: 1,
+        timestamp: now,
+        type: 'system_prompt_set',
+        data: { type: 'system_prompt_set', text: 'You are a test assistant.' },
+      }),
+    ];
+    let seq = 2;
+    for (let i = 0; i < count; i++) {
+      const tid = `big_turn_${i}`;
+      const push = (type: string, data: Record<string, unknown>, turnId?: string) =>
+        lines.push(
+          JSON.stringify({
+            eventSeq: seq++,
+            timestamp: now,
+            ...(turnId ? { turnId } : {}),
+            type,
+            data: { type, ...data },
+          })
+        );
+      push('prompt', { content: [{ type: 'text', text: `big prompt ${i}` }] });
+      push('turn_start', {}, tid);
+      push('message', { content: [{ type: 'text', text: 'x'.repeat(chars) }] }, tid);
+      push('turn_end', { stopReason: 'end_turn' }, tid);
+    }
+    writeFileSync(join(sessionDir, 'events.jsonl'), lines.join('\n') + '\n');
+    writeFileSync(
+      join(sessionDir, 'state.json'),
+      JSON.stringify({ nextEventSeq: seq, nextStreamSeq: 1 })
+    );
+  }
+
+  it('sizes the preserved tail to the model window rather than a fixed 300K', async () => {
+    // PRI-2906. The tail budget used to be a flat 300K with no relationship to
+    // the running model. On a 200K model that budget is bigger than the entire
+    // window, so this very retry would 400 again and every later turn would
+    // burn another compaction that also could not help. Two runs over the same
+    // ~600K history, differing only in the provider's window.
+    const HISTORY = { turns: 12, chars: 200_000 }; // ~50k tokens per turn
+
+    seedLargeTurns(HISTORY.turns, HISTORY.chars);
+    const wide = new ScriptedProvider([CONTEXT_EXCEEDED, CLEAN_TURN]);
+    await run(wide).promise;
+    const wideRetryTokens = estimateProviderTokens(wide.sentMessages[1]!);
+
+    class NarrowProvider extends ScriptedProvider {
+      override contextWindowForModel(): number {
+        return 200_000;
+      }
+    }
+    seedLargeTurns(HISTORY.turns, HISTORY.chars);
+    const narrow = new NarrowProvider([CONTEXT_EXCEEDED, CLEAN_TURN]);
+    await run(narrow).promise;
+    const narrowRetryTokens = estimateProviderTokens(narrow.sentMessages[1]!);
+
+    // The 1M model keeps the 300K ceiling — which is what makes this history
+    // still far too big for a 200K model.
+    expect(wideRetryTokens).toBeGreaterThan(200_000);
+    // The 200K model's retry actually fits the window it just bounced off.
+    expect(narrowRetryTokens).toBeLessThan(200_000);
+    expect(narrowRetryTokens).toBeLessThan(wideRetryTokens);
+  });
 
   it('compacts and retries the turn once, so the turn completes', async () => {
     const provider = new ScriptedProvider([CONTEXT_EXCEEDED, CLEAN_TURN]);

--- a/packages/agent/src/core/conversation/runner.ts
+++ b/packages/agent/src/core/conversation/runner.ts
@@ -1085,6 +1085,7 @@ export class ConversationRunner {
           try {
             compacted = await this.compactSession({
               modelId,
+              contextWindow: provider.contextWindowForModel(modelId ?? 'default'),
               updateTurnSeq: durableTurnSeq,
             });
           } catch (compactionErr) {
@@ -1145,10 +1146,12 @@ export class ConversationRunner {
             pauseResumeCount = 0;
             // The compacted history is the whole point of the retry. If it is
             // STILL over the window, the retry will 400 again and the session
-            // churns — the tail budget in track-compaction is a fixed constant,
-            // not a function of this model's window, so that is reachable on
-            // any model with a window under ~350K. Say so loudly; the retry
-            // still runs, and the emergency budget bounds the churn.
+            // churns. Since PRI-2906 the tail budget is a fraction of this
+            // model's window, so the remaining way to land here is a single
+            // in-flight turn too large to compress at all — track-based
+            // preserves it regardless rather than dropping the turn. Say so
+            // loudly; the retry still runs, and the emergency budget bounds
+            // the churn.
             const compactedEstimate = estimateProviderTokens(providerMessages);
             const windowSize = provider.contextWindowForModel(modelId ?? 'default');
             if (compactedEstimate >= windowSize) {
@@ -1519,6 +1522,7 @@ export class ConversationRunner {
         if (compactionRequest.requested || breakpointCompactCrossed) {
           await this.compactSession({
             modelId,
+            contextWindow: contextWindowSize,
             guidance: compactionRequest.guidance,
             updateTurnSeq: durableTurnSeq,
           });
@@ -1574,6 +1578,13 @@ export class ConversationRunner {
   private async compactSession(params: {
     modelId?: string;
     guidance?: string;
+    /**
+     * Context window of the model this turn ran on. The strategy sizes the
+     * preserved tail against it — without it, compaction can hand back a
+     * history that is still too big for the very model that just rejected it
+     * (PRI-2906). Both callers run inside `run()`, where the provider is live.
+     */
+    contextWindow: number;
     /** Stream seq for the compaction_complete update. */
     updateTurnSeq: number;
   }): Promise<boolean> {
@@ -1590,6 +1601,7 @@ export class ConversationRunner {
       sessionDir,
       connectionId: this.config.connectionId,
       modelId: params.modelId ?? undefined,
+      contextWindow: params.contextWindow,
       guidance: params.guidance,
     });
     const raw = await strategy.compact(

--- a/packages/agent/src/core/conversation/runner.ts
+++ b/packages/agent/src/core/conversation/runner.ts
@@ -1147,11 +1147,15 @@ export class ConversationRunner {
             // The compacted history is the whole point of the retry. If it is
             // STILL over the window, the retry will 400 again and the session
             // churns. Since PRI-2906 the tail budget is a fraction of this
-            // model's window, so the remaining way to land here is a single
-            // in-flight turn too large to compress at all — track-based
-            // preserves it regardless rather than dropping the turn. Say so
-            // loudly; the retry still runs, and the emergency budget bounds
-            // the churn.
+            // model's window, which removes the largest cause but not every
+            // one: a single in-flight turn too big to compress at all is
+            // preserved regardless rather than dropped; a strategy may ignore
+            // ctx.contextWindow; the catalog may report the wrong window for a
+            // model it doesn't describe; and this very check measures messages
+            // only — estimateProviderTokens excludes the system prompt, tool
+            // schemas, and images, so it under-reports and can stay quiet on a
+            // session that will 400 again. Say so loudly; the retry still
+            // runs, and the emergency budget bounds the churn.
             const compactedEstimate = estimateProviderTokens(providerMessages);
             const windowSize = provider.contextWindowForModel(modelId ?? 'default');
             if (compactedEstimate >= windowSize) {

--- a/packages/agent/src/message-building/message-builder.ts
+++ b/packages/agent/src/message-building/message-builder.ts
@@ -5,7 +5,10 @@ import type { ContentBlock, ProviderMessage, ThinkingBlock } from '../providers/
 import { appendOrMergeUser } from './append-or-merge';
 import { foldEvent, initialFoldState, type FoldState } from './fold-event';
 import type { ToolCall as CoreToolCall, ToolResult as CoreToolResult } from '../tools/types';
-import { estimateTokens } from '@lace/agent/utils/token-estimation';
+import { estimateProviderTokens } from '@lace/agent/utils/token-estimation';
+
+// Re-exported from its pure home so the many existing importers are unchanged.
+export { estimateProviderTokens };
 import { logger } from '@lace/agent/utils/logger';
 import { readParsedSessionEvents, type ParsedSessionEvent } from './parsed-events';
 
@@ -402,31 +405,4 @@ export function buildProviderMessagesFromParsedEvents(
   for (const e of parsedEvents) applyEventToProjection(acc, e.type, e.data);
   finalizeProjectionWarnings(acc);
   return { messages: acc.state.messages, systemPrompt: acc.systemPrompt };
-}
-
-/**
- * Estimates the total token count for a set of provider messages.
- * Includes content tokens, tool call tokens, and tool result tokens.
- */
-export function estimateProviderTokens(messages: ProviderMessage[]): number {
-  let total = 0;
-  for (const message of messages) {
-    if (typeof message.content === 'string') {
-      total += estimateTokens(message.content);
-    } else {
-      // Count tokens for text blocks only (images don't count as text tokens)
-      const textContent = message.content
-        .filter((b): b is ContentBlock & { type: 'text' } => b.type === 'text')
-        .map((b) => b.text)
-        .join('\n');
-      total += estimateTokens(textContent);
-    }
-    if (message.toolCalls) {
-      total += estimateTokens(JSON.stringify(message.toolCalls));
-    }
-    if (message.toolResults) {
-      total += estimateTokens(JSON.stringify(message.toolResults));
-    }
-  }
-  return total;
 }

--- a/packages/agent/src/providers/catalog/__tests__/shipped-model-windows.test.ts
+++ b/packages/agent/src/providers/catalog/__tests__/shipped-model-windows.test.ts
@@ -1,0 +1,38 @@
+// ABOUTME: Pins the context window of every model the fleet actually runs, because
+// ABOUTME: a model missing from this catalog does not fail — it silently gets the
+// ABOUTME: dynamic provider's INFERRED_CONTEXT_WINDOW of 200K. That guess is
+// ABOUTME: invisible at runtime and now decides how much history compaction keeps.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { CatalogProviderSchema } from '../types';
+
+/**
+ * Models named by sen's personas and environments. A model absent from the
+ * static catalog resolves to a 200K window whether or not that is true, which
+ * (a) makes compaction pressure fire five times too early on a 1M model and
+ * (b) since PRI-2906 shrinks the preserved tail to match the wrong number.
+ * `claude-sonnet-5` was exactly that case: three personas ran it while lace
+ * believed it held 200K.
+ */
+const EXPECTED_WINDOWS: Record<string, number> = {
+  'claude-opus-5': 1_000_000,
+  'claude-opus-4-8': 1_000_000,
+  'claude-sonnet-5': 1_000_000,
+  'claude-haiku-4-5-20251001': 200_000,
+};
+
+describe('shipped Anthropic catalog', () => {
+  const raw = readFileSync(path.resolve(__dirname, '../data/anthropic.json'), 'utf8');
+  const catalog = CatalogProviderSchema.parse(JSON.parse(raw));
+  const byId = new Map(catalog.models.map((m) => [m.id, m]));
+
+  for (const [id, window] of Object.entries(EXPECTED_WINDOWS)) {
+    it(`describes ${id} with a ${window / 1000}K context window`, () => {
+      const model = byId.get(id);
+      expect(model, `${id} is missing from the static catalog`).toBeDefined();
+      expect(model!.context_window).toBe(window);
+    });
+  }
+});

--- a/packages/agent/src/providers/catalog/alias-resolver.ts
+++ b/packages/agent/src/providers/catalog/alias-resolver.ts
@@ -1,7 +1,15 @@
 // ABOUTME: Resolves bare model aliases (haiku, sonnet, opus) to concrete catalog ids
 // ABOUTME: Exact catalog ids pass through unchanged; unknown strings also pass through
 
-import type { CatalogModel } from './types';
+/**
+ * Anything with an id can be ranked — the resolver reads nothing else. Widened
+ * from CatalogModel so a caller holding a provider's own ModelInfo[] can resolve
+ * an alias against exactly the model list that provider was built with, rather
+ * than re-deriving one from the catalog and risking a different answer.
+ */
+interface HasModelId {
+  id: string;
+}
 
 const KNOWN_ALIASES = new Set(['haiku', 'sonnet', 'opus']);
 const DATE_PATTERN = /(\d{8})/;
@@ -13,8 +21,8 @@ function dateScore(id: string): number {
 
 export function resolveModelAlias(
   modelId: string,
-  models: CatalogModel[],
-  fallbackModels?: CatalogModel[]
+  models: HasModelId[],
+  fallbackModels?: HasModelId[]
 ): string {
   if (models.some((m) => m.id === modelId)) {
     return modelId;
@@ -44,7 +52,7 @@ export function resolveModelAlias(
   return modelId;
 }
 
-function pickNewest(matches: CatalogModel[]): string {
+function pickNewest(matches: HasModelId[]): string {
   const sorted = [...matches].sort((a, b) => {
     const dateDiff = dateScore(b.id) - dateScore(a.id);
     if (dateDiff !== 0) return dateDiff;

--- a/packages/agent/src/providers/catalog/data/anthropic.json
+++ b/packages/agent/src/providers/catalog/data/anthropic.json
@@ -48,6 +48,18 @@
       "supports_attachments": true
     },
     {
+      "id": "claude-sonnet-5",
+      "name": "Claude Sonnet 5",
+      "cost_per_1m_in": 3,
+      "cost_per_1m_out": 15,
+      "cost_per_1m_in_cached": 3.75,
+      "cost_per_1m_out_cached": 0.3,
+      "context_window": 1000000,
+      "default_max_tokens": 50000,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
       "id": "claude-sonnet-4-5-20250929",
       "name": "Claude Sonnet 4.5",
       "cost_per_1m_in": 3,

--- a/packages/agent/src/rpc/handlers/session-operations.ts
+++ b/packages/agent/src/rpc/handlers/session-operations.ts
@@ -40,8 +40,7 @@ import {
 } from '../../message-building/message-builder';
 import { resolveCompactionStrategy, validatePreserved } from '@lace/agent/compaction/strategy';
 import { compactionStrategyNameForSession } from '@lace/agent/compaction/select';
-import { buildCompactionContext } from '@lace/agent/compaction/build-context';
-import { resolveContextWindow } from '@lace/agent/compaction/context-window';
+import { buildCompactionContextForConnection } from '@lace/agent/compaction/build-context';
 import type { TypedDurableEvent } from '@lace/agent/storage/event-types';
 import { getEffectiveConfig } from '@lace/agent/core/session';
 import { buildSessionConfigOptions, isApprovalMode } from '../session-config';
@@ -510,15 +509,11 @@ export function registerSessionOperationHandlers(
         const msg = err instanceof Error ? err.message : String(err);
         throw { code: -32602, message: msg, data: { category: 'protocol' } };
       }
-      const compactionCtx = buildCompactionContext({
+      const compactionCtx = await buildCompactionContextForConnection({
         threadId: state.activeSession!.meta.sessionId,
         sessionDir,
         connectionId: effectiveConfig.connectionId,
         modelId: effectiveConfig.modelId,
-        contextWindow: await resolveContextWindow({
-          connectionId: effectiveConfig.connectionId,
-          modelId: effectiveConfig.modelId,
-        }),
         guidance: parsed?.guidance,
       });
       const raw = await strategy.compact(events, compactionCtx);

--- a/packages/agent/src/rpc/handlers/session-operations.ts
+++ b/packages/agent/src/rpc/handlers/session-operations.ts
@@ -41,6 +41,7 @@ import {
 import { resolveCompactionStrategy, validatePreserved } from '@lace/agent/compaction/strategy';
 import { compactionStrategyNameForSession } from '@lace/agent/compaction/select';
 import { buildCompactionContext } from '@lace/agent/compaction/build-context';
+import { resolveContextWindow } from '@lace/agent/compaction/context-window';
 import type { TypedDurableEvent } from '@lace/agent/storage/event-types';
 import { getEffectiveConfig } from '@lace/agent/core/session';
 import { buildSessionConfigOptions, isApprovalMode } from '../session-config';
@@ -514,6 +515,10 @@ export function registerSessionOperationHandlers(
         sessionDir,
         connectionId: effectiveConfig.connectionId,
         modelId: effectiveConfig.modelId,
+        contextWindow: await resolveContextWindow({
+          connectionId: effectiveConfig.connectionId,
+          modelId: effectiveConfig.modelId,
+        }),
         guidance: parsed?.guidance,
       });
       const raw = await strategy.compact(events, compactionCtx);

--- a/packages/agent/src/utils/token-estimation.ts
+++ b/packages/agent/src/utils/token-estimation.ts
@@ -1,5 +1,10 @@
 // ABOUTME: Token estimation utilities for analysis and display
 // ABOUTME: Provides consistent token counting across components
+// ABOUTME: Deliberately dependency-free — compaction's toolkit is imported across
+// ABOUTME: checkouts by plugins, and reaching these through message-builder pulled
+// ABOUTME: the whole storage layer (and better-sqlite3) in behind them.
+
+import type { ContentBlock, ProviderMessage } from '@lace/agent/providers/base-provider';
 
 /**
  * Estimate token count for text content
@@ -7,4 +12,34 @@
  */
 export function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
+}
+
+/**
+ * Estimates the total token count for a set of provider messages.
+ * Includes content tokens, tool call tokens, and tool result tokens.
+ *
+ * Text only: images and other non-text blocks contribute nothing, so callers
+ * sizing a payload against a context window are reading a floor, not a total.
+ */
+export function estimateProviderTokens(messages: ProviderMessage[]): number {
+  let total = 0;
+  for (const message of messages) {
+    if (typeof message.content === 'string') {
+      total += estimateTokens(message.content);
+    } else {
+      // Count tokens for text blocks only (images don't count as text tokens)
+      const textContent = message.content
+        .filter((b): b is ContentBlock & { type: 'text' } => b.type === 'text')
+        .map((b) => b.text)
+        .join('\n');
+      total += estimateTokens(textContent);
+    }
+    if (message.toolCalls) {
+      total += estimateTokens(JSON.stringify(message.toolCalls));
+    }
+    if (message.toolResults) {
+      total += estimateTokens(JSON.stringify(message.toolResults));
+    }
+  }
+  return total;
 }


### PR DESCRIPTION
Compaction preserved a verbatim tail capped at a hard-coded 300K tokens with no relationship to the running model. On any window under ~333K that budget was larger than the whole window, so a compacted session was *still* over the limit: PRI-2903's emergency self-heal would compact, retry, 400 again, and every later turn would burn another compaction that also could not help. The fleet runs ~1M-window models, so nothing here would have surfaced on its own.

The budget is now `min(300K, 0.5 × window − 25K)`, plumbed to every compaction call site.

## Why those numbers

The fraction is a **post-compaction pressure target**, not the tail's share of the window. `computePressure` divides the model's report of the *whole* input by the window, while the budget bounds only the tail — and `estimateProviderTokens` counts message text while skipping the system prompt, tool schemas, and images entirely. The overhead allowance is absolute because the overhead is absolute: it does not shrink with the window, which is exactly why small-window models were the ones that wedged.

It has to land *below* the lowest compact breakpoint, not at it. `evaluateBreakpoints` resets `highestFiredBreakpointAt` only when pressure is strictly under the lowest breakpoint, so a compaction that returns the session to 0.9 leaves every breakpoint fired and no post-turn compaction ever runs again — the same wedge one notch along. The test asserting this reads `DEFAULT_BREAKPOINTS` rather than a copy of the number, so retuning breakpoints without retuning the budget fails here instead of in production.

## Also in scope, because the fix regresses without them

- **`claude-sonnet-5` was missing from the static catalog**, so it silently resolved to the dynamic provider's inferred 200K. Three sen personas run it against a real 1M window — compaction pressure was firing five times too early there, and this change would have shed 40% of their tail. Added, with a test pinning the window of every model the fleet actually runs.
- **`resolveContextWindow` looked the window up with the unresolved model id.** The turn factory resolves a bare alias internally but never returns what it resolved to, and the lookup is an exact match — so a session configured with `opus` got the 200K default. It resolves first now, and reports "unknown" rather than a default-as-fact.
- **The toolkit had stopped being self-contained.** Reaching `estimateProviderTokens` through message-builder dragged in the storage layer and `better-sqlite3`, a native module — and plugins import the toolkit across checkouts. The function is twenty pure lines and now lives in the pure token-estimation module. There is a test that imports the toolkit alone and fails if a native module comes with it.

## Review notes

Three rounds of adversarial review, each of which found something real in the round before — including that the first two attempts at the fraction did not achieve what their commit messages claimed. Mutation-tested throughout: the post-turn trigger's window, the emergency trigger's window, `compact()` reading `ctx.contextWindow`, the min/max direction, the fraction, and the catalog window each fail a test when broken.

The two RPC handlers previously repeated a resolve-then-build pair that no test could observe — deleting the window from either passed the whole suite — so that pair is now one composed function and the composition is what the tests assert.