### PR TITLE
feat(catalog): pin what the bare model aliases and defaults mean (PRI-2918)

### DIFF
--- a/packages/agent/src/compaction/context-window.ts
+++ b/packages/agent/src/compaction/context-window.ts
@@ -40,7 +40,12 @@ export async function resolveContextWindow(
     // preserved tail to a fraction of what fits, which is the regression this
     // whole plumbing exists to avoid.
     const models = provider.getAvailableModels();
-    const resolvedId = resolveModelAlias(opts.modelId, models);
+    const resolvedId = resolveModelAlias(
+      opts.modelId,
+      models,
+      undefined,
+      provider.modelAliasesForProvider()
+    );
     const model = models.find((m) => m.id === resolvedId);
     if (!model) {
       // Better to say "I don't know" than to report a default as if it were

--- a/packages/agent/src/providers/base-provider.ts
+++ b/packages/agent/src/providers/base-provider.ts
@@ -557,6 +557,17 @@ export abstract class AIProvider extends EventEmitter {
     return this.getModelContextWindow(modelId, fallback);
   }
 
+  /**
+   * This provider's explicit alias pins, if its catalog declares any. Public so
+   * that anything resolving an alias OUTSIDE the registry resolves it to the
+   * same model the registry would have built — two resolvers disagreeing about
+   * what `opus` means is how a session gets sized against a window it does not
+   * have.
+   */
+  modelAliasesForProvider(): Record<string, string> | undefined {
+    return this._catalogData?.model_aliases;
+  }
+
   // Get model max output tokens from catalog or fallback
   protected getModelMaxOutputTokens(modelId: string, fallback: number = 8192): number {
     if (!this._catalogData) {

--- a/packages/agent/src/providers/catalog/__tests__/alias-resolver.test.ts
+++ b/packages/agent/src/providers/catalog/__tests__/alias-resolver.test.ts
@@ -94,3 +94,75 @@ describe('resolveModelAlias', () => {
     expect(resolveModelAlias('haiku', models)).toBe('claude-haiku-old-20200101');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Explicit alias pins (PRI-2918)
+// ---------------------------------------------------------------------------
+// The date-ranking heuristic below is a guess about which model an alias means,
+// and it guessed wrong: current-generation Anthropic ids carry no date, score
+// zero, and lose to older dated ones. A provider that knows what its aliases
+// mean says so instead of being inferred at.
+
+describe('resolveModelAlias — explicit pins', () => {
+  const currentGen: CatalogModel[] = [
+    makeModel('claude-opus-5'),
+    makeModel('claude-opus-4-8'),
+    makeModel('claude-sonnet-5'),
+    makeModel('claude-sonnet-4-5-20250929'),
+    makeModel('claude-opus-4-5-20251101'),
+    makeModel('claude-haiku-4-5-20251001'),
+  ];
+  const pins = {
+    opus: 'claude-opus-4-8',
+    sonnet: 'claude-sonnet-5',
+    haiku: 'claude-haiku-4-5-20251001',
+  };
+
+  it('resolves an alias to the pinned id', () => {
+    expect(resolveModelAlias('opus', currentGen, undefined, pins)).toBe('claude-opus-4-8');
+    expect(resolveModelAlias('sonnet', currentGen, undefined, pins)).toBe('claude-sonnet-5');
+    expect(resolveModelAlias('haiku', currentGen, undefined, pins)).toBe(
+      'claude-haiku-4-5-20251001'
+    );
+  });
+
+  it('honours a pin that is not what any ranking would have picked', () => {
+    // The point of pinning: `opus` means 4.8 because that is the deliberate
+    // choice, not because 4.8 sorts highest. Newest-wins would say opus-5 and
+    // the date heuristic says opus-4-5-20251101; both are wrong here.
+    const resolved = resolveModelAlias('opus', currentGen, undefined, pins);
+    expect(resolved).not.toBe('claude-opus-5');
+    expect(resolved).not.toBe('claude-opus-4-5-20251101');
+  });
+
+  it('is case-insensitive, like the rest of alias handling', () => {
+    expect(resolveModelAlias('OPUS', currentGen, undefined, pins)).toBe('claude-opus-4-8');
+    expect(resolveModelAlias('Sonnet', currentGen, undefined, pins)).toBe('claude-sonnet-5');
+  });
+
+  it('falls back to the static catalog when the live one is cold', () => {
+    // Same reason the heuristic takes a fallback list: a dynamic catalog can be
+    // partial or stale, and a pin naming a model it has not listed yet must not
+    // silently degrade to the old wrong answer.
+    expect(resolveModelAlias('sonnet', [], currentGen, pins)).toBe('claude-sonnet-5');
+  });
+
+  it('ignores a pin whose target no provider serves', () => {
+    // A stale pin must not hand back an id that will 404 at request time; fall
+    // through to the heuristic, which at least returns something servable.
+    const stale = { sonnet: 'claude-sonnet-99' };
+    expect(resolveModelAlias('sonnet', currentGen, undefined, stale)).toBe(
+      'claude-sonnet-4-5-20250929'
+    );
+  });
+
+  it('leaves an exact model id alone even when it is also a pin key', () => {
+    expect(resolveModelAlias('claude-opus-5', currentGen, undefined, pins)).toBe('claude-opus-5');
+  });
+
+  it('still resolves by ranking for a provider with no pins', () => {
+    // openai/openrouter catalogs carry no pins; their behaviour is unchanged.
+    expect(resolveModelAlias('haiku', anthropicLike)).toBe('claude-haiku-4-5-20251001');
+    expect(resolveModelAlias('gpt-4', anthropicLike)).toBe('gpt-4');
+  });
+});

--- a/packages/agent/src/providers/catalog/__tests__/shipped-model-windows.test.ts
+++ b/packages/agent/src/providers/catalog/__tests__/shipped-model-windows.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { CatalogProviderSchema } from '../types';
+import { resolveModelAlias } from '../alias-resolver';
 
 /**
  * Models named by sen's personas and environments. A model absent from the
@@ -35,4 +36,30 @@ describe('shipped Anthropic catalog', () => {
       expect(model!.context_window).toBe(window);
     });
   }
+
+  // A bare alias is what someone types when they have not thought about the
+  // exact id, so what it resolves to is a decision, not a detail. Pinned here
+  // against the SHIPPED catalog, resolved through the real resolver — the same
+  // path the registry and compaction both take.
+  const EXPECTED_ALIASES: Record<string, string> = {
+    opus: 'claude-opus-4-8',
+    sonnet: 'claude-sonnet-5',
+    haiku: 'claude-haiku-4-5-20251001',
+  };
+
+  for (const [alias, expected] of Object.entries(EXPECTED_ALIASES)) {
+    it(`resolves the bare alias '${alias}' to ${expected}`, () => {
+      expect(resolveModelAlias(alias, catalog.models, undefined, catalog.model_aliases)).toBe(
+        expected
+      );
+    });
+  }
+
+  it('serves every model an alias points at', () => {
+    // A pin naming a model this provider does not list falls back to the
+    // ranking, silently — which is the failure the pins exist to prevent.
+    for (const target of Object.values(catalog.model_aliases ?? {})) {
+      expect(byId.has(target), `alias target ${target} is not in the catalog`).toBe(true);
+    }
+  });
 });

--- a/packages/agent/src/providers/catalog/__tests__/shipped-model-windows.test.ts
+++ b/packages/agent/src/providers/catalog/__tests__/shipped-model-windows.test.ts
@@ -55,6 +55,16 @@ describe('shipped Anthropic catalog', () => {
     });
   }
 
+  it('defaults to current-generation models', () => {
+    // What a session with no configured model gets. These drifted a generation
+    // behind the same way the aliases did, and just as quietly: nothing reports
+    // which model a default resolved to.
+    expect(catalog.default_large_model_id).toBe('claude-sonnet-5');
+    expect(catalog.default_small_model_id).toBe('claude-haiku-4-5-20251001');
+    expect(byId.has(catalog.default_large_model_id)).toBe(true);
+    expect(byId.has(catalog.default_small_model_id)).toBe(true);
+  });
+
   it('serves every model an alias points at', () => {
     // A pin naming a model this provider does not list falls back to the
     // ranking, silently — which is the failure the pins exist to prevent.

--- a/packages/agent/src/providers/catalog/alias-resolver.ts
+++ b/packages/agent/src/providers/catalog/alias-resolver.ts
@@ -22,7 +22,14 @@ function dateScore(id: string): number {
 export function resolveModelAlias(
   modelId: string,
   models: HasModelId[],
-  fallbackModels?: HasModelId[]
+  fallbackModels?: HasModelId[],
+  /**
+   * The provider's own statement of what its aliases mean, from the catalog's
+   * `model_aliases`. Consulted before the ranking below, because the ranking is
+   * a guess and this is not: it says `opus` means Opus 4.8 because that is the
+   * model we chose to run, which no ordering of ids would tell you.
+   */
+  aliasPins?: Record<string, string>
 ): string {
   if (models.some((m) => m.id === modelId)) {
     return modelId;
@@ -31,6 +38,18 @@ export function resolveModelAlias(
   const aliasKey = modelId.toLowerCase();
   if (!KNOWN_ALIASES.has(aliasKey)) {
     return modelId;
+  }
+
+  const pinned = aliasPins?.[aliasKey];
+  if (pinned) {
+    // Only honour a pin the provider can actually serve. A stale pin naming a
+    // retired model would otherwise hand back an id that 404s at request time;
+    // falling through to the ranking at least returns something servable.
+    const servable =
+      models.some((m) => m.id === pinned) || fallbackModels?.some((m) => m.id === pinned);
+    if (servable) {
+      return pinned;
+    }
   }
 
   const primaryMatches = models.filter((m) => m.id.toLowerCase().includes(aliasKey));

--- a/packages/agent/src/providers/catalog/data/anthropic.json
+++ b/packages/agent/src/providers/catalog/data/anthropic.json
@@ -6,6 +6,11 @@
   "api_endpoint": "$ANTHROPIC_API_ENDPOINT",
   "default_large_model_id": "claude-sonnet-4-5-20250929",
   "default_small_model_id": "claude-3-5-haiku-20241022",
+  "model_aliases": {
+    "opus": "claude-opus-4-8",
+    "sonnet": "claude-sonnet-5",
+    "haiku": "claude-haiku-4-5-20251001"
+  },
   "models": [
     {
       "id": "claude-opus-5",

--- a/packages/agent/src/providers/catalog/data/anthropic.json
+++ b/packages/agent/src/providers/catalog/data/anthropic.json
@@ -4,8 +4,8 @@
   "type": "anthropic",
   "api_key": "$ANTHROPIC_API_KEY",
   "api_endpoint": "$ANTHROPIC_API_ENDPOINT",
-  "default_large_model_id": "claude-sonnet-4-5-20250929",
-  "default_small_model_id": "claude-3-5-haiku-20241022",
+  "default_large_model_id": "claude-sonnet-5",
+  "default_small_model_id": "claude-haiku-4-5-20251001",
   "model_aliases": {
     "opus": "claude-opus-4-8",
     "sonnet": "claude-sonnet-5",

--- a/packages/agent/src/providers/catalog/types.ts
+++ b/packages/agent/src/providers/catalog/types.ts
@@ -49,6 +49,10 @@ export const CatalogProviderSchema = z.object({
   api_endpoint: z.string().optional(),
   default_large_model_id: z.string().min(1),
   default_small_model_id: z.string().min(1),
+  // What this provider's bare aliases ('opus', 'sonnet', 'haiku') mean, as a
+  // deliberate choice rather than something inferred from the model list.
+  // Absent for providers that are happy with the resolver's ranking.
+  model_aliases: z.record(z.string(), z.string()).optional(),
   models: z.array(CatalogModelSchema),
 });
 

--- a/packages/agent/src/providers/registry.ts
+++ b/packages/agent/src/providers/registry.ts
@@ -334,7 +334,14 @@ export class ProviderRegistry {
     const staticCatalog = this.catalogManager.getProvider(providerId);
     const catalog = await this.getCatalogProvider(providerId);
     if (catalog) {
-      const resolvedModelId = resolveModelAlias(modelId, catalog.models, staticCatalog?.models);
+      const resolvedModelId = resolveModelAlias(
+        modelId,
+        catalog.models,
+        staticCatalog?.models,
+        // Pins come from the STATIC catalog: they are our deliberate choice of
+        // what an alias means, not something a live provider listing reports.
+        staticCatalog?.model_aliases ?? catalog.model_aliases
+      );
       const model =
         catalog.models.find((m) => m.id === resolvedModelId) ??
         staticCatalog?.models.find((m) => m.id === resolvedModelId);
@@ -424,7 +431,8 @@ export class ProviderRegistry {
     const resolvedModelId = resolveModelAlias(
       modelId,
       catalog?.models ?? [],
-      staticCatalog?.models
+      staticCatalog?.models,
+      staticCatalog?.model_aliases ?? catalog?.model_aliases
     );
     if (resolvedModelId !== modelId) {
       logger.debug('Resolved model alias', {

--- a/packages/ent-protocol/src/schemas/shared.ts
+++ b/packages/ent-protocol/src/schemas/shared.ts
@@ -374,6 +374,11 @@ export const CatalogProviderInfoSchema = z
     api_endpoint: z.string().optional(),
     default_large_model_id: NonEmptyStringSchema,
     default_small_model_id: NonEmptyStringSchema,
+    // What this provider's bare aliases ('opus', 'sonnet', 'haiku') resolve to.
+    // On the wire because the handler returns the catalog as-is, and because a
+    // client showing a model picker should be able to say what an alias means
+    // rather than re-deriving it and disagreeing with the agent.
+    model_aliases: z.record(z.string(), z.string()).optional(),
     models: z.array(CatalogModelInfoSchema),
   })
   .strict();


### PR DESCRIPTION
`opus` resolved to Opus 4.5 and `sonnet` to Sonnet 4.5. The resolver ranks candidates by an eight-digit date scraped out of the model id, and current-generation ids carry no date — `claude-opus-5`, `claude-opus-4-8`, `claude-sonnet-5` all score zero and lose to any older dated id that matches. So a bare alias silently selected a previous-generation model with a fifth of the context window, at different pricing, and it got *worse* every time a current model was added to the catalog.

After this: **`sonnet` → Sonnet 5, `opus` → Opus 4.8, `haiku` → Haiku 4.5.** Defaults for a session with no configured model move the same way, from Sonnet 4.5 / Haiku 3.5 to Sonnet 5 / Haiku 4.5.

## Why not just fix the ranking

Because the right answer is not "newest". `opus` means Opus 4.8 — a deliberate choice, and one no ordering of ids would ever produce; newest-wins would give you Opus 5. A heuristic cannot be repaired into a decision.

So the catalog states it. A provider declares `model_aliases`, and the resolver consults that before falling back to the existing ranking. Providers that declare none (openai, openrouter) behave exactly as before.

A pin is only honoured if the provider actually serves the model it names — otherwise a stale pin would hand back an id that 404s at request time, and falling through to the ranking at least returns something servable. A test asserts every pin's target is present in the shipped catalog, so a pin cannot rot into that state unnoticed.

## Notes

- Both registry call sites *and* compaction's `resolveContextWindow` pass the pins. Two resolvers disagreeing about what `opus` means is how a session gets its history sized against a window it does not have, which is the bug #375 just finished fixing.
- The alias map reaches the wire: `ent/providers/catalog` returns catalog objects as-is, so the protocol schema gains the field rather than the handler silently stripping it. A client with a model picker should be able to say what an alias means instead of re-deriving it and disagreeing with the agent.
- Mutation-tested: disabling the pin lookup fails 6 tests; dropping the servable guard fails 1.

Found while writing a test for #375 — the compaction work needed to know what window a session actually had, and the answer was wrong for anyone using an alias.