### PR TITLE
fix(compaction): size the preserved tail against the model's own report (PRI-2947)

### DIFF
--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -433,6 +433,12 @@ interface CompactionContext {
   // preserve against it — see "Sizing the preserved tail" below. Absent only when
   // the call site has no connection/model to resolve one from.
   readonly contextWindow?: number;
+  // What the provider reported the context cost on its most recent API call —
+  // the whole input, including the system prompt, the tool schemas and images.
+  // Calibrate your tail estimate against it; see "Sizing the preserved tail".
+  // ABSENT, never 0, when nobody reported one (first turn, legacy transcript,
+  // a provider with no usage accounting).
+  readonly measuredContextTokens?: number;
   // Free-text steering from the compact caller (compact_session / ent.session.compact
   // `guidance`, or /compact's command tail). Absent when auto-fired; built-ins ignore it.
   guidance?: string;
@@ -458,15 +464,35 @@ const { earlier, tail } = trimTailToTokenBudget(
   tailTokenBudget(ctx.contextWindow),
   // Optional: measure through your own shrinking step, so the budget sees what
   // the provider actually receives rather than the raw events.
-  trimMyToolIO
+  trimMyToolIO,
+  // Optional: the model's own report of the context size. Pass it.
+  ctx.measuredContextTokens
 );
 ```
 
-`tailTokenBudget` returns `min(300K, 60% of the window)`, falling back to a
-conservative 200K window when `ctx.contextWindow` is absent. The fraction sits
+`tailTokenBudget` returns `min(300K, 50% of the window) - 25K`, falling back to
+a conservative 200K window when `ctx.contextWindow` is absent. The fraction sits
 below the lowest default compact breakpoint on purpose: compaction has to
 relieve pressure past that breakpoint, or `highestFiredBreakpointAt` never
 resets and no further post-turn compaction fires.
+
+**Measure, don't estimate.** The budget is compared against `estimateTailTokens`
+— a `chars/4` floor over message text that counts no system prompt, no tool
+schema and no image. On real coworker content that reads an order of magnitude
+under the truth, so a session the runner knows is at 63% of its window looks to
+the strategy like it comfortably fits, nothing is peeled, and compaction returns
+a noop forever. Passing `ctx.measuredContextTokens` lets `trimTailToTokenBudget`
+calibrate the estimator against what the model actually charged: it derives a
+scale (clamped at 1, so it can never shrink the estimate) and applies it to
+every tail measurement. When the context holds a measurement neither you nor the
+caller passed, it reads the newest `turn_end`'s `lastCallInputContextTokens`
+itself, so `/compact` and `ent/session/compact` are covered too. With no
+measurement anywhere the estimate stands exactly as before.
+
+This cannot make compaction more aggressive on a healthy session: the scaled
+measurement of the FULL tail is the reported figure itself, so peeling begins
+only when the model says the session is over the budget — the same number the
+pressure trigger acts on.
 
 **Compaction is triggered three ways**, all routing through the persona-selected
 strategy and `validatePreserved`: automatically in the runner's post-turn hook

--- a/packages/agent/src/compaction/__tests__/measured-context.test.ts
+++ b/packages/agent/src/compaction/__tests__/measured-context.test.ts
@@ -1,0 +1,305 @@
+// ABOUTME: Tests for sizing the preserved tail against the model's REPORTED context
+// ABOUTME: size rather than the local chars/4 floor (PRI-2947). Covers the
+// ABOUTME: measurement lookup, the estimator calibration scale, and the effect on
+// ABOUTME: trimTailToTokenBudget / track-based compact().
+
+import { describe, it, expect } from 'vitest';
+import type { DurableEventData, TypedDurableEvent } from '@lace/agent/storage/event-types';
+import {
+  lastReportedContextTokens,
+  estimateCurrentContextTokens,
+  contextMeasurementScale,
+  trimTailToTokenBudget,
+  estimateTailTokens,
+  splitAtTailBoundary,
+} from '../toolkit';
+import { compact } from '../track-compaction';
+import { estimateProviderTokens } from '@lace/agent/utils/token-estimation';
+import type { ProviderMessage } from '@lace/agent/providers/base-provider';
+
+const event = (
+  seq: number,
+  type: DurableEventData['type'],
+  data: Record<string, unknown>,
+  turnId?: string
+): TypedDurableEvent => ({
+  eventSeq: seq,
+  timestamp: `2026-08-25T00:00:${String(seq).padStart(2, '0')}Z`,
+  ...(turnId ? { turnId } : {}),
+  type,
+  data: { type, ...data } as TypedDurableEvent['data'],
+});
+
+/** A turn whose assistant message carries `chars` characters of text. */
+const sizedTurn = (
+  startSeq: number,
+  t: number,
+  chars: number,
+  lastCallInputContextTokens?: number
+): TypedDurableEvent[] => {
+  const turnId = `turn_${t}`;
+  return [
+    event(startSeq, 'prompt', {
+      content: [{ type: 'text', text: `msg ${t}` }],
+      track: `ext:T${t}`,
+    }),
+    event(startSeq + 1, 'turn_start', {}, turnId),
+    event(startSeq + 2, 'message', { content: 'x'.repeat(chars) }, turnId),
+    event(
+      startSeq + 3,
+      'turn_end',
+      {
+        stopReason: 'end_turn',
+        usage: {
+          inputTokens: 1,
+          outputTokens: 1,
+          ...(lastCallInputContextTokens !== undefined ? { lastCallInputContextTokens } : {}),
+        },
+      },
+      turnId
+    ),
+  ];
+};
+
+const buildSession = (turnSizes: number[], measured?: number): TypedDurableEvent[] => {
+  const events: TypedDurableEvent[] = [];
+  let seq = 1;
+  turnSizes.forEach((chars, t) => {
+    // Only the newest turn carries the measurement, mirroring what a live
+    // session looks like at the moment compaction runs.
+    const isLast = t === turnSizes.length - 1;
+    events.push(...sizedTurn(seq, t, chars, isLast ? measured : undefined));
+    seq += 4;
+  });
+  return events;
+};
+
+// ---------------------------------------------------------------------------
+// Finding the measurement in the durable log
+// ---------------------------------------------------------------------------
+
+describe('lastReportedContextTokens', () => {
+  it('returns the newest turn_end’s reported context size', () => {
+    const events = [...sizedTurn(1, 0, 10, 111_000), ...sizedTurn(5, 1, 10, 222_000)];
+    expect(lastReportedContextTokens(events)).toBe(222_000);
+  });
+
+  it('is undefined — not zero — when no turn reported one', () => {
+    // Legacy transcripts, a first turn, or a provider that reports nothing.
+    // Zero would read as "empty context" and suppress compaction forever.
+    const events = buildSession([10, 10]);
+    expect(lastReportedContextTokens(events)).toBeUndefined();
+  });
+
+  it('ignores a measurement taken before the last compaction', () => {
+    // That figure describes the pre-compaction context. Pairing it with an
+    // estimate of the post-compaction event set would invent a huge scale and
+    // peel the tail to nothing.
+    const events = [
+      ...sizedTurn(1, 0, 10, 900_000),
+      event(5, 'context_compacted', { strategy: 'track-based', preserved: [] }),
+      ...sizedTurn(6, 1, 10),
+    ];
+    expect(lastReportedContextTokens(events)).toBeUndefined();
+  });
+});
+
+describe('estimateCurrentContextTokens', () => {
+  it('measures the whole event stream when nothing has been compacted', () => {
+    const events = buildSession([20_000, 20_000]);
+    expect(estimateCurrentContextTokens(events)).toBe(
+      estimateTailTokens(splitAtTailBoundary(events, 10).tail)
+    );
+  });
+
+  it('counts the compaction prefix plus the events after it, not the summarized history', () => {
+    // The replayed context is the preserved prefix + everything since. Counting
+    // the pre-compaction events too would inflate the denominator and quietly
+    // cancel the correction on any session that has compacted before.
+    const preserved = [{ role: 'user', content: 'y'.repeat(4_000) }];
+    const events: TypedDurableEvent[] = [
+      ...sizedTurn(1, 0, 100_000),
+      event(5, 'context_compacted', { strategy: 'track-based', preserved }),
+      ...sizedTurn(6, 1, 8_000),
+    ];
+    const estimated = estimateCurrentContextTokens(events);
+    // prefix 4000 chars + one 8000-char turn ≈ 3k tokens; the 100k-char turn
+    // before the compaction must not be in there.
+    expect(estimated).toBeLessThan(5_000);
+    expect(estimated).toBeGreaterThan(2_000);
+  });
+});
+
+describe('estimateProviderTokens on a malformed history', () => {
+  it('counts an unrecognized content shape as no text instead of throwing', () => {
+    // Calibration estimates the WHOLE log, not just the slice about to be
+    // preserved, so it is the first thing to meet a history no other code path
+    // ever folded. sen-core's replay of ada's real bad-state session folds to
+    // entries with no `content` field at all, and the estimator's declared type
+    // says that cannot happen. Throwing here takes compaction down on exactly
+    // the sessions that need it most.
+    const malformed = [
+      { role: 'user' },
+      { role: 'assistant', content: null },
+      { role: 'user', content: [null, { type: 'text', text: 'abcd' }] },
+    ] as unknown as ProviderMessage[];
+    expect(estimateProviderTokens(malformed)).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reconciling the measurement with the local estimate
+// ---------------------------------------------------------------------------
+
+describe('contextMeasurementScale', () => {
+  it('is exactly 1 when there is no measurement', () => {
+    const events = buildSession([20_000, 20_000]);
+    expect(contextMeasurementScale(events, undefined)).toBe(1);
+  });
+
+  it('is the ratio by which the local estimator under-reads reality', () => {
+    const events = buildSession([20_000, 20_000]);
+    const estimated = estimateCurrentContextTokens(events);
+    expect(contextMeasurementScale(events, estimated * 4)).toBeCloseTo(4, 5);
+  });
+
+  it('never shrinks the estimate below the local one', () => {
+    // Clamped at 1 so the change can only ever make compaction size the tail
+    // more truthfully, never less.
+    const events = buildSession([20_000, 20_000]);
+    const estimated = estimateCurrentContextTokens(events);
+    expect(contextMeasurementScale(events, Math.floor(estimated / 3))).toBe(1);
+  });
+
+  it('ignores a nonsensical measurement rather than trusting it', () => {
+    const events = buildSession([20_000, 20_000]);
+    expect(contextMeasurementScale(events, 0)).toBe(1);
+    expect(contextMeasurementScale(events, -5)).toBe(1);
+    expect(contextMeasurementScale(events, Number.NaN)).toBe(1);
+  });
+
+  it('is 1 when there is nothing to calibrate against', () => {
+    // No estimable text at all: the ratio would be a division by zero, and any
+    // number we invented from it would be a guess.
+    expect(contextMeasurementScale([], 600_000)).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The behavior PRI-2947 is about
+// ---------------------------------------------------------------------------
+
+describe('trimTailToTokenBudget with a measured context size', () => {
+  it('peels turns the local estimate said would fit, when the model says otherwise', () => {
+    // The bug, in one test. A short session whose durable text estimates at a
+    // few thousand tokens but that the provider reports at 633K: the estimate
+    // wins, nothing is peeled, and `earlier` comes back empty.
+    const events = buildSession([20_000, 20_000, 20_000, 20_000, 20_000]);
+    const budget = 300_000;
+
+    const blind = trimTailToTokenBudget(events, 10, budget);
+    expect(blind.earlier).toEqual([]);
+
+    const measured = trimTailToTokenBudget(events, 10, budget, undefined, 633_419);
+    expect(measured.earlier.length).toBeGreaterThan(0);
+    expect(measured.tail.length).toBeLessThan(blind.tail.length);
+  });
+
+  it('reads the measurement out of the log when the caller passes none', () => {
+    // /compact and ent.session.compact hold no live usage figure; the newest
+    // turn_end does.
+    const events = buildSession([20_000, 20_000, 20_000, 20_000, 20_000], 633_419);
+    expect(trimTailToTokenBudget(events, 10, 300_000).earlier.length).toBeGreaterThan(0);
+  });
+
+  it('prefers the caller’s figure over the log’s', () => {
+    // The runner's in-flight number is fresher than the last turn_end — which
+    // matters most on the emergency path, where the turn that blew the window
+    // has not written one yet.
+    const events = buildSession([20_000, 20_000, 20_000, 20_000, 20_000], 10);
+    expect(trimTailToTokenBudget(events, 10, 300_000).earlier).toEqual([]);
+    expect(
+      trimTailToTokenBudget(events, 10, 300_000, undefined, 633_419).earlier.length
+    ).toBeGreaterThan(0);
+  });
+
+  it('leaves a healthy session alone', () => {
+    // The direction that must not regress: a session the model reports as
+    // comfortably inside the budget keeps its whole tail. The scaled estimate
+    // of the FULL tail is the measurement itself, so "over budget" now means
+    // exactly what the compaction trigger means by it.
+    const events = buildSession([20_000, 20_000, 20_000, 20_000, 20_000]);
+    const baseline = trimTailToTokenBudget(events, 10, 300_000);
+    const healthy = trimTailToTokenBudget(events, 10, 300_000, undefined, 120_000);
+    expect(healthy.tail.map((e) => e.eventSeq)).toEqual(baseline.tail.map((e) => e.eventSeq));
+    expect(healthy.earlier).toEqual([]);
+  });
+
+  it('changes nothing when the measurement is absent', () => {
+    const events = buildSession(Array(12).fill(20_000));
+    const before = trimTailToTokenBudget(events, 10, 12_000);
+    const after = trimTailToTokenBudget(events, 10, 12_000, undefined, undefined);
+    expect(after.tail.map((e) => e.eventSeq)).toEqual(before.tail.map((e) => e.eventSeq));
+  });
+
+  it('does not manufacture an earlier slice out of a single-turn session', () => {
+    // The peel loop bottoms out at one turn, and a one-turn split hands back
+    // the leading system_prompt_set as `earlier` — non-empty, but no
+    // conversation. A strategy would read that as something to summarize and
+    // write a compaction that preserved the entire history verbatim, spending
+    // the breakpoint that authorized it on nothing at all. That is the PRI-2945
+    // wedge, and getting the tail measurement right must not walk back into it.
+    const events: TypedDurableEvent[] = [
+      event(1, 'system_prompt_set', { text: 'You are a test assistant.' }),
+      ...sizedTurn(2, 0, 20_000),
+    ];
+    const trimmed = trimTailToTokenBudget(events, 10, 300_000, undefined, 633_419);
+    expect(trimmed.earlier).toEqual([]);
+    return compact(events, {
+      threadId: 's_single',
+      contextWindow: 1_000_000,
+      measuredContextTokens: 633_419,
+    }).then((result) => {
+      expect('noop' in result).toBe(true);
+    });
+  });
+
+  it('still preserves the in-flight turn when the measurement dwarfs the budget', () => {
+    const events = buildSession([20_000, 20_000, 20_000]);
+    const trimmed = trimTailToTokenBudget(events, 10, 1_000, undefined, 5_000_000);
+    expect(trimmed.tail.length).toBe(4);
+  });
+});
+
+describe('track-based compact() with a measured context size', () => {
+  it('sheds history on a short session the model reports as full', () => {
+    // Fewer turns than TAIL_TURNS, so the turn-count split alone yields no
+    // `earlier` — the only thing that can produce one is the tail budget, and
+    // before PRI-2947 the budget was compared against a number an order of
+    // magnitude below reality.
+    const events = buildSession([20_000, 20_000, 20_000, 20_000, 20_000]);
+
+    return Promise.all([
+      compact(events, { threadId: 's_blind', contextWindow: 1_000_000 }),
+      compact(events, {
+        threadId: 's_measured',
+        contextWindow: 1_000_000,
+        measuredContextTokens: 633_419,
+      }),
+    ]).then(([blind, measured]) => {
+      expect('noop' in blind).toBe(true);
+      expect('compactionEvent' in measured).toBe(true);
+    });
+  });
+
+  it('still noops on a short session the model reports as nearly empty', () => {
+    const events = buildSession([20_000, 20_000, 20_000, 20_000, 20_000]);
+    return compact(events, {
+      threadId: 's_healthy',
+      contextWindow: 1_000_000,
+      measuredContextTokens: 40_000,
+    }).then((result) => {
+      expect('noop' in result).toBe(true);
+    });
+  });
+});

--- a/packages/agent/src/compaction/build-context.ts
+++ b/packages/agent/src/compaction/build-context.ts
@@ -78,6 +78,7 @@ export function buildCompactionContext(
     guidance?: string;
     referenceTimestamp?: string;
     contextWindow?: number;
+    measuredContextTokens?: number;
   },
   deps?: BuildContextDeps
 ): CompactionContext {
@@ -89,6 +90,14 @@ export function buildCompactionContext(
     sessionDir: opts.sessionDir,
     referenceTimestamp: opts.referenceTimestamp ?? new Date().toISOString(),
     ...(opts.contextWindow !== undefined ? { contextWindow: opts.contextWindow } : {}),
+    // Only a real, positive reading is passed on. A zero or a NaN from a
+    // provider that reports nothing must arrive at the strategy as ABSENT, not
+    // as "this session's context is empty" — see CompactionContext.
+    ...(typeof opts.measuredContextTokens === 'number' &&
+    Number.isFinite(opts.measuredContextTokens) &&
+    opts.measuredContextTokens > 0
+      ? { measuredContextTokens: opts.measuredContextTokens }
+      : {}),
     ...(opts.guidance !== undefined ? { guidance: opts.guidance } : {}),
   };
 

--- a/packages/agent/src/compaction/toolkit.ts
+++ b/packages/agent/src/compaction/toolkit.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Pure, self-contained (no rpc/utils dependency). Safe for cross-checkout import.
 
 import { isEventOfType } from '@lace/agent/storage/event-types';
-import type { TypedDurableEvent } from '@lace/agent/storage/event-types';
+import type { TypedDurableEvent, ContextCompactedEventData } from '@lace/agent/storage/event-types';
 import type { ContentBlock, ThinkingBlock } from '@lace/agent/providers/base-provider';
 import type { ToolCall as CoreToolCall, ToolResult as CoreToolResult } from '../tools/types';
 import type { ToolResult as ProtocolToolResult } from '@lace/ent-protocol';
@@ -762,6 +762,103 @@ export function estimateTailTokens(tail: TypedDurableEvent[]): number {
   return estimateProviderTokens(buildPreservedTail(tail));
 }
 
+/** Index of the newest `context_compacted` event, or -1 when there is none. */
+function lastCompactedIndex(events: TypedDurableEvent[]): number {
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (events[i].type === 'context_compacted') return i;
+  }
+  return -1;
+}
+
+/**
+ * The provider's own report of how big this session's context actually is, read
+ * from the newest `turn_end` — `lastCallInputContextTokens`, the whole input of
+ * the last API call: system prompt, tool schemas, images, history, everything
+ * `estimateProviderTokens` cannot see.
+ *
+ * Returns `undefined`, never 0, when nothing reported one (a legacy transcript,
+ * a first turn, a provider that reports no usage). A zero would read as "the
+ * context is empty" and is exactly how you build a compaction that never fires.
+ *
+ * Only turns AFTER the newest compaction count. An older figure describes the
+ * pre-compaction context; pairing it with an estimate of the post-compaction
+ * event set would invent an enormous correction factor and peel the tail to
+ * nothing.
+ */
+export function lastReportedContextTokens(events: TypedDurableEvent[]): number | undefined {
+  for (let i = events.length - 1; i > lastCompactedIndex(events); i--) {
+    const e = events[i];
+    if (!isEventOfType(e, 'turn_end')) continue;
+    const reported = e.data.usage?.lastCallInputContextTokens;
+    if (typeof reported === 'number' && Number.isFinite(reported) && reported > 0) return reported;
+  }
+  return undefined;
+}
+
+/**
+ * The local estimator's reading of the context the provider is currently
+ * replaying: the newest compaction's preserved prefix plus every event since.
+ * The denominator of the calibration below — it has to cover the same span the
+ * measurement does, or the ratio between them means nothing.
+ */
+export function estimateCurrentContextTokens(events: TypedDurableEvent[]): number {
+  const compactedAt = lastCompactedIndex(events);
+  // `preserved` is `unknown[]` on the event and genuinely is unknown on a real
+  // transcript — ada's bad-state fixture carries entries with no `content` at
+  // all. The cast is safe because `estimateProviderTokens` counts anything it
+  // does not recognize as no text rather than throwing.
+  const prefix =
+    compactedAt >= 0
+      ? (((events[compactedAt].data as ContextCompactedEventData).preserved ??
+          []) as PreservedMessage[])
+      : [];
+  const since = buildPreservedTail(events.slice(compactedAt + 1));
+  return estimateProviderTokens([...prefix, ...since]);
+}
+
+/**
+ * How far `estimateProviderTokens` under-reads this session's real content, as
+ * a multiplier ≥ 1.
+ *
+ * The estimator is a chars/4 floor over message text. Real coworker content
+ * measures 2.4–2.9 chars per token, and the system prompt, the tool schemas and
+ * every image are outside what it counts at all — on ada-sen the prompt and
+ * schemas alone are 88K characters. So a session the runner knows is at 633K
+ * tokens estimates at ~25K, the tail budget sees a tail that comfortably fits,
+ * nothing is peeled, and compaction returns a noop on a session that is
+ * two-thirds full (PRI-2947).
+ *
+ * The correction is deliberately a ratio and not a subtracted gap. A fixed gap
+ * would survive every peel — the loop would shed turn after turn without the
+ * measure ever falling, and land on a single turn every time. A ratio shrinks
+ * as the tail shrinks, which is how the density half of the error actually
+ * behaves. The fixed half (prompt + schemas) is amortized across the tail by
+ * the same ratio, which over-attributes it to a shrinking tail; that errs
+ * toward peeling one more turn than strictly needed, which is the safe
+ * direction for a mechanism whose job is to get back under the window.
+ *
+ * Clamped at 1: this can only ever make the tail read closer to what the model
+ * sees, never smaller. Absent, zero, negative and NaN measurements all mean "we
+ * were told nothing" and leave the estimate exactly as it was.
+ */
+export function contextMeasurementScale(
+  events: TypedDurableEvent[],
+  measuredContextTokens: number | undefined
+): number {
+  if (
+    measuredContextTokens === undefined ||
+    !Number.isFinite(measuredContextTokens) ||
+    measuredContextTokens <= 0
+  ) {
+    return 1;
+  }
+  const estimated = estimateCurrentContextTokens(events);
+  // Nothing to calibrate against — any factor derived from zero would be
+  // invented rather than measured.
+  if (estimated <= 0) return 1;
+  return Math.max(1, measuredContextTokens / estimated);
+}
+
 /**
  * Apply a token budget to the turn-based split. Starting from the turn-count
  * split, while the verbatim tail's estimated tokens exceed `budget` AND the
@@ -789,9 +886,24 @@ export function trimTailToTokenBudget(
    * always the untransformed events — the caller still applies its own
    * transform downstream.
    */
-  prepareTail?: (tail: TypedDurableEvent[]) => TypedDurableEvent[]
+  prepareTail?: (tail: TypedDurableEvent[]) => TypedDurableEvent[],
+  /**
+   * The provider's report of the session's real context size, when the caller
+   * holds a fresher one than the durable log does — the runner's in-flight
+   * figure, which on the emergency path predates any `turn_end` for the turn
+   * that just blew the window. Omitted, the newest `turn_end` is consulted, so
+   * the out-of-band callers (`/compact`, `ent/session/compact`) get the
+   * correction too. Nothing anywhere reports it: the estimate stands as it did
+   * before PRI-2947.
+   */
+  measuredContextTokens?: number
 ): { earlier: TypedDurableEvent[]; tail: TypedDurableEvent[] } {
-  const measure = (tail: TypedDurableEvent[]) => estimateTailTokens(prepareTail?.(tail) ?? tail);
+  const scale = contextMeasurementScale(
+    events,
+    measuredContextTokens ?? lastReportedContextTokens(events)
+  );
+  const measure = (tail: TypedDurableEvent[]) =>
+    Math.round(estimateTailTokens(prepareTail?.(tail) ?? tail) * scale);
   let split = splitAtTailBoundary(events, tailTurns);
   let turns = tailTurns;
 
@@ -800,12 +912,25 @@ export function trimTailToTokenBudget(
     split = splitAtTailBoundary(events, turns);
   }
 
+  // Peeling only counts when a whole TURN moved. On a session with a single
+  // turn the loop bottoms out at one turn and `splitAtTailBoundary` hands back
+  // the leading `system_prompt_set` as `earlier` — non-empty, but holding no
+  // conversation at all. A strategy testing `earlier.length === 0` reads that
+  // as something to summarize and writes a compaction that preserves the whole
+  // history verbatim, which sheds nothing and spends the breakpoint that
+  // authorized it (PRI-2945). There is no tail size that fits such a session;
+  // hand back the untrimmed split and let the strategy noop.
+  if (!split.earlier.some((e) => e.type === 'turn_end')) {
+    split = splitAtTailBoundary(events, tailTurns);
+  }
+
   if (measure(split.tail) > budget) {
     logger.warn(
       'compaction: preserved tail exceeds token budget with a single turn — preserving it anyway',
       {
         budget,
         estimatedTailTokens: measure(split.tail),
+        measurementScale: scale,
         tailTurns: turns,
       }
     );

--- a/packages/agent/src/compaction/track-compaction.ts
+++ b/packages/agent/src/compaction/track-compaction.ts
@@ -30,6 +30,9 @@ export {
   tailTokenBudget,
   estimateTailTokens,
   trimTailToTokenBudget,
+  lastReportedContextTokens,
+  estimateCurrentContextTokens,
+  contextMeasurementScale,
 } from './toolkit';
 
 /**
@@ -193,7 +196,9 @@ export async function compact(
   const { earlier, tail } = trimTailToTokenBudget(
     events,
     TAIL_TURNS,
-    tailTokenBudget(ctx.contextWindow)
+    tailTokenBudget(ctx.contextWindow),
+    undefined,
+    ctx.measuredContextTokens
   );
 
   if (earlier.length === 0) {

--- a/packages/agent/src/compaction/types.ts
+++ b/packages/agent/src/compaction/types.ts
@@ -41,6 +41,28 @@ export interface CompactionContext {
    */
   readonly contextWindow?: number;
   /**
+   * What the provider reported the session's context actually cost on its most
+   * recent API call — the whole input: system prompt, tool schemas, images,
+   * history. The number the compaction TRIGGER already computes pressure from.
+   *
+   * Strategies size their verbatim tail against a local `chars/4` estimate over
+   * durable event text, which sees none of that and under-reads real coworker
+   * content by an order of magnitude. Handed the same measurement the trigger
+   * used, a strategy can calibrate that estimate instead of arguing with the
+   * model about how full its own window is (PRI-2947).
+   *
+   * Absent — never zero — when nobody reported one: a first turn, a legacy
+   * transcript, a provider with no usage accounting. A zero would read as "the
+   * context is empty" and would suppress compaction for the life of the
+   * session. Absent means "we were told nothing", and a strategy handed nothing
+   * must fall back to its own estimate rather than to an implied number.
+   *
+   * Absolute tokens rather than a pressure ratio: `contextWindow` rides
+   * alongside, so a strategy that wants the ratio can divide, while the tail
+   * budget it is compared against is denominated in tokens.
+   */
+  readonly measuredContextTokens?: number;
+  /**
    * Free-text steering hint forwarded from the compact caller:
    * - compact_session / ent.session.compact passes the request's `guidance` field
    * - /compact passes the remainder of the command line

--- a/packages/agent/src/core/conversation/__tests__/runner.breakpoints.test.ts
+++ b/packages/agent/src/core/conversation/__tests__/runner.breakpoints.test.ts
@@ -399,7 +399,14 @@ describe('ConversationRunner - configurable breakpoints', () => {
     mockBreakpoints.mockReturnValue([{ at: 0.5, action: 'compact' }]);
 
     const compactedUnderWindow = async (window: number) => {
-      seedLargeTurns(sessionDir, sessionId, cwd, 'compact-low', 12, 200_000);
+      // A session directory of its own per arm. Re-seeding the shared one left
+      // the second arm running against the FIRST arm's compacted log — so the
+      // two numbers being compared came from different histories, and the
+      // scripted usage no longer described the session it was attached to.
+      const armSessionId = `sess_${randomUUID()}`;
+      const sessionDir = join(laceDir, 'agent-sessions', armSessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      seedLargeTurns(sessionDir, armSessionId, cwd, 'compact-low', 12, 200_000);
       const provider = new ScriptedProvider(
         [
           {
@@ -420,7 +427,7 @@ describe('ConversationRunner - configurable breakpoints', () => {
       const runner = new ConversationRunner(
         {
           sessionDir,
-          sessionId,
+          sessionId: armSessionId,
           cwd,
           executionMode: 'execute',
           approvalMode: 'approve',

--- a/packages/agent/src/core/conversation/runner.ts
+++ b/packages/agent/src/core/conversation/runner.ts
@@ -1086,11 +1086,21 @@ export class ConversationRunner {
           emergencyCompactions < MAX_EMERGENCY_COMPACTIONS
         ) {
           emergencyCompactions++;
+          const lastCallContextTokens =
+            lastCallInputTokens + lastCallCacheCreationInputTokens + lastCallCacheReadInputTokens;
           let compacted = false;
           try {
             compacted = await this.compactSession({
               modelId,
               contextWindow: provider.contextWindowForModel(modelId ?? 'default'),
+              // The call that just overflowed reported no usage, so these hold
+              // the last SUCCESSFUL call's figures — a lower bound on the
+              // context that failed, which is exactly the direction that keeps
+              // this honest. Zero (nothing has succeeded yet this run) is sent
+              // as absent, never as an empty context.
+              ...(lastCallContextTokens > 0
+                ? { measuredContextTokens: lastCallContextTokens }
+                : {}),
               updateTurnSeq: durableTurnSeq,
             });
           } catch (compactionErr) {
@@ -1532,6 +1542,12 @@ export class ConversationRunner {
           const compacted = await this.compactSession({
             modelId,
             contextWindow: contextWindowSize,
+            // The very number `pressure` above was computed from. Handing the
+            // strategy the window but not the measurement is what let it
+            // disagree with the trigger that woke it (PRI-2947).
+            ...(usage.lastCallInputContextTokens > 0
+              ? { measuredContextTokens: usage.lastCallInputContextTokens }
+              : {}),
             guidance: compactionRequest.guidance,
             updateTurnSeq: durableTurnSeq,
           });
@@ -1634,6 +1650,17 @@ export class ConversationRunner {
      * (PRI-2906). Both callers run inside `run()`, where the provider is live.
      */
     contextWindow: number;
+    /**
+     * What the provider reported this session's context cost on its last call.
+     * The strategy's own estimator is a chars/4 floor over durable event text —
+     * blind to the system prompt, the tool schemas and every image — so on real
+     * coworker content it reads an order of magnitude under the figure the
+     * pressure trigger three lines up just acted on, and the strategy concludes
+     * its tail fits when the model says the window is two-thirds gone
+     * (PRI-2947). Absent when no call in this run reported usage; absent means
+     * unknown, and the strategy falls back to its estimate.
+     */
+    measuredContextTokens?: number;
     /** Stream seq for the compaction_complete update. */
     updateTurnSeq: number;
   }): Promise<boolean> {
@@ -1655,6 +1682,9 @@ export class ConversationRunner {
       connectionId: this.config.connectionId,
       modelId: params.modelId ?? undefined,
       contextWindow: params.contextWindow,
+      ...(params.measuredContextTokens !== undefined
+        ? { measuredContextTokens: params.measuredContextTokens }
+        : {}),
       guidance: params.guidance,
     });
     const raw = await strategy.compact(

--- a/packages/agent/src/utils/token-estimation.ts
+++ b/packages/agent/src/utils/token-estimation.ts
@@ -26,14 +26,18 @@ export function estimateProviderTokens(messages: ProviderMessage[]): number {
   for (const message of messages) {
     if (typeof message.content === 'string') {
       total += estimateTokens(message.content);
-    } else {
+    } else if (Array.isArray(message.content)) {
       // Count tokens for text blocks only (images don't count as text tokens)
       const textContent = message.content
-        .filter((b): b is ContentBlock & { type: 'text' } => b.type === 'text')
+        .filter((b): b is ContentBlock & { type: 'text' } => b?.type === 'text')
         .map((b) => b.text)
         .join('\n');
       total += estimateTokens(textContent);
     }
+    // Anything else contributes no text. The type says content is always a
+    // string or a block array, and real transcripts disagree: ada's bad-state
+    // fixture folds to entries with no content field at all. Throwing here
+    // would take compaction down on precisely the sessions that need it most.
     if (message.toolCalls) {
       total += estimateTokens(JSON.stringify(message.toolCalls));
     }


### PR DESCRIPTION
## The problem

`ConversationRunner` computes pressure from what the provider charged for the last call. It then hands the compaction strategy a `contextWindow` and nothing else. The strategy sizes its verbatim tail with `estimateProviderTokens` — a `chars/4` floor over durable event text that counts no system prompt, no tool schema, and no image.

On real coworker content that under-reads by an order of magnitude. A session the runner knows is at **633,419 tokens (63% of a 1M window)** estimates at ~25K, the tail budget sees a tail that comfortably fits, no `earlier` slice is produced, and compaction returns `{noop: true}`. Every turn. After #380 it retries rather than being silenced forever, but it still cannot shed anything.

## The fix

- **`CompactionContext.measuredContextTokens`** — absolute tokens, **absent (never 0)** when nobody reported one. A zero would read as "the context is empty" and is how you build a compaction that never fires. Absolute rather than a ratio because `contextWindow` rides alongside and the budget is denominated in tokens.
- **`trimTailToTokenBudget` calibrates** rather than replaces: `scale = measured / the estimator's own reading of the context currently being replayed` (the newest compaction's preserved prefix plus everything since), clamped at `>= 1`, applied to every tail measurement. It needs a per-event size to decide *what* to peel, so the measurement alone is not a drop-in — a ratio corrects the density error the way that error actually behaves. A subtracted gap would survive every peel and shed turns until only one was left.
- **Falls back to the log.** With no figure from the caller it reads the newest `turn_end`'s `lastCallInputContextTokens` — only turns *after* the newest compaction, since an older figure describes a context that no longer exists. That covers `/compact` and `ent/session/compact` without threading the number through two more handlers.
- **The runner passes its live figure** at both call sites, including the emergency `context_window_exceeded` path, where the last *successful* call's figure is a lower bound on the context that just failed.

## What stops this making compaction more aggressive

The scaled measurement of the **full** tail is the reported figure itself. So peeling begins only when the model says the session is over the tail budget — the same number the pressure trigger already acted on to authorize this compaction. A healthy session keeps its whole tail, pinned by a test. The scale is clamped at 1, so a session where the local estimator already over-reads is untouched.

## Two things the measurement surfaced

Both are regressions this change would otherwise introduce, so both are fixed here:

- The peel loop bottoms out at one turn, and a one-turn split hands back a leading `system_prompt_set` as `earlier` — non-empty, but no conversation. A strategy reads that as something to summarize and writes a compaction preserving the entire history verbatim, spending the breakpoint that authorized it on nothing. That is the PRI-2945 wedge. **Peeling now only counts when a whole turn moves.**
- Calibration estimates the **whole** log, so it is the first code path to meet a history no slice ever folded. sen-core's replay of ada's real bad-state session folds to entries with no `content` at all, and `estimateProviderTokens` threw. It now counts an unrecognized content shape as no text — throwing there takes compaction down on exactly the sessions that need it most.

## `estimateProviderTokens` keeps its chars/4 constant

Deliberately. Where a measurement exists it is now calibrated against. Where none exists, retuning a global constant on the strength of one fleet's measured density would make compaction more aggressive everywhere on no evidence — the opposite of the direction this change is supposed to be conservative in.

## Test fixture fix

The PRI-2906 window test re-seeded one shared session directory for both of its arms, so the second arm ran against the first arm's compacted log and its scripted usage no longer described the session it was attached to. Each arm gets its own session now.

## Verification

Every new test proven non-vacuous by reverting the fix:

- revert the scale application → 4 fail (the measured-peel tests, the log fallback, the caller-precedence test, the end-to-end `compact()`)
- revert the whole-turn peel guard → 2 fail (the single-turn test, and `runner.breakpoints` PRI-2945)
- revert the estimator hardening → 1 fail here, plus sen-core's real-Ada bad-state replay

Gates: `npm run lint`, `npm run format:check`, `npm test --workspace=packages/agent` (3592 passed) all green.

Paired with prime-radiant-inc/sen-core-v2#79, which passes the same figure from `sen-multiconv`.