### PR TITLE
fix(compaction): don't spend a breakpoint on a compaction that did nothing (PRI-2945)

### DIFF
--- a/packages/agent/src/core/conversation/__tests__/runner.breakpoints.test.ts
+++ b/packages/agent/src/core/conversation/__tests__/runner.breakpoints.test.ts
@@ -932,4 +932,105 @@ describe('ConversationRunner - configurable breakpoints', () => {
     const state = readSessionState(sessionDir);
     expect(state.highestFiredBreakpointAt ?? 0).toBe(0);
   });
+  // -------------------------------------------------------------------------
+  // A compaction that did nothing must not consume the breakpoint (PRI-2945)
+  // -------------------------------------------------------------------------
+  //
+  // Subagent sessions are short. track-based compaction preserves the last ten
+  // turns verbatim, so a session with fewer than ten turns whose durable text
+  // fits the tail budget has no `earlier` slice at all and the strategy returns
+  // a noop. The runner used to latch `highestFiredBreakpointAt` before finding
+  // that out, which spends the breakpoint on a compaction that never happened:
+  // pressure never falls back below the lowest breakpoint, so it never resets,
+  // and no later turn can fire it again. Measured on ada-sen: 427 subagent
+  // sessions, zero `context_compacted` events, including sessions that ran for
+  // twenty turns at 63% of their window.
+
+  /** Seed only the system prompt — a brand-new session, as a subagent starts. */
+  function seedEmptySession(sessionDirPath: string, id: string, workDir: string, persona: string) {
+    const now = new Date().toISOString();
+    writeFileSync(
+      join(sessionDirPath, 'events.jsonl'),
+      JSON.stringify({
+        eventSeq: 1,
+        timestamp: now,
+        type: 'system_prompt_set',
+        data: { type: 'system_prompt_set', text: 'You are a test assistant.' },
+      }) + '\n'
+    );
+    writeFileSync(
+      join(sessionDirPath, 'state.json'),
+      JSON.stringify({ nextEventSeq: 2, nextStreamSeq: 1 })
+    );
+    writeFileSync(
+      join(sessionDirPath, 'meta.json'),
+      JSON.stringify({ sessionId: id, workDir, created: now, persona })
+    );
+  }
+
+  function subagentRunner(persona: string, promptTokens: number, replyChars: number) {
+    const provider = new ScriptedProvider(
+      [
+        {
+          content: 'y'.repeat(replyChars),
+          toolCalls: [],
+          stopReason: 'stop',
+          usage: { promptTokens, completionTokens: 10, totalTokens: promptTokens + 10 },
+        },
+      ],
+      1_000_000
+    );
+    const executor = new ToolExecutor();
+    executor.registerAllAvailableTools({ skillDirs: [] } as any);
+    return new ConversationRunner(
+      { sessionDir, sessionId, cwd, executionMode: 'execute', approvalMode: 'approve', persona },
+      createMockDeps({
+        createProvider: vi.fn().mockImplementation(async () => provider),
+        createToolExecutor: vi.fn().mockReturnValue({
+          executor,
+          toolsForProvider: executor.getAllTools(),
+        }),
+      })
+    );
+  }
+
+  it('a breakpoint whose compaction was a noop does not latch (PRI-2945)', async () => {
+    mockBreakpoints.mockReturnValue(DEFAULT_BREAKPOINTS);
+    seedEmptySession(sessionDir, sessionId, cwd, 'persistent-box-worker');
+
+    // 63% of a 1M window — past the 0.6 default compact breakpoint. But this is
+    // the session's FIRST turn, so track-based has nothing older than the tail
+    // to summarize and returns a noop.
+    await subagentRunner('persistent-box-worker', 633_419, 20_000).run({
+      content: [{ type: 'text', text: 'hello' }],
+      abortController: new AbortController(),
+      turnId: `turn_${randomUUID()}`,
+      startedAt: new Date().toISOString(),
+    });
+
+    const { events } = readDurableEvents(sessionDir, { limit: Number.MAX_SAFE_INTEGER });
+    expect(events.some((e) => e.type === 'context_compacted')).toBe(false);
+    // The breakpoint must still be available to a later turn that CAN compact.
+    expect(readSessionState(sessionDir).highestFiredBreakpointAt ?? 0).toBe(0);
+  });
+
+  it('a multi-turn subagent session compacts once track-based can act (PRI-2945)', async () => {
+    mockBreakpoints.mockReturnValue(DEFAULT_BREAKPOINTS);
+    seedEmptySession(sessionDir, sessionId, cwd, 'persistent-box-worker');
+
+    // Every turn sits at 63% pressure — the shape ada-sen's subagents run at,
+    // where a big system prompt and tool schemas put the session over the
+    // breakpoint from the very first call and it never comes back down.
+    for (let turn = 0; turn < 12; turn++) {
+      await subagentRunner('persistent-box-worker', 633_419, 20_000).run({
+        content: [{ type: 'text', text: `task ${turn}` }],
+        abortController: new AbortController(),
+        turnId: `turn_${turn}_${randomUUID()}`,
+        startedAt: new Date().toISOString(),
+      });
+    }
+
+    const { events } = readDurableEvents(sessionDir, { limit: Number.MAX_SAFE_INTEGER });
+    expect(events.filter((e) => e.type === 'context_compacted').length).toBeGreaterThan(0);
+  });
 });

--- a/packages/agent/src/core/conversation/runner.ts
+++ b/packages/agent/src/core/conversation/runner.ts
@@ -1483,6 +1483,7 @@ export class ConversationRunner {
         // bypasses the clean-stop gate entirely so the agent can explicitly
         // request compaction at any stop reason).
         let breakpointCompactCrossed = false;
+        let pendingBreakpointLatch: number | null = null;
         if (isCleanStop) {
           const breakpoints = compactionBreakpointsForPersona(
             this.config.persona ?? null,
@@ -1520,25 +1521,60 @@ export class ConversationRunner {
             });
           } else if (ev.fire?.action === 'compact') {
             breakpointCompactCrossed = true;
-            // Persist the new highestFiredBreakpointAt — the compact path below
-            // will read and write state under its own runExclusive.
-            await this.deps.runExclusive(() => {
-              const sessionState = readSessionState(sessionDir);
-              writeSessionState(sessionDir, {
-                ...sessionState,
-                highestFiredBreakpointAt: ev.nextHighestFiredAt,
-              });
-            });
+            // The latch is NOT written here. It is written below, and only if
+            // the compaction it authorized actually produced something. See
+            // the comment on that write.
+            pendingBreakpointLatch = ev.nextHighestFiredAt;
           }
         }
 
         if (compactionRequest.requested || breakpointCompactCrossed) {
-          await this.compactSession({
+          const compacted = await this.compactSession({
             modelId,
             contextWindow: contextWindowSize,
             guidance: compactionRequest.guidance,
             updateTurnSeq: durableTurnSeq,
           });
+
+          // Spend the breakpoint only on a compaction that happened (PRI-2945).
+          //
+          // `compactSession` returns false when the strategy had nothing to
+          // work with — track-based preserves the last ten turns verbatim, so
+          // a session shorter than that whose durable text fits the tail
+          // budget has no `earlier` slice and returns a noop. Latching anyway
+          // is permanent: `evaluateBreakpoints` only resets once pressure
+          // falls back BELOW the lowest breakpoint, and a session that just
+          // failed to shed anything is still above it. Every later turn then
+          // evaluates to `fire: null`, including the turns where compaction
+          // would finally have worked. Measured on ada-sen: 427 subagent
+          // sessions, zero `context_compacted` events, some of them twenty
+          // turns long at 63% of their window.
+          //
+          // Leaving the latch alone means the next clean turn re-evaluates and
+          // tries again. Retrying is cheap — track-based is pure and takes no
+          // model call — and it is the only thing that lets a session compact
+          // as soon as it becomes able to.
+          if (breakpointCompactCrossed && pendingBreakpointLatch !== null) {
+            if (compacted) {
+              await this.deps.runExclusive(() => {
+                const sessionState = readSessionState(sessionDir);
+                writeSessionState(sessionDir, {
+                  ...sessionState,
+                  highestFiredBreakpointAt: pendingBreakpointLatch,
+                });
+              });
+            } else {
+              logger.warn(
+                'runner: breakpoint fired but compaction produced nothing; leaving the breakpoint unspent',
+                {
+                  sessionId,
+                  turnId,
+                  pressure,
+                  breakpoint: pendingBreakpointLatch,
+                }
+              );
+            }
+          }
         }
       } catch (compactionErr) {
         logger.error('runner: compaction failed', {


### PR DESCRIPTION
Linear: [PRI-2945](https://linear.app/prime-radiant/issue/PRI-2945)

## The mystery

Across ada-sen's whole history: **427 subagent sessions, zero `context_compacted` events** — including 43 multi-turn sessions, some twenty turns long, one measured at 633,419 tokens of a 1,000,000 window.

Every link in the chain checks out, and I verified each one rather than assuming:

- Subagent jobs do reach `ConversationRunner` (child lace process, `session/prompt`).
- `end_turn` is in `CLEAN_STOP_REASONS`, so breakpoints are evaluated at each turn end.
- Subagent personas carry no `compaction:` stanza and resolve — through the **real** registry, verified in a harness — to `[{at:0.6,compact},{at:0.9,compact}]`.
- `computePressure` reads `lastCallInputContextTokens / contextWindow` and gets 0.633.
- There is no subagent-specific guard anywhere on the path.

The breakpoint **fires**. The compaction it authorizes returns a noop. The latch is written anyway.

## The cause

`track-based` preserves the last ten turns verbatim. `splitAtTailBoundary` returns `earlier: []` whenever the session has fewer than ten `turn_end` events, and `trimTailToTokenBudget` only peels turns back into `earlier` while the estimated tail exceeds the budget (300K on a 1M window). A short session whose durable text fits that budget therefore has nothing older than the tail, and `compact()` returns `{ noop: true }`.

Subagent sessions are short and start heavy — a big system prompt and tool schemas put them past 0.6 on the very first call. So turn one fires 0.6, compacts nothing, and records 0.6 as fired.

That is permanent. `evaluateBreakpoints` resets only when pressure falls back **below** the lowest breakpoint, and a session that just failed to shed anything is still above it. Every later turn evaluates to `fire: null` — including turn ten and beyond, where compaction would finally have worked.

Harness output on an unmodified tree, one subagent-shaped session run sixteen times at 63% pressure:

```
turn  0: turn_ends=1  compacted=0  highestFired=0.6
turn  1: turn_ends=2  compacted=0  highestFired=0.6
...
turn 15: turn_ends=16 compacted=0  highestFired=0.6
```

Sixteen turns, ten of them past the point where the strategy could have acted, zero compactions. One noop at the start silences the session for life. That is the whole of "427 sessions, zero events" — single-turn and multi-turn alike.

## The fix

Write the latch **after** `compactSession`, and only when it reports that it compacted. A breakpoint that produced nothing stays unspent, so the next clean turn re-evaluates and tries again — one pure, deterministic pass, no model call. Deferring the write also closes the crash window in the old ordering, where a crash between latch and compact left the session silenced with nothing to show for it.

A noop now also logs at warn, so the next occurrence is visible rather than mute.

## Coverage, stated honestly

This covers every session that ever reaches a state where track-based can act — the multi-turn ones, which are 43 of the 163 sessions with >50 events. A session that ends inside its first turn still cannot compact at a turn boundary, because there is no boundary before the end; 120 of those 163 are single-turn. That bound is inherent to turn-end relief, not to this change, and no mid-turn relief is added here.

## Corrections to PRI-2945's description

- The description says the cause is that "a delegated subagent job is one turn containing N tool-call round-trips", so breakpoints are evaluated once and the session is then discarded. That is not what the 427 measured. Many subagent sessions are **resumed** across delegate calls (`session/resume` in `subagent-job.ts`) and accumulate real turns; those sessions did evaluate breakpoints, repeatedly, and still never compacted. The noop latch explains them; the one-turn framing does not.
- "Subagent persona compaction stanzas are not indicated by this evidence" — still correct, and now for a demonstrated reason. See the companion sen-core PR.

## Tests

Two added to `runner.breakpoints.test.ts`:

- a breakpoint whose compaction was a noop does not latch
- a multi-turn subagent session compacts once track-based can act (12 turns at 63%)

Non-vacuity: with the runner change reverted, both fail — `expected 0.6 to be +0` and `expected 0 to be greater than 0`.

## Gates

`npm run lint`, `npm run format:check`, `npm run typecheck` clean. `npm test --workspace=packages/agent`: 3572 passed / 27 skipped, plus 276 / 12 in the second project.