### PR TITLE
fix(compaction): loud persona failures, bounded fallback, and a progress postcondition (PRI-2943)

### DIFF
--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -443,11 +443,14 @@ interface CompactionContext {
 must bound that tail by TOKENS, not just by turn count — a handful of large
 turns can preserve more than the whole context window, and a compaction that
 leaves the session over the limit cannot get it back under, so the next turn
-400s and every turn after it burns another compaction that also cannot help.
-The toolkit ships the primitives:
+400s and every turn after it burns another compaction that also cannot help. The
+toolkit ships the primitives:
 
 ```ts
-import { tailTokenBudget, trimTailToTokenBudget } from '@lace/agent/compaction/toolkit';
+import {
+  tailTokenBudget,
+  trimTailToTokenBudget,
+} from '@lace/agent/compaction/toolkit';
 
 const { earlier, tail } = trimTailToTokenBudget(
   events,

--- a/packages/agent/src/compaction/__tests__/compaction-progress-guard.test.ts
+++ b/packages/agent/src/compaction/__tests__/compaction-progress-guard.test.ts
@@ -1,0 +1,85 @@
+// ABOUTME: PRI-2943 — a compaction that cannot fit the window must be reported as
+// ABOUTME: unrecoverable, not retried forever as if it had succeeded.
+
+import { describe, it, expect } from 'vitest';
+import type { CompactResult } from '../types';
+// Does not exist yet. The postcondition compaction never had.
+import { assessCompactionProgress } from '../strategy';
+
+// ---------------------------------------------------------------------------
+// `validatePreserved` checks that the result is structurally sound and that is
+// all. cadence-sen's emergency compactions all passed it while emitting a
+// prefix larger than the window, so the runner retried, re-assembled a
+// multi-megabyte context, and eventually exhausted the 2GB node heap. Thirty-two
+// times. The container reported `Up (healthy)` throughout and Slack events kept
+// queueing, so from outside she looked idle rather than broken.
+//
+// The missing postcondition is not "did it produce valid output" but "did it
+// make the session runnable". A compaction that cannot is a terminal state and
+// needs to say so once, loudly, rather than fail silently on a loop.
+// ---------------------------------------------------------------------------
+
+const CONTEXT_WINDOW = 1_000_000;
+
+const resultOfSize = (chars: number): CompactResult =>
+  ({
+    compactionEvent: {
+      type: 'context_compacted',
+      data: {
+        type: 'context_compacted',
+        strategy: 'track-based',
+        messagesCompacted: 13957,
+        preserved: [{ role: 'user', content: 'x'.repeat(chars) }],
+      },
+    },
+  }) as unknown as CompactResult;
+
+describe('assessCompactionProgress (PRI-2943)', () => {
+  it('accepts a compaction that leaves the session comfortably runnable', () => {
+    const verdict = assessCompactionProgress(resultOfSize(200_000), {
+      contextWindow: CONTEXT_WINDOW,
+      inputChars: 8_000_000,
+    });
+    expect(verdict.ok).toBe(true);
+  });
+
+  it('rejects a compaction whose own output exceeds the window', () => {
+    const verdict = assessCompactionProgress(resultOfSize(4_400_000), {
+      contextWindow: CONTEXT_WINDOW,
+      inputChars: 8_000_000,
+    });
+    expect(verdict.ok).toBe(false);
+  });
+
+  it('marks an over-window result unrecoverable rather than retryable', () => {
+    const verdict = assessCompactionProgress(resultOfSize(4_400_000), {
+      contextWindow: CONTEXT_WINDOW,
+      inputChars: 8_000_000,
+    });
+    expect(verdict.retryable).toBe(false);
+  });
+
+  it('rejects a compaction that did not shrink its input', () => {
+    const verdict = assessCompactionProgress(resultOfSize(500_000), {
+      contextWindow: CONTEXT_WINDOW,
+      inputChars: 500_000,
+    });
+    expect(verdict.ok).toBe(false);
+  });
+
+  it('explains itself with the numbers an operator needs', () => {
+    const verdict = assessCompactionProgress(resultOfSize(4_400_000), {
+      contextWindow: CONTEXT_WINDOW,
+      inputChars: 8_000_000,
+    });
+    expect(verdict.reason).toBeTruthy();
+    expect(String(verdict.reason)).toMatch(/\d/);
+  });
+
+  it('passes through when no context window is known', () => {
+    const verdict = assessCompactionProgress(resultOfSize(4_400_000), {
+      inputChars: 8_000_000,
+    });
+    expect(verdict.ok).toBe(true);
+  });
+});

--- a/packages/agent/src/compaction/__tests__/select.test.ts
+++ b/packages/agent/src/compaction/__tests__/select.test.ts
@@ -12,9 +12,13 @@ vi.mock('@lace/agent/config/persona-registry', () => ({
     parsePersona: vi.fn(),
   },
 }));
+vi.mock('@lace/agent/utils/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
 
 import { personaForSessionDir } from '@lace/agent/storage/event-log';
 import { personaRegistry } from '@lace/agent/config/persona-registry';
+import { logger } from '@lace/agent/utils/logger';
 import {
   compactionBreakpointsForSession,
   compactionStrategyNameForSession,
@@ -23,6 +27,7 @@ import {
 
 const mockPersonaForSessionDir = vi.mocked(personaForSessionDir);
 const mockParsePersona = vi.mocked(personaRegistry.parsePersona);
+const mockWarn = vi.mocked(logger.warn);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -120,5 +125,68 @@ describe('compactionStrategyNameForSession', () => {
       body: '',
     } as any);
     expect(compactionStrategyNameForSession('/some/dir')).toBe('my-strategy');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PRI-2943: a persona that cannot be resolved must not degrade in silence.
+//
+// cadence-sen ran 203 consecutive compactions on `track-based` while her
+// persona asked for `sen-multiconv`, because `personaRegistry.parsePersona`
+// threw (her instance had no `$LACE_DIR/agent-personas`) and this module
+// swallowed the throw with a bare `catch`. Nothing logged. The fallback itself
+// is correct — compaction must not become fatal on a live coworker — but it
+// has to be OBSERVABLE, and the strategy side needs the same coverage the
+// breakpoint side already had.
+// ---------------------------------------------------------------------------
+describe('persona resolution failure is loud (PRI-2943)', () => {
+  it('still falls back to track-based when parsePersona throws', () => {
+    mockPersonaForSessionDir.mockReturnValue('core');
+    mockParsePersona.mockImplementation(() => {
+      throw new Error("Persona 'core' not found. Available personas: lace");
+    });
+    expect(compactionStrategyNameForSession('/some/dir')).toBe('track-based');
+  });
+
+  it('warns when a named persona cannot be parsed for its strategy', () => {
+    mockPersonaForSessionDir.mockReturnValue('core');
+    mockParsePersona.mockImplementation(() => {
+      throw new Error("Persona 'core' not found. Available personas: lace");
+    });
+    compactionStrategyNameForSession('/some/dir');
+    expect(mockWarn).toHaveBeenCalled();
+  });
+
+  it('names the persona and the session dir in the warning', () => {
+    mockPersonaForSessionDir.mockReturnValue('core');
+    mockParsePersona.mockImplementation(() => {
+      throw new Error('boom');
+    });
+    compactionStrategyNameForSession('/instances/cadence/state/lace/agent-sessions/sess_x');
+    const logged = JSON.stringify(mockWarn.mock.calls);
+    expect(logged).toContain('core');
+    expect(logged).toContain('sess_x');
+  });
+
+  it('warns when a named persona cannot be parsed for its breakpoints', () => {
+    mockPersonaForSessionDir.mockReturnValue('core');
+    mockParsePersona.mockImplementation(() => {
+      throw new Error('boom');
+    });
+    compactionBreakpointsForSession('/some/dir');
+    expect(mockWarn).toHaveBeenCalled();
+  });
+
+  it('stays quiet on the legitimate no-persona path', () => {
+    mockPersonaForSessionDir.mockReturnValue(null);
+    expect(compactionStrategyNameForSession('/some/dir')).toBe('track-based');
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet when a parsed persona simply configures no strategy', () => {
+    mockPersonaForSessionDir.mockReturnValue('minimal');
+    mockParsePersona.mockReturnValue({ config: {}, body: '' } as any);
+    expect(compactionStrategyNameForSession('/some/dir')).toBe('track-based');
+    expect(mockWarn).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/src/compaction/__tests__/toolkit-bounds.test.ts
+++ b/packages/agent/src/compaction/__tests__/toolkit-bounds.test.ts
@@ -41,9 +41,9 @@ function pathologicalConversation(): TypedDurableEvent[] {
   const events: TypedDurableEvent[] = [];
   for (let i = 0; i < PATHOLOGICAL_EVENTS; i++) {
     events.push(
-      event(i * 2, 'prompt', { content: [{ type: 'text', text: `${LONG_TEXT} prompt ${i}` }] })
+      event(i * 2, 'prompt', { content: [{ type: 'text', text: `prompt ${i} ${LONG_TEXT}` }] })
     );
-    events.push(event(i * 2 + 1, 'message', { content: `${LONG_TEXT} reply ${i}` }));
+    events.push(event(i * 2 + 1, 'message', { content: `reply ${i} ${LONG_TEXT}` }));
   }
   return events;
 }

--- a/packages/agent/src/compaction/__tests__/toolkit-bounds.test.ts
+++ b/packages/agent/src/compaction/__tests__/toolkit-bounds.test.ts
@@ -1,0 +1,145 @@
+// ABOUTME: PRI-2943 — size bounds on the generic (track-based) compaction renderer.
+// ABOUTME: track-based is the universal fallback every session lands on when its
+// ABOUTME: persona cannot be resolved, so its output must be bounded by construction.
+
+import { describe, it, expect } from 'vitest';
+import type { DurableEventData, TypedDurableEvent } from '@lace/agent/storage/event-types';
+import { renderGenericSections, untrackedSalience, type TrackBlock } from '../toolkit';
+
+// ---------------------------------------------------------------------------
+// Why this file exists
+//
+// cadence-sen's compacted prefix reached 2,304,363 chars — ~1.01M tokens on its
+// own, larger than the 1M window it had to fit inside. Compaction could only
+// ever shed the 160KB of live tail around it, so every emergency pass produced
+// the same over-limit request and the session could never recover.
+//
+// The block was `untrackedSalience` output joined by `renderGenericSections`:
+// 4,056 `Assistant:` + 679 `User:` + 840 `Note:` lines. Each LINE was capped at
+// 500 chars; the LINE COUNT was capped at nothing, and nothing evicted by age.
+//
+// The numbers below are deliberately far beyond any sane session so the
+// assertions describe a hard ceiling rather than a tuning preference.
+// ---------------------------------------------------------------------------
+
+const PATHOLOGICAL_EVENTS = 5000;
+const LONG_TEXT = 'x'.repeat(3000);
+
+const event = (
+  seq: number,
+  type: DurableEventData['type'],
+  data: Record<string, unknown>
+): TypedDurableEvent => ({
+  eventSeq: seq,
+  timestamp: new Date(Date.parse('2026-06-01T00:00:00Z') + seq * 1000).toISOString(),
+  type,
+  data: { type, ...data } as TypedDurableEvent['data'],
+});
+
+/** A conversation track with far more turns than any bound should allow through. */
+function pathologicalConversation(): TypedDurableEvent[] {
+  const events: TypedDurableEvent[] = [];
+  for (let i = 0; i < PATHOLOGICAL_EVENTS; i++) {
+    events.push(
+      event(i * 2, 'prompt', { content: [{ type: 'text', text: `${LONG_TEXT} prompt ${i}` }] })
+    );
+    events.push(event(i * 2 + 1, 'message', { content: `${LONG_TEXT} reply ${i}` }));
+  }
+  return events;
+}
+
+/** A ceiling generous enough that no legitimate session hits it. */
+const PREFIX_CHAR_CEILING = 400_000;
+
+describe('untrackedSalience is bounded (PRI-2943)', () => {
+  it('caps total body size, not just per-line length', () => {
+    const block = untrackedSalience('untracked', pathologicalConversation());
+    expect(block.body.length).toBeLessThanOrEqual(PREFIX_CHAR_CEILING);
+  });
+
+  it('caps the number of rendered lines', () => {
+    const block = untrackedSalience('untracked', pathologicalConversation());
+    const lines = block.body.split('\n').filter((l) => l.trim().length > 0);
+    expect(lines.length).toBeLessThan(PATHOLOGICAL_EVENTS);
+  });
+
+  it('keeps the most recent turns when it drops', () => {
+    const block = untrackedSalience('untracked', pathologicalConversation());
+    expect(block.body).toContain(`reply ${PATHOLOGICAL_EVENTS - 1}`);
+  });
+
+  it('says so when it dropped history, so the agent knows to recall', () => {
+    const block = untrackedSalience('untracked', pathologicalConversation());
+    expect(block.body.toLowerCase()).toMatch(/omitted|dropped|truncated|earlier|recall/);
+  });
+
+  it('leaves a small conversation completely intact', () => {
+    const small: TypedDurableEvent[] = [
+      event(0, 'prompt', { content: [{ type: 'text', text: 'hello' }] }),
+      event(1, 'message', { content: 'hi back' }),
+    ];
+    const block = untrackedSalience('untracked', small);
+    expect(block.body).toContain('User: hello');
+    expect(block.body).toContain('Assistant: hi back');
+  });
+});
+
+describe('renderGenericSections is bounded (PRI-2943)', () => {
+  const bigBlock = (trackId: string, n: number): TrackBlock => ({
+    trackId,
+    body: `${trackId}\n${'y'.repeat(20_000)}`,
+    estimatedTokens: 5000,
+    lastActivityTs: new Date(Date.parse('2026-06-01T00:00:00Z') + n * 1000).toISOString(),
+    lastSeq: n,
+  });
+
+  it('caps the whole rendered prefix regardless of how many blocks arrive', () => {
+    const blocks = [
+      ...Array.from({ length: 200 }, (_, i) => bigBlock(`system:notify-${i}`, i)),
+      ...Array.from({ length: 200 }, (_, i) => bigBlock(`slack:C0/thread-${i}`, 200 + i)),
+    ];
+    const out = renderGenericSections({
+      blocks,
+      scheduler: { alarmsPending: 0, remindersPending: 0 },
+      referenceTimestamp: '2026-06-08T00:00:00Z',
+    });
+    expect(out.length).toBeLessThanOrEqual(PREFIX_CHAR_CEILING);
+  });
+
+  it('evicts stale system blocks the way it already evicts stale job blocks', () => {
+    const blocks = Array.from({ length: 200 }, (_, i) => bigBlock(`system:notify-${i}`, i));
+    const out = renderGenericSections({
+      blocks,
+      scheduler: { alarmsPending: 0, remindersPending: 0 },
+      referenceTimestamp: '2026-07-01T00:00:00Z', // every block is far past any horizon
+    });
+    expect(out).not.toContain('system:notify-0');
+    expect(out).toContain(`system:notify-199`);
+  });
+
+  it('never grows without a referenceTimestamp either', () => {
+    const blocks = Array.from({ length: 200 }, (_, i) => bigBlock(`other:${i}`, i));
+    const out = renderGenericSections({
+      blocks,
+      scheduler: { alarmsPending: 0, remindersPending: 0 },
+    });
+    expect(out.length).toBeLessThanOrEqual(PREFIX_CHAR_CEILING);
+  });
+
+  it('renders a normal-sized set unchanged', () => {
+    const out = renderGenericSections({
+      blocks: [
+        {
+          trackId: 'job:abc',
+          body: '- job:abc do a thing → ✓ completed',
+          estimatedTokens: 10,
+          lastActivityTs: '2026-06-01T00:00:00Z',
+          lastSeq: 1,
+        },
+      ],
+      scheduler: { alarmsPending: 0, remindersPending: 0 },
+    });
+    expect(out).toContain('## Subagent jobs');
+    expect(out).toContain('- job:abc do a thing → ✓ completed');
+  });
+});

--- a/packages/agent/src/compaction/__tests__/track-compaction.fixedpoint.test.ts
+++ b/packages/agent/src/compaction/__tests__/track-compaction.fixedpoint.test.ts
@@ -1,0 +1,145 @@
+// ABOUTME: PRI-2943 — compaction must make progress: strictly smaller than its input,
+// ABOUTME: and never larger on a second pass over its own output.
+
+import { describe, it, expect } from 'vitest';
+import type { DurableEventData, TypedDurableEvent } from '@lace/agent/storage/event-types';
+import { compact } from '../track-compaction';
+
+// ---------------------------------------------------------------------------
+// The wedge this prevents.
+//
+// cadence-sen ran ten consecutive emergency compactions on 2026-08-24 with
+// `messagesCompacted` frozen at 13,957 and the resulting request pinned at
+// ~1,010,063 tokens against a 1,000,000 window. Compaction "succeeded" every
+// time — it produced a structurally valid result — while making no progress at
+// all, because the compacted prefix it emitted was itself larger than the
+// window and the strategy had no way to shrink it further.
+//
+// Structural validity was the only postcondition anyone checked. These tests
+// add the two that matter: output smaller than input, and no growth across
+// passes.
+// ---------------------------------------------------------------------------
+
+const CONTEXT_WINDOW = 1_000_000;
+const CHARS_PER_TOKEN = 4;
+
+const event = (
+  seq: number,
+  type: DurableEventData['type'],
+  data: Record<string, unknown>,
+  turnId?: string
+): TypedDurableEvent => ({
+  eventSeq: seq,
+  timestamp: new Date(Date.parse('2026-06-01T00:00:00Z') + seq * 1000).toISOString(),
+  ...(turnId ? { turnId } : {}),
+  type,
+  data: { type, ...data } as TypedDurableEvent['data'],
+});
+
+/**
+ * A session shaped like cadence's: thousands of turns of chatty
+ * notification-and-reply traffic, none of it individually large.
+ */
+function longSession(turns: number, startSeq = 0): TypedDurableEvent[] {
+  const events: TypedDurableEvent[] = [];
+  let seq = startSeq;
+  for (let i = 0; i < turns; i++) {
+    const turnId = `turn_${i}`;
+    events.push(event(seq++, 'turn_start', {}, turnId));
+    events.push(
+      event(seq++, 'prompt', {
+        content: [{ type: 'text', text: `message ${i} from a human: ${'detail '.repeat(40)}` }],
+      })
+    );
+    events.push(
+      event(seq++, 'context_injected', {
+        content: [
+          {
+            type: 'text',
+            text: `<notification kind="job-completed">Your background job completed successfully (exit code 0). ${'padding '.repeat(30)}</notification>`,
+          },
+        ],
+      })
+    );
+    events.push(
+      event(seq++, 'message', { content: `reply ${i}: ${'reasoning '.repeat(40)}` }, turnId)
+    );
+    events.push(event(seq++, 'turn_end', { stopReason: 'end_turn' }, turnId));
+  }
+  return events;
+}
+
+const sizeOf = (events: TypedDurableEvent[]) => JSON.stringify(events).length;
+
+function preservedSize(result: Awaited<ReturnType<typeof compact>>): number {
+  if ('noop' in result) return 0;
+  return JSON.stringify(result.compactionEvent.data.preserved).length;
+}
+
+describe('compaction makes progress (PRI-2943)', () => {
+  it('emits a prefix smaller than the events it compacted', async () => {
+    const events = longSession(1500);
+    const result = await compact(events, {
+      threadId: 'sess_progress',
+      contextWindow: CONTEXT_WINDOW,
+    });
+    expect('noop' in result).toBe(false);
+    expect(preservedSize(result)).toBeLessThan(sizeOf(events));
+  });
+
+  it('emits a prefix that fits the context window it was given', async () => {
+    const events = longSession(3000);
+    const result = await compact(events, { threadId: 'sess_fits', contextWindow: CONTEXT_WINDOW });
+    expect('noop' in result).toBe(false);
+    // Not merely "under the window" — under it with room for a real turn.
+    expect(preservedSize(result) / CHARS_PER_TOKEN).toBeLessThan(CONTEXT_WINDOW * 0.8);
+  });
+
+  it('does not grow when compacting again over its own output', async () => {
+    const first = longSession(1500);
+    const firstResult = await compact(first, {
+      threadId: 'sess_fixedpoint',
+      contextWindow: CONTEXT_WINDOW,
+    });
+    expect('noop' in firstResult).toBe(false);
+    if ('noop' in firstResult) return;
+
+    // Replay as the runner does: the prior compaction event, then more traffic.
+    const second = [
+      ...first,
+      { ...event(9_000, 'context_compacted', {}), data: firstResult.compactionEvent.data },
+      ...longSession(200, 10_000),
+    ] as TypedDurableEvent[];
+
+    const secondResult = await compact(second, {
+      threadId: 'sess_fixedpoint',
+      contextWindow: CONTEXT_WINDOW,
+    });
+    expect('noop' in secondResult).toBe(false);
+    expect(preservedSize(secondResult)).toBeLessThanOrEqual(preservedSize(firstResult) * 1.1);
+  });
+
+  it('still shrinks a session whose prior prefix is already over the window', async () => {
+    // cadence's actual state: the carried summary alone exceeds the window.
+    const oversizeSummary = '[Earlier conversation, compacted by track]\n' + 'x'.repeat(2_300_000);
+    const events = [
+      {
+        ...event(0, 'context_compacted', {}),
+        data: {
+          type: 'context_compacted',
+          strategy: 'track-based',
+          messagesCompacted: 13957,
+          preserved: [{ role: 'user', content: oversizeSummary }],
+        },
+      },
+      ...longSession(100, 1),
+    ] as TypedDurableEvent[];
+
+    const result = await compact(events, {
+      threadId: 'sess_wedged',
+      contextWindow: CONTEXT_WINDOW,
+    });
+    expect('noop' in result).toBe(false);
+    expect(preservedSize(result) / CHARS_PER_TOKEN).toBeLessThan(CONTEXT_WINDOW * 0.8);
+  });
+});

--- a/packages/agent/src/compaction/select.ts
+++ b/packages/agent/src/compaction/select.ts
@@ -1,6 +1,8 @@
 // ABOUTME: Resolve the compaction strategy NAME and breakpoints for a session from its persona
 import { personaForSessionDir } from '@lace/agent/storage/event-log';
 import { personaRegistry } from '@lace/agent/config/persona-registry';
+import { logger } from '@lace/agent/utils/logger';
+import { basename } from 'node:path';
 
 export type Breakpoint = { at: number; action: 'notify' | 'compact' };
 
@@ -9,29 +11,57 @@ export const DEFAULT_BREAKPOINTS: Breakpoint[] = [
   { at: 0.9, action: 'compact' },
 ];
 
-export function compactionStrategyNameForSession(sessionDir: string): string {
+/**
+ * Resolve a session's persona config, or `null` when the session has no persona.
+ *
+ * A session that NAMES a persona which then fails to parse is a misconfiguration,
+ * not a default: the caller falls back so a live agent keeps running, but the
+ * fallback is reported. PRI-2943 — cadence-sen named `core`, the registry could
+ * not find it (her instance had no `$LACE_DIR/agent-personas`), and a bare
+ * `catch` turned that into 203 consecutive compactions on the wrong strategy
+ * with an unbounded renderer. Nothing logged for four weeks.
+ */
+function personaConfigForSession(
+  sessionDir: string,
+  what: string
+): { compaction?: { strategy?: string; breakpoints?: unknown[] } } | null {
+  let persona: string | null = null;
   try {
-    const persona = personaForSessionDir(sessionDir);
-    if (persona) {
-      return personaRegistry.parsePersona(persona).config.compaction?.strategy ?? 'track-based';
-    }
-  } catch {
-    /* default */
+    persona = personaForSessionDir(sessionDir);
+  } catch (err) {
+    logger.warn('compaction: could not read the persona for this session; using defaults', {
+      session: basename(sessionDir),
+      sessionDir,
+      resolving: what,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
   }
-  return 'track-based';
+  // No persona is a legitimate state, not a failure — stay quiet.
+  if (!persona) return null;
+
+  try {
+    return personaRegistry.parsePersona(persona).config;
+  } catch (err) {
+    logger.warn(
+      'compaction: session names a persona that failed to parse; falling back to defaults',
+      {
+        persona,
+        session: basename(sessionDir),
+        sessionDir,
+        resolving: what,
+        error: err instanceof Error ? err.message : String(err),
+      }
+    );
+    return null;
+  }
+}
+
+export function compactionStrategyNameForSession(sessionDir: string): string {
+  return personaConfigForSession(sessionDir, 'strategy')?.compaction?.strategy ?? 'track-based';
 }
 
 export function compactionBreakpointsForSession(sessionDir: string): Breakpoint[] {
-  try {
-    const persona = personaForSessionDir(sessionDir);
-    if (persona) {
-      const bp = personaRegistry.parsePersona(persona).config.compaction?.breakpoints;
-      if (bp && bp.length > 0) {
-        return bp as Breakpoint[];
-      }
-    }
-  } catch {
-    /* default */
-  }
-  return DEFAULT_BREAKPOINTS;
+  const bp = personaConfigForSession(sessionDir, 'breakpoints')?.compaction?.breakpoints;
+  return bp && bp.length > 0 ? (bp as Breakpoint[]) : DEFAULT_BREAKPOINTS;
 }

--- a/packages/agent/src/compaction/strategy.ts
+++ b/packages/agent/src/compaction/strategy.ts
@@ -43,3 +43,69 @@ export function validatePreserved(result: CompactResult): CompactResult {
     },
   };
 }
+
+// ---------------------------------------------------------------------------
+// Compaction progress postcondition (PRI-2943)
+//
+// `validatePreserved` answers "is this result structurally sound". Nothing
+// answered "did this compaction make the session runnable again", and the two
+// are not the same question. cadence-sen's emergency compactions all passed
+// validation while emitting a prefix larger than the context window; the runner
+// read that as success, retried, re-assembled a multi-megabyte context, and
+// exhausted the 2GB node heap. Thirty-two times over two days, with the
+// container reporting healthy and Slack events queueing behind it.
+//
+// A compaction that cannot fit the window is terminal, not transient: the same
+// strategy over the same events is deterministic, so retrying reproduces it
+// exactly. Say so once, loudly, and stop.
+// ---------------------------------------------------------------------------
+
+/**
+ * Deliberately pessimistic chars-per-token divisor. A real wedged session
+ * measured 2.46 chars/token against Anthropic's count_tokens endpoint; the
+ * conventional 4 would have understated that prefix by ~40% and let it through.
+ * This guard exists to catch the pathological case, so it errs toward tripping.
+ */
+const CONSERVATIVE_CHARS_PER_TOKEN = 3;
+
+export interface CompactionProgress {
+  /** Did compaction leave the session in a runnable state? */
+  ok: boolean;
+  /** Is retrying the same compaction capable of a different outcome? */
+  retryable: boolean;
+  /** Operator-facing explanation, with the numbers, when `ok` is false. */
+  reason?: string;
+}
+
+export function assessCompactionProgress(
+  result: CompactResult,
+  opts: { contextWindow?: number; inputChars: number }
+): CompactionProgress {
+  if ('noop' in result) return { ok: true, retryable: true };
+
+  const preservedChars = JSON.stringify(result.compactionEvent.data.preserved).length;
+  const preservedTokens = Math.ceil(preservedChars / CONSERVATIVE_CHARS_PER_TOKEN);
+
+  if (opts.contextWindow !== undefined && preservedTokens >= opts.contextWindow) {
+    return {
+      ok: false,
+      retryable: false,
+      reason:
+        `compacted prefix is ~${preservedTokens} tokens (${preservedChars} chars), at or over the ` +
+        `${opts.contextWindow}-token context window — compaction cannot make this session runnable ` +
+        `and retrying is deterministic. The session needs its history repaired out of band.`,
+    };
+  }
+
+  if (preservedChars >= opts.inputChars) {
+    return {
+      ok: false,
+      retryable: false,
+      reason:
+        `compaction did not shrink the session: ${preservedChars} chars out for ${opts.inputChars} ` +
+        `chars in. The strategy has nothing left to shed; retrying reproduces this exactly.`,
+    };
+  }
+
+  return { ok: true, retryable: true };
+}

--- a/packages/agent/src/compaction/toolkit.ts
+++ b/packages/agent/src/compaction/toolkit.ts
@@ -335,6 +335,79 @@ export function jobSalience(trackId: string, events: TypedDurableEvent[]): Track
   return { trackId, body, estimatedTokens: estimate(body), ...activityOf(events) };
 }
 
+// ---------------------------------------------------------------------------
+// Size bounds (PRI-2943)
+//
+// Per-LINE truncation without a bound on the NUMBER of lines is not a bound.
+// cadence-sen's compacted prefix reached 2,304,363 chars — 4,056 `Assistant:`
+// lines, 679 `User:`, 840 `Note:`, each dutifully capped at 500 chars — which
+// is larger than the 1M-token window it had to fit inside. Compaction could
+// then never get the session back under the limit, and the coworker was
+// unrecoverable without hand surgery.
+//
+// track-based is the strategy every session falls back to when its persona
+// cannot be resolved, so its output has to be bounded by construction rather
+// than by the good behaviour of the sessions that reach it. Dropped material is
+// never lost: it stays in events.jsonl and is recall-able. What the agent needs
+// in the auto-loaded prefix is the RECENT end plus an honest marker saying the
+// rest exists.
+// ---------------------------------------------------------------------------
+
+/** Max prose lines kept in a single untracked/generic conversation block. */
+const UNTRACKED_MAX_LINES = 400;
+/** Max chars kept in a single untracked/generic conversation block. */
+const UNTRACKED_MAX_CHARS = 60_000;
+/** Max chars for one rendered `##` section of the generic prefix. */
+const SECTION_CHAR_BUDGET = 60_000;
+/** Max chars for the whole rendered generic prefix, all sections together. */
+const PREFIX_CHAR_BUDGET = 120_000;
+/** Stale-block eviction for system/untracked tracks: within 2 days OR newest 15. */
+const SYSTEM_EVICT_HORIZON_MS = 2 * 24 * 60 * 60 * 1000;
+const SYSTEM_EVICT_FLOOR_N = 15;
+
+function omissionNote(n: number, unit: string): string {
+  return `…${n} older ${unit} omitted from this summary — still in the event log, use recall to read them.`;
+}
+
+/**
+ * Keep the most recent lines within both the line-count and char budgets.
+ * Lines arrive oldest-first, so trimming takes from the front.
+ */
+function keepNewestLines(lines: string[]): string {
+  let kept = lines;
+  if (kept.length > UNTRACKED_MAX_LINES) kept = kept.slice(-UNTRACKED_MAX_LINES);
+  let used = kept.reduce((n, l) => n + l.length + 1, 0);
+  let start = 0;
+  while (start < kept.length - 1 && used > UNTRACKED_MAX_CHARS) {
+    used -= kept[start].length + 1;
+    start++;
+  }
+  kept = kept.slice(start);
+  const droppedCount = lines.length - kept.length;
+  if (droppedCount === 0) return kept.join('\n');
+  return [omissionNote(droppedCount, 'turns'), ...kept].join('\n');
+}
+
+/**
+ * Render a set of track bodies within a char budget, keeping the most recently
+ * active and restoring chronological order for what survives.
+ */
+function renderSectionWithinBudget(blocks: TrackBlock[], budget: number): string {
+  const newestFirst = [...blocks].sort((a, b) => b.lastSeq - a.lastSeq);
+  const kept: TrackBlock[] = [];
+  let used = 0;
+  for (const b of newestFirst) {
+    const cost = b.body.length + 2;
+    if (kept.length > 0 && used + cost > budget) continue;
+    kept.push(b);
+    used += cost;
+  }
+  kept.sort((a, b) => a.lastSeq - b.lastSeq);
+  const body = kept.map((b) => b.body).join('\n\n');
+  const dropped = blocks.length - kept.length;
+  return dropped > 0 ? `${body}\n\n${omissionNote(dropped, 'entries')}` : body;
+}
+
 /**
  * Salience for untracked (and generic conversation) tracks:
  * User/Assistant/Note prose extraction.
@@ -353,7 +426,7 @@ export function untrackedSalience(trackId: string, events: TypedDurableEvent[]):
       if (t) lines.push(`Note: ${truncate(t, 500)}`);
     }
   }
-  const body = lines.length > 0 ? lines.join('\n') : '(empty)';
+  const body = lines.length > 0 ? keepNewestLines(lines) : '(empty)';
   return { trackId, body, estimatedTokens: estimate(body), ...activityOf(events) };
 }
 
@@ -421,9 +494,21 @@ export function renderGenericSections(input: GenericRenderInput, extraSections?:
       getSeq: (b) => b.lastSeq,
     });
   }
-  const systemBlocks = input.blocks.filter(
+  let systemBlocks = input.blocks.filter(
     (b) => b.trackId.startsWith('system:') || b.trackId === 'untracked'
   );
+  // System/untracked tracks evict on the same age+floor rule as job tracks.
+  // Before PRI-2943 only `job:` evicted, so `## System events` grew forever —
+  // 868,093 chars of it on the coworker this bound was written for.
+  if (input.referenceTimestamp) {
+    systemBlocks = applyRecencyKeep(systemBlocks, {
+      now: input.referenceTimestamp,
+      horizonMs: SYSTEM_EVICT_HORIZON_MS,
+      floorN: SYSTEM_EVICT_FLOOR_N,
+      getTs: (b) => b.lastActivityTs,
+      getSeq: (b) => b.lastSeq,
+    });
+  }
   const otherBlocks = input.blocks.filter(
     (b) =>
       !b.trackId.startsWith('job:') && !b.trackId.startsWith('system:') && b.trackId !== 'untracked'
@@ -450,15 +535,23 @@ export function renderGenericSections(input: GenericRenderInput, extraSections?:
 
   if (systemBlocks.length > 0) {
     parts.push('\n## System events\n');
-    parts.push(systemBlocks.map((b) => b.body).join('\n\n'));
+    parts.push(renderSectionWithinBudget(systemBlocks, SECTION_CHAR_BUDGET));
   }
 
   if (otherBlocks.length > 0) {
     parts.push('\n## Other\n');
-    parts.push(otherBlocks.map((b) => b.body).join('\n\n'));
+    parts.push(renderSectionWithinBudget(otherBlocks, SECTION_CHAR_BUDGET));
   }
 
-  return parts.join('\n');
+  // Whole-prefix backstop. The per-section budgets bound the common case; this
+  // catches any future section, or an extraSections block a plugin hands in,
+  // from putting the prefix back over the window.
+  const rendered = parts.join('\n');
+  if (rendered.length <= PREFIX_CHAR_BUDGET) return rendered;
+  return `${stripTrailingLoneSurrogate(rendered.slice(0, PREFIX_CHAR_BUDGET))}\n${omissionNote(
+    rendered.length - PREFIX_CHAR_BUDGET,
+    'chars'
+  )}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/agent/src/config/__tests__/persona-dirs-env.test.ts
+++ b/packages/agent/src/config/__tests__/persona-dirs-env.test.ts
@@ -1,0 +1,53 @@
+// ABOUTME: PRI-2943 — an embedder must be able to declare where user personas live
+// ABOUTME: instead of having the location inferred from LACE_DIR.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { userPersonaPaths } from '../persona-registry';
+
+const ORIGINAL = { ...process.env };
+afterEach(() => {
+  process.env = { ...ORIGINAL };
+});
+
+// lace infers user personas at `$LACE_DIR/agent-personas`. sen-core keeps them
+// under `<instance>/user/agent-personas` — user-authored, git-managed content —
+// and points LACE_DIR at `<instance>/state/lace`, which is runtime state. The
+// two only ever met through a symlink that one host happened to carry from an
+// older layout, and when a host lacked it lace silently saw no persona at all.
+// An embedder needs to be able to say where its personas are.
+
+describe('userPersonaPaths (PRI-2943)', () => {
+  it('falls back to the LACE_DIR convention when nothing is declared', () => {
+    process.env.LACE_DIR = '/srv/lace';
+    delete process.env.LACE_USER_PERSONA_DIRS;
+    expect(userPersonaPaths()).toEqual(['/srv/lace/agent-personas']);
+  });
+
+  it('uses a declared directory', () => {
+    process.env.LACE_DIR = '/inst/state/lace';
+    process.env.LACE_USER_PERSONA_DIRS = '/inst/user/agent-personas';
+    expect(userPersonaPaths()[0]).toBe('/inst/user/agent-personas');
+  });
+
+  it('keeps the LACE_DIR convention as a lower-precedence fallback', () => {
+    process.env.LACE_DIR = '/inst/state/lace';
+    process.env.LACE_USER_PERSONA_DIRS = '/inst/user/agent-personas';
+    expect(userPersonaPaths()).toContain('/inst/state/lace/agent-personas');
+    expect(userPersonaPaths().indexOf('/inst/user/agent-personas')).toBeLessThan(
+      userPersonaPaths().indexOf('/inst/state/lace/agent-personas')
+    );
+  });
+
+  it('accepts several directories, earlier winning', () => {
+    process.env.LACE_DIR = '/srv/lace';
+    process.env.LACE_USER_PERSONA_DIRS = '/a/personas:/b/personas';
+    const paths = userPersonaPaths();
+    expect(paths.slice(0, 2)).toEqual(['/a/personas', '/b/personas']);
+  });
+
+  it('ignores empty segments rather than resolving them to cwd', () => {
+    process.env.LACE_DIR = '/srv/lace';
+    process.env.LACE_USER_PERSONA_DIRS = '/a/personas::  :';
+    expect(userPersonaPaths()).toEqual(['/a/personas', '/srv/lace/agent-personas']);
+  });
+});

--- a/packages/agent/src/config/persona-registry.ts
+++ b/packages/agent/src/config/persona-registry.ts
@@ -11,6 +11,7 @@ import { resolveMcpServerCommandArgs } from './mcp-path-resolution';
 import { scanEmbeddedFiles, resolveResourcePath } from '@lace/agent/utils/resource-resolver';
 import { logger } from '@lace/agent/utils/logger';
 import { personaDirs } from '@lace/agent/plugins';
+import { getEnvVar } from '@lace/agent/config/env-loader';
 import { TemplateEngine, type TemplateContext } from './template-engine';
 
 export interface PersonaInfo {
@@ -688,7 +689,30 @@ function readEmbeddedFileSync(file: unknown): string {
 // Singleton convenience for non-embedder callers; embedders may construct their own registry.
 const bundledPersonasPath = resolveResourcePath(import.meta.url, 'agent-personas');
 
+/**
+ * Ordered user-persona search paths, earlier winning.
+ *
+ * `LACE_USER_PERSONA_DIRS` (colon-separated) lets an embedder DECLARE where its
+ * personas live. lace's own convention — `$LACE_DIR/agent-personas` — stays as
+ * the last entry so nothing that relies on it breaks.
+ *
+ * PRI-2943: sen-core keeps personas under `<instance>/user/agent-personas`
+ * (user-authored, git-managed) and points LACE_DIR at `<instance>/state/lace`
+ * (runtime state). Nothing connected the two except a symlink one host carried
+ * over from an older layout. On a host without it, `parsePersona('core')` threw,
+ * compaction silently fell back to the unbounded built-in strategy, and the
+ * session grew a summary larger than its own context window. An inferred path
+ * cannot fail loudly; a declared one can.
+ */
+export function userPersonaPaths(): string[] {
+  const declared = (getEnvVar('LACE_USER_PERSONA_DIRS') ?? '')
+    .split(':')
+    .map((d) => d.trim())
+    .filter((d) => d.length > 0);
+  return [...declared, path.join(getLaceDir(), 'agent-personas')];
+}
+
 export const personaRegistry = new PersonaRegistry({
   bundledPersonasPath,
-  userPersonasPaths: [path.join(getLaceDir(), 'agent-personas')],
+  userPersonasPaths: userPersonaPaths(),
 });

--- a/packages/agent/src/core/conversation/runner.ts
+++ b/packages/agent/src/core/conversation/runner.ts
@@ -50,7 +50,11 @@ import { logger } from '@lace/agent/utils/logger';
 import { buildCacheHealthLog } from '@lace/agent/core/conversation/cache-health';
 import { computePressure, evaluateBreakpoints } from './compaction-trigger';
 import { estimateProviderTokens } from '@lace/agent/message-building/message-builder';
-import { resolveCompactionStrategy, validatePreserved } from '@lace/agent/compaction/strategy';
+import {
+  assessCompactionProgress,
+  resolveCompactionStrategy,
+  validatePreserved,
+} from '@lace/agent/compaction/strategy';
 import {
   compactionStrategyNameForSession,
   compactionBreakpointsForSession,
@@ -1618,6 +1622,28 @@ export class ConversationRunner {
     );
     const result = validatePreserved(raw);
     if ('noop' in result) return false;
+
+    // Structural validity is not progress (PRI-2943). A strategy can emit a
+    // perfectly well-formed prefix that is itself larger than the window, and
+    // because compaction over a fixed event log is deterministic, retrying
+    // reproduces it byte for byte. cadence-sen wrote ten identical 2.6MB
+    // context_compacted events in one day this way — each one making the
+    // session no more runnable than the last, and each one costing another
+    // 2.6MB of transcript. Refuse to persist a compaction that made no
+    // progress, and say why once per attempt rather than failing mutely.
+    const progress = assessCompactionProgress(result, {
+      ...(params.contextWindow !== undefined ? { contextWindow: params.contextWindow } : {}),
+      inputChars: JSON.stringify(allEvents).length,
+    });
+    if (!progress.ok) {
+      logger.error('runner: compaction made no progress; refusing to persist it', {
+        sessionId,
+        strategy: strategyName,
+        retryable: progress.retryable,
+        reason: progress.reason,
+      });
+      return false;
+    }
 
     await this.deps.runExclusive(async () => {
       const sessionState = readSessionState(sessionDir);


### PR DESCRIPTION
## Why

`cadence-sen` sent zero LLM requests for 38 hours while her container reported `Up (healthy)` and Slack events queued behind her. Root cause is a chain of four defects, each of which alone would have been survivable.

**1. Persona resolution failed silently.** The registry searches one user path, `$LACE_DIR/agent-personas`. On her instance that path does not exist, so `parsePersona('core')` threw and `select.ts` swallowed it with a bare `catch`, returning `'track-based'`. Her persona asks for `sen-multiconv`. All 203 of her compactions ran the wrong strategy, and the same silent path replaced her breakpoints with the defaults. Nothing logged, for four weeks.

**2. `track-based` has no size bound.** `untrackedSalience` capped each *line* at 500 chars and the line *count* at nothing; `renderGenericSections` evicted `job:` tracks only. Her compacted prefix reached 2,304,363 chars = 1,029,578 real tokens — larger than the 1,000,000-token window it had to fit inside.

**3. Nothing checked that compaction helped.** `validatePreserved` answers "is this structurally sound", never "did this make the session runnable". Ten emergency compactions in one day each wrote a byte-identical 2.6MB event with `messagesCompacted` frozen at 13,957.

**4. The existing guard could not see.** `runner.ts` already logs `compacted history STILL exceeds the context window` — it fired **zero** times across 203 compactions and 136 rejected requests, because `estimateProviderTokens` omits the system prompt and tool schemas.

## What changed

- `select.ts` — both resolvers go through one helper. No persona is legitimate and stays quiet; a session that *names* a persona which fails to parse now warns with the persona, session and error. The fallback stays: making compaction fatal on a live coworker trades a slow wedge for an immediate outage.
- `toolkit.ts` — `untrackedSalience` keeps the newest 400 lines / 60k chars with an omission note pointing at recall. `system:`/`untracked` tracks evict on the same age+floor rule `job:` already used; 60k per section, 120k whole-prefix backstop.
- `strategy.ts` — `assessCompactionProgress`. Over the window, or failed to shrink, is terminal rather than transient: compaction over a fixed event log is deterministic, so a retry reproduces it byte for byte. Pessimistic 3 chars/token divisor — measured density on the real session was 2.44, so the conventional 4 understates by ~40%.
- `runner.ts` — `compactSession` refuses to persist a no-progress compaction and says why. This alone stops the ~26MB/day of identical events she has been writing.
- `persona-registry.ts` — `LACE_USER_PERSONA_DIRS` lets an embedder *declare* where personas live. `$LACE_DIR/agent-personas` stays as the last entry, so nothing that relies on it breaks.

## Evidence

Running the deployed `sen-multiconv` against her real 14,181-event log with a live `ctx.query` produces a **17,619-token** prefix versus the 1,029,578 status quo — a 58× reduction, history intact. The bounded `track-based` in this PR would also have prevented the wedge on its own.

## Tests

`select` 17, `toolkit-bounds` 9, `track-compaction.fixedpoint` 4, `compaction-progress-guard` 6, `persona-dirs-env` 5 — plus all 42 pre-existing toolkit tests and the full agent suite (276) green.

The bounds tests are paired with guards that a small session renders unchanged and the no-persona path stays quiet, so a fix cannot satisfy them by clamping everything.

PRI-2943