### PR TITLE
feat(protocol): put lastCallInputContextTokens on the usage wire (PRI-2945)

### DIFF
--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -2240,11 +2240,26 @@ interface UsageInfo {
   outputTokens: number;
   cacheReadTokens?: number;
   cacheWriteTokens?: number;
+  lastCallInputContextTokens?: number;
   thinkingTokens?: number;
   totalTokens?: number;
   costUsd?: number;
 }
 ```
+
+`inputTokens`, `cacheReadTokens` and `cacheWriteTokens` are **turn-cumulative**:
+a turn containing a ten-call tool loop over a 100k context sums to roughly 1M.
+Summing them measures work done, not context occupied.
+
+`lastCallInputContextTokens` is the **last** API call's on-the-wire input
+context size for the turn (its uncached input plus cache-write plus cache-read
+tokens) — what the next call will actually send. A client deciding when to
+compact should key on this field.
+
+It is optional and is **absent, never zero**, when the agent does not report it
+(a provider with no cache accounting, or an agent predating the field). Treat
+absent as unknown and fall back; reading it as 0 would look like an empty
+context and suppress compaction indefinitely.
 
 ### 11.7 ToolResult
 

--- a/packages/agent/src/rpc/handlers/__tests__/prompt.usage-context-tokens.test.ts
+++ b/packages/agent/src/rpc/handlers/__tests__/prompt.usage-context-tokens.test.ts
@@ -1,0 +1,164 @@
+// ABOUTME: Tests that the prompt handler puts the runner's
+// ABOUTME: lastCallInputContextTokens on the ent-protocol wire — both the
+// ABOUTME: session/update turn_end notification and the session/prompt result —
+// ABOUTME: so an embedder can gate compaction on real context occupancy rather
+// ABOUTME: than the turn-cumulative input+cache sum.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
+import {
+  createNdjsonStdioTransport,
+  JsonRpcPeer,
+  SessionUpdateNotificationSchema,
+} from '@lace/ent-protocol';
+import { createAgentServerState, registerAgentRpcMethods } from '../../../server';
+import { defaultInitializeParams } from '../../../__tests__/helpers/initialize';
+import { ConversationRunner } from '@lace/agent/core/conversation/runner';
+
+type RunnerUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+  lastCallInputContextTokens?: number;
+  costUsd?: number;
+};
+
+function createPairedPeers(register: (peer: JsonRpcPeer) => void) {
+  const aToB = new PassThrough();
+  const bToA = new PassThrough();
+
+  const clientTransport = createNdjsonStdioTransport({ readable: bToA, writable: aToB });
+  const serverTransport = createNdjsonStdioTransport({ readable: aToB, writable: bToA });
+
+  const client = new JsonRpcPeer(clientTransport, { idPrefix: 'c_' });
+  const server = new JsonRpcPeer(serverTransport, { idPrefix: 'a_' });
+  register(server);
+
+  return { client, server };
+}
+
+/** Make runner.run resolve with a fixed usage payload. */
+function stubRunnerUsage(usage: RunnerUsage) {
+  return vi
+    .spyOn(ConversationRunner.prototype, 'run')
+    .mockImplementation(async (opts: { turnId: string }) => ({
+      turnId: opts.turnId,
+      stopReason: 'end_turn' as const,
+      stopDetails: null,
+      content: [{ type: 'text' as const, text: 'done' }],
+      usage,
+      lastSeenEventSeq: 0,
+    }));
+}
+
+describe('prompt handler: lastCallInputContextTokens on the wire', () => {
+  let originalLaceDir: string | undefined;
+  let originalTestProvider: string | undefined;
+  let tempDir: string;
+  let workDir: string;
+
+  beforeEach(() => {
+    originalLaceDir = process.env.LACE_DIR;
+    originalTestProvider = process.env.LACE_AGENT_TEST_PROVIDER;
+
+    tempDir = mkdtempSync(join(tmpdir(), 'lace-prompt-ctx-tokens-test-'));
+    workDir = mkdtempSync(join(tmpdir(), 'lace-prompt-ctx-tokens-wd-'));
+    process.env.LACE_DIR = tempDir;
+    process.env.LACE_AGENT_TEST_PROVIDER = '1';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalLaceDir === undefined) delete process.env.LACE_DIR;
+    else process.env.LACE_DIR = originalLaceDir;
+    if (originalTestProvider === undefined) delete process.env.LACE_AGENT_TEST_PROVIDER;
+    else process.env.LACE_AGENT_TEST_PROVIDER = originalTestProvider;
+    rmSync(tempDir, { recursive: true, force: true });
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('carries the last call context size, distinct from the turn-cumulative sums', async () => {
+    // A three-call tool loop over a ~66k context: the turn-cumulative sums add
+    // up to ~200k, while the actual context the next call would send is 66,212.
+    // The wire must carry the latter, or an embedder can only see the inflated
+    // sum (the exact defect PRI-2945 describes).
+    stubRunnerUsage({
+      inputTokens: 36,
+      outputTokens: 300,
+      cacheCreationInputTokens: 3_600,
+      cacheReadInputTokens: 195_000,
+      lastCallInputContextTokens: 66_212,
+      costUsd: 0.42,
+    });
+
+    const state = createAgentServerState();
+    const { client, server } = createPairedPeers((peer) => registerAgentRpcMethods(peer, state));
+    const turnEnds: unknown[] = [];
+    client.onRequest('session/update', async (params) => {
+      if ((params as { type?: string })?.type === 'turn_end') turnEnds.push(params);
+      return undefined;
+    });
+
+    try {
+      await client.request('initialize', defaultInitializeParams());
+      await client.request('session/new', { cwd: workDir, mcpServers: [] });
+
+      const result = (await client.request('session/prompt', {
+        content: [{ type: 'text', text: 'hello' }],
+      })) as { usage: Record<string, unknown> };
+
+      expect(result.usage.lastCallInputContextTokens).toBe(66_212);
+      // The cumulative fields still cross unchanged — this adds a field, it
+      // does not redefine the existing ones.
+      expect(result.usage.cacheReadTokens).toBe(195_000);
+      expect(result.usage.cacheWriteTokens).toBe(3_600);
+      expect(result.usage.inputTokens).toBe(36);
+
+      expect(turnEnds).toHaveLength(1);
+      const notified = turnEnds[0] as { usage: Record<string, unknown> };
+      expect(notified.usage.lastCallInputContextTokens).toBe(66_212);
+
+      // And the notification must survive the strict wire schema a real
+      // embedder parses it with.
+      expect(() =>
+        SessionUpdateNotificationSchema.parse({
+          jsonrpc: '2.0',
+          method: 'session/update',
+          params: notified,
+        })
+      ).not.toThrow();
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+
+  it('omits the field when the runner did not report one', async () => {
+    // Providers with no cache accounting (or a runner predating the field)
+    // must produce a payload with the key absent, not present-and-zero: zero
+    // would read as "empty context" and suppress compaction forever.
+    stubRunnerUsage({ inputTokens: 36, outputTokens: 300 });
+
+    const state = createAgentServerState();
+    const { client, server } = createPairedPeers((peer) => registerAgentRpcMethods(peer, state));
+    client.onRequest('session/update', async () => undefined);
+
+    try {
+      await client.request('initialize', defaultInitializeParams());
+      await client.request('session/new', { cwd: workDir, mcpServers: [] });
+
+      const result = (await client.request('session/prompt', {
+        content: [{ type: 'text', text: 'hello' }],
+      })) as { usage: Record<string, unknown> };
+
+      expect('lastCallInputContextTokens' in result.usage).toBe(false);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+});

--- a/packages/agent/src/rpc/handlers/prompt.ts
+++ b/packages/agent/src/rpc/handlers/prompt.ts
@@ -527,6 +527,13 @@ export function registerPromptHandler(
         ...(result.usage.cacheCreationInputTokens !== undefined
           ? { cacheWriteTokens: result.usage.cacheCreationInputTokens }
           : {}),
+        // The last API call's context size, as opposed to the turn-cumulative
+        // sums above. Emitted only when the runner reported it: absent means
+        // "unknown", where a literal 0 would read as "empty context" and tell
+        // an embedder it never needs to compact.
+        ...(result.usage.lastCallInputContextTokens !== undefined
+          ? { lastCallInputContextTokens: result.usage.lastCallInputContextTokens }
+          : {}),
         ...(result.usage.costUsd !== undefined ? { costUsd: result.usage.costUsd } : {}),
       };
 

--- a/packages/ent-protocol/src/schemas/__tests__/usage-context-tokens.test.ts
+++ b/packages/ent-protocol/src/schemas/__tests__/usage-context-tokens.test.ts
@@ -1,0 +1,75 @@
+// ABOUTME: Tests that UsageInfoSchema carries lastCallInputContextTokens — the
+// ABOUTME: last API call's on-the-wire input context size — so an embedder can
+// ABOUTME: gate compaction on real context occupancy instead of a turn-cumulative
+// ABOUTME: sum. Also pins the back-compat contract: the field is optional and the
+// ABOUTME: schema stays strict about genuinely unknown keys.
+
+import { describe, expect, it } from 'vitest';
+import { UsageInfoSchema } from '../shared';
+import { SessionUpdateNotificationSchema } from '../methods';
+
+describe('UsageInfoSchema.lastCallInputContextTokens', () => {
+  it('accepts the field and preserves its value', () => {
+    const parsed = UsageInfoSchema.parse({
+      inputTokens: 12,
+      outputTokens: 34,
+      cacheReadTokens: 65_000,
+      cacheWriteTokens: 1_200,
+      lastCallInputContextTokens: 66_212,
+    });
+    expect(parsed.lastCallInputContextTokens).toBe(66_212);
+  });
+
+  it('leaves the field undefined when absent, so an older agent still parses', () => {
+    // Back-compat direction: a newer embedder pointed at an older lace that
+    // does not send the field must still parse the payload and simply see
+    // `undefined` — never a validation failure.
+    const parsed = UsageInfoSchema.parse({ inputTokens: 12, outputTokens: 34 });
+    expect(parsed.lastCallInputContextTokens).toBeUndefined();
+  });
+
+  it('still rejects genuinely unknown keys', () => {
+    expect(() =>
+      UsageInfoSchema.parse({
+        inputTokens: 12,
+        outputTokens: 34,
+        somethingNobodyDefined: 1,
+      })
+    ).toThrow();
+  });
+
+  it('rejects a non-numeric value', () => {
+    expect(() =>
+      UsageInfoSchema.parse({
+        inputTokens: 12,
+        outputTokens: 34,
+        lastCallInputContextTokens: 'lots',
+      })
+    ).toThrow();
+  });
+
+  it('rides on a turn_end session/update notification', () => {
+    // turn_end is the payload sen-core's CompactionTrigger reads. The
+    // notification schema is strict, so the field has to be declared for the
+    // wire message to validate at all.
+    const parsed = SessionUpdateNotificationSchema.parse({
+      jsonrpc: '2.0',
+      method: 'session/update',
+      params: {
+        sessionId: 'sess_00000000-0000-4000-8000-000000000000',
+        streamSeq: 1,
+        type: 'turn_end',
+        stopReason: 'end_turn',
+        content: [{ type: 'text', text: 'done' }],
+        usage: {
+          inputTokens: 12,
+          outputTokens: 34,
+          cacheReadTokens: 65_000,
+          lastCallInputContextTokens: 66_212,
+        },
+      },
+    });
+    const params = parsed.params as { usage: { lastCallInputContextTokens?: number } };
+    expect(params.usage.lastCallInputContextTokens).toBe(66_212);
+  });
+});

--- a/packages/ent-protocol/src/schemas/shared.ts
+++ b/packages/ent-protocol/src/schemas/shared.ts
@@ -175,6 +175,21 @@ export const UsageInfoSchema = z
     outputTokens: z.number(),
     cacheReadTokens: z.number().optional(),
     cacheWriteTokens: z.number().optional(),
+    /**
+     * The LAST API call's on-the-wire input context size for this turn: its
+     * uncached input plus cache-write plus cache-read tokens. The
+     * `inputTokens`/`cacheReadTokens`/`cacheWriteTokens` fields above are
+     * turn-CUMULATIVE — a turn with a ten-call tool loop over a 100k context
+     * sums to ~1M — so summing them measures work done, not context occupied.
+     * An embedder deciding when to compact wants this field: it is what the
+     * next API call will actually send.
+     *
+     * Optional, and absent rather than zero when the agent does not report it
+     * (a provider with no cache accounting, or an agent predating the field).
+     * Zero would read as "empty context" and suppress compaction forever, so
+     * consumers must treat absent as unknown and fall back, never as 0.
+     */
+    lastCallInputContextTokens: z.number().optional(),
     thinkingTokens: z.number().optional(),
     totalTokens: z.number().optional(),
     costUsd: z.number().optional(),


### PR DESCRIPTION
## Problem

sen-core's `CompactionTrigger` has no way to see how full a session's context actually is.

Everything on the ent-protocol usage payload — `inputTokens`, `cacheReadTokens`, `cacheWriteTokens` — is **turn-cumulative**: the runner sums them across every LLM call in a turn. A turn with a ten-call tool loop over a 100k context sums to ~1M. Summing them measures work done, not context occupied.

That left sen-core with two bad options, both of which it has shipped: gate on `inputTokens` alone (~0 on a warm agentic loop, so it never fires — measured on a real coworker: `input_tokens` 1,302 against `cache_read_input_tokens` 65,004,192 across 652 requests in one day), or gate on the cumulative sum with the threshold cranked to 800k to stay safe (a coarse backstop, not a signal).

lace already computes the right number in `runner.ts` — `lastCallInputContextTokens`, the last API call's on-the-wire input context size — and uses it for its own `computePressure` and its own durable `turn_end` event. It just never crossed the wire.

## Change

- `UsageInfoSchema` gains `lastCallInputContextTokens?: number`.
- `rpc/handlers/prompt.ts` carries it through the runner→protocol translation, so it rides on both the `turn_end` `session/update` notification and the `session/prompt` result.
- `docs/protocol-spec.md` §11.6 documents the cumulative-vs-last-call distinction and the absent-not-zero contract.

Consuming it in sen-core is a follow-up in that repo. Nothing about *when* breakpoints are evaluated changes here.

## Compatibility

Optional on the wire, and **absent rather than zero** when the runner did not report it (a provider with no cache accounting, or a session predating the field). A literal 0 would read as "empty context" and suppress compaction forever, so consumers must treat absent as unknown and fall back.

Both skew directions are safe:

- **Newer embedder, older lace** — the field is simply absent; optional means the payload still parses.
- **Newer lace, older embedder** — sen-core hard-parses `session/update` params with the strict `SessionUpdateParamsSchema` and throws on an unknown key, so this direction *would* be a break if the two could skew. They can't: sen-core depends on `@lace/ent-protocol` via `file:../lace/packages/ent-protocol`, a symlink, and builds with plain `tsc` (no bundling), so at runtime it loads the zod schemas out of the same lace checkout the daemon runs from. `coworker upgrade` fast-forwards both checkouts and rebuilds sen-core against the new lace source in one operation. sen-core's `UsageInfoSchema` is always the running lace's.

## Durable log

Unaffected. `lastCallInputContextTokens` was *already* being written to `turn_end` in `events.jsonl` before this change; this PR only adds the wire hop. Durable events are read with plain `JSON.parse` + a TS cast (`storage/event-log.ts`) — no zod, no strict rejection — and `TurnEndEventData.usage.lastCallInputContextTokens` is already declared optional, so older transcripts replay exactly as before.

## Tests

TDD, both files written failing first:

- `packages/ent-protocol/src/schemas/__tests__/usage-context-tokens.test.ts` — the field parses and round-trips, is optional, still rejects genuinely unknown keys and non-numeric values, and validates on a real `turn_end` notification.
- `packages/agent/src/rpc/handlers/__tests__/prompt.usage-context-tokens.test.ts` — end-to-end over a paired JSON-RPC peer with a stubbed runner: a turn whose cumulative sums are ~200k but whose last call was 66,212 puts **66,212** on both the notification and the RPC result, and the notification validates against the strict wire schema. A runner reporting no value produces a payload with the key absent.

Non-vacuity confirmed by stashing only the `prompt.ts` change: `expected undefined to be 66212`.

Gates: `npm run lint`, `npm run format:check`, `npm run build`, `npm test --workspace=packages/ent-protocol` (91 passed), `npm test --workspace=packages/agent` (276 passed, 12 skipped) — all green.

PRI-2945