### PR TITLE
fix(file_find): one container exec per entry wedged a coworker for 96 minutes (PRI-2975)

### DIFF
--- a/packages/agent/src/tools/executor-slow-tool-warning.test.ts
+++ b/packages/agent/src/tools/executor-slow-tool-warning.test.ts
@@ -1,0 +1,69 @@
+// ABOUTME: A tool call that never returns takes the whole agent loop offline
+// ABOUTME: (PRI-2975: file_find ran 96 minutes and ada-sen went mute). The
+// ABOUTME: executor cannot safely kill such a call, but it must say which tool
+// ABOUTME: is responsible, because the symptom is silence.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ToolExecutor } from './executor';
+import { Tool } from './tool';
+import { logger } from '@lace/agent/utils/logger';
+import { z } from 'zod';
+import type { ToolResult } from './types';
+
+class SleepyTool extends Tool {
+  name = 'sleepy';
+  description = 'sleeps';
+  schema = z.object({ ms: z.number() });
+  protected async executeValidated(args: { ms: number }): Promise<ToolResult> {
+    await new Promise((r) => setTimeout(r, args.ms));
+    return this.createResult('done');
+  }
+}
+
+describe('ToolExecutor slow-tool warning (PRI-2975)', () => {
+  let executor: ToolExecutor;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  const originalThreshold = ToolExecutor.SLOW_TOOL_WARN_MS;
+
+  beforeEach(() => {
+    executor = new ToolExecutor();
+    executor.registerTool('sleepy', new SleepyTool());
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    ToolExecutor.SLOW_TOOL_WARN_MS = originalThreshold;
+    warnSpy.mockRestore();
+  });
+
+  it('names the tool still running past the threshold', async () => {
+    ToolExecutor.SLOW_TOOL_WARN_MS = 10;
+
+    await executor.execute({ id: 'c1', name: 'sleepy', arguments: { ms: 80 } }, {});
+
+    const named = warnSpy.mock.calls.some(
+      (call) =>
+        JSON.stringify(call).includes('sleepy') && /still running/i.test(JSON.stringify(call))
+    );
+    expect(named).toBe(true);
+  });
+
+  it('stays quiet for a tool that returns promptly', async () => {
+    ToolExecutor.SLOW_TOOL_WARN_MS = 10_000;
+
+    await executor.execute({ id: 'c2', name: 'sleepy', arguments: { ms: 1 } }, {});
+
+    const named = warnSpy.mock.calls.some((call) => /still running/i.test(JSON.stringify(call)));
+    expect(named).toBe(false);
+  });
+
+  it('does not leave a timer behind that fires after the tool finished', async () => {
+    ToolExecutor.SLOW_TOOL_WARN_MS = 40;
+
+    await executor.execute({ id: 'c3', name: 'sleepy', arguments: { ms: 1 } }, {});
+    warnSpy.mockClear();
+    await new Promise((r) => setTimeout(r, 90));
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/src/tools/executor.ts
+++ b/packages/agent/src/tools/executor.ts
@@ -349,10 +349,6 @@ export class ToolExecutor {
   }
 
   /**
-   * Execute a tool directly without approval complexity.
-   * Agent owns approval flow - ToolExecutor just executes when told.
-   */
-  /**
    * Warn when a single tool call has been running this long (PRI-2975).
    *
    * The agent loop awaits tool results, so a call that does not return takes
@@ -365,6 +361,10 @@ export class ToolExecutor {
    */
   static SLOW_TOOL_WARN_MS = 120_000;
 
+  /**
+   * Execute a tool directly without approval complexity.
+   * Agent owns approval flow - ToolExecutor just executes when told.
+   */
   async execute(toolCall: ToolCall, context: ToolContext): Promise<ToolResult> {
     const tool = this.getTool(toolCall.name);
     if (!tool) {

--- a/packages/agent/src/tools/executor.ts
+++ b/packages/agent/src/tools/executor.ts
@@ -396,8 +396,12 @@ export class ToolExecutor {
       toolContext = { ...toolContext, jobManager: this.jobManager };
     }
 
-    // Reset the runtime's per-tool-call filesystem budget (PRI-2975), so the
-    // ceiling bounds ONE tool call rather than the lifetime of a session.
+    // Reset the runtime's per-tool-call filesystem budget (PRI-2975).
+    //
+    // Defensive, not load-bearing today: runner.executeToolCall builds a fresh
+    // runtime per call, so the counter already starts at zero. This keeps the
+    // ceiling scoped to one tool call if a runtime is ever cached or pooled,
+    // where otherwise a long session would accumulate its way into a refusal.
     toolContext.runtime?.fs?.beginToolCall?.();
 
     const startedAt = Date.now();

--- a/packages/agent/src/tools/executor.ts
+++ b/packages/agent/src/tools/executor.ts
@@ -396,6 +396,10 @@ export class ToolExecutor {
       toolContext = { ...toolContext, jobManager: this.jobManager };
     }
 
+    // Reset the runtime's per-tool-call filesystem budget (PRI-2975), so the
+    // ceiling bounds ONE tool call rather than the lifetime of a session.
+    toolContext.runtime?.fs?.beginToolCall?.();
+
     const startedAt = Date.now();
     const slowWarning = setTimeout(() => {
       logger.warn('tool call still running', {

--- a/packages/agent/src/tools/executor.ts
+++ b/packages/agent/src/tools/executor.ts
@@ -352,6 +352,19 @@ export class ToolExecutor {
    * Execute a tool directly without approval complexity.
    * Agent owns approval flow - ToolExecutor just executes when told.
    */
+  /**
+   * Warn when a single tool call has been running this long (PRI-2975).
+   *
+   * The agent loop awaits tool results, so a call that does not return takes
+   * the coworker offline entirely — ada-sen sat mute for 96 minutes inside one
+   * file_find while Docker still reported healthy. The executor cannot safely
+   * cancel arbitrary tools (delegate and subagent calls legitimately run for
+   * hours), but silence is the symptom, so it must at least name the culprit.
+   *
+   * Public so tests can shorten it.
+   */
+  static SLOW_TOOL_WARN_MS = 120_000;
+
   async execute(toolCall: ToolCall, context: ToolContext): Promise<ToolResult> {
     const tool = this.getTool(toolCall.name);
     if (!tool) {
@@ -383,7 +396,30 @@ export class ToolExecutor {
       toolContext = { ...toolContext, jobManager: this.jobManager };
     }
 
-    const result = await tool.execute(toolCall.arguments, toolContext);
+    const startedAt = Date.now();
+    const slowWarning = setTimeout(() => {
+      logger.warn('tool call still running', {
+        tool: toolCall.name,
+        toolCallId: toolCall.id,
+        elapsedMs: Date.now() - startedAt,
+        note: 'the agent loop is blocked until this returns',
+      });
+    }, ToolExecutor.SLOW_TOOL_WARN_MS);
+
+    let result: ToolResult;
+    try {
+      result = await tool.execute(toolCall.arguments, toolContext);
+    } finally {
+      clearTimeout(slowWarning);
+      const elapsedMs = Date.now() - startedAt;
+      if (elapsedMs >= ToolExecutor.SLOW_TOOL_WARN_MS) {
+        logger.warn('tool call finished after running long', {
+          tool: toolCall.name,
+          toolCallId: toolCall.id,
+          elapsedMs,
+        });
+      }
+    }
 
     // Ensure the result has the call ID if it wasn't set by the tool
     if (!result.id && toolCall.id) {

--- a/packages/agent/src/tools/file-find.test.ts
+++ b/packages/agent/src/tools/file-find.test.ts
@@ -9,6 +9,7 @@ import { createTestTempDir } from '@lace/agent/test-utils/temp-directory';
 import { createFakeRuntime } from './runtime/__tests__/fake-runtime';
 import { HostToolRuntime } from './runtime/host';
 import type { ToolContext } from './types';
+import { FilesystemCallCeilingError } from './runtime/types';
 import type { RuntimePath } from './runtime/types';
 
 describe('FileFindTool with schema validation', () => {
@@ -817,5 +818,44 @@ describe('FileFindTool single-exec fast path (PRI-2975)', () => {
     expect(result.status).toBe('completed');
     expect(result.content[0].text).toContain('top.ts');
     expect(readdirSpy).toHaveBeenCalled();
+  });
+});
+
+// PRI-2975: the walk's catch blocks intentionally swallow per-entry errors
+// (permissions, broken symlinks). The call ceiling must NOT be swallowed —
+// otherwise a truncated search is reported as a complete one, and the model
+// concludes the file does not exist.
+describe('FileFindTool honours the runtime call ceiling (PRI-2975)', () => {
+  it('reports the search as incomplete instead of silently returning a partial', async () => {
+    const root: RuntimePath = {
+      original: '.',
+      runtimePath: '/runtime',
+      displayPath: 'project',
+    };
+    const runtime = createFakeRuntime({ resolve: root, statType: 'directory' });
+
+    // No fast path: force the walk.
+    vi.mocked(runtime.process.exec).mockResolvedValue({
+      exitCode: 127,
+      stdout: '',
+      stderr: 'find: not found',
+    });
+    vi.mocked(runtime.fs.readdir).mockResolvedValue([
+      { name: 'a.ts', type: 'file' },
+      { name: 'b.ts', type: 'file' },
+    ]);
+    vi.mocked(runtime.fs.stat).mockImplementation(async (p) => {
+      if (p.runtimePath === root.runtimePath)
+        return { type: 'directory', size: 0, mtime: new Date() };
+      throw new FilesystemCallCeilingError('too many filesystem calls in a single tool call');
+    });
+
+    const result = await new FileFindTool().execute(
+      { pattern: '*.ts', path: '.' },
+      { signal: new AbortController().signal, runtime }
+    );
+
+    expect(result.status).toBe('completed');
+    expect(result.content[0].text).toContain('Search stopped early');
   });
 });

--- a/packages/agent/src/tools/file-find.test.ts
+++ b/packages/agent/src/tools/file-find.test.ts
@@ -171,6 +171,15 @@ describe('FileFindTool with schema validation', () => {
         resolve: rootPath,
         statType: 'directory',
       });
+      // This test is about the recursive walk's display paths, so take the
+      // single-exec fast path out of play. The fake's exec otherwise reports
+      // success with empty output for any command, which reads as "find ran and
+      // matched nothing".
+      vi.mocked(runtime.process.exec).mockResolvedValue({
+        exitCode: 127,
+        stdout: '',
+        stderr: 'find: not found',
+      });
       const mtime = new Date('2026-05-20T00:00:00.000Z');
       vi.mocked(runtime.fs.stat).mockImplementation(async (path) => {
         if (path.runtimePath === rootPath.runtimePath || path.runtimePath === srcPath.runtimePath) {
@@ -706,5 +715,107 @@ describe('FileFindTool search budget (PRI-2975)', () => {
     expect(result.status).toBe('completed');
     expect(result.content[0].text).not.toContain(INCOMPLETE_MARKER);
     expect(result.content[0].text).toContain('f-0.txt');
+  });
+});
+
+// PRI-2975 (A3): one `find` exec instead of a per-directory walk. ripgrep_search
+// already delegates traversal to a single in-container process; file_find was
+// the odd one out.
+describe('FileFindTool single-exec fast path (PRI-2975)', () => {
+  const tempDir = createTestTempDir('file_find-fast-');
+  let testDir: string;
+  let rtId = 0;
+
+  beforeEach(async () => {
+    testDir = await tempDir.getPath();
+    await mkdir(join(testDir, 'nested', 'deeper'), { recursive: true });
+    await mkdir(join(testDir, '.hidden'), { recursive: true });
+    await writeFile(join(testDir, 'top.ts'), 'a');
+    await writeFile(join(testDir, 'nested', 'mid.ts'), 'bb');
+    await writeFile(join(testDir, 'nested', 'deeper', 'low.ts'), 'ccc');
+    await writeFile(join(testDir, 'nested', 'other.js'), 'dddd');
+    await writeFile(join(testDir, '.hidden', 'secret.ts'), 'eeeee');
+    await writeFile(join(testDir, 'weird[1].ts'), 'ffffff');
+  });
+
+  afterEach(async () => {
+    await tempDir.cleanup();
+  });
+
+  function instrumented() {
+    const runtime = new HostToolRuntime({ id: `rt_fast_${rtId++}`, cwd: testDir });
+    const execSpy = vi.spyOn(runtime.process, 'exec');
+    const readdirSpy = vi.spyOn(runtime.fs, 'readdir');
+    return {
+      context: { signal: new AbortController().signal, runtime } as ToolContext,
+      execSpy,
+      readdirSpy,
+    };
+  }
+
+  it('walks the whole tree in a single exec for a simple glob', async () => {
+    const { context, execSpy, readdirSpy } = instrumented();
+
+    const result = await new FileFindTool().execute(
+      { pattern: '*.ts', path: testDir, maxDepth: 10 },
+      context
+    );
+
+    expect(result.status).toBe('completed');
+    const text = result.content[0].text ?? '';
+    expect(text).toContain('top.ts');
+    expect(text).toContain('mid.ts');
+    expect(text).toContain('low.ts');
+    expect(text).not.toContain('other.js');
+    // Hidden entries stay excluded by default, as in the walk.
+    expect(text).not.toContain('secret.ts');
+
+    expect(execSpy).toHaveBeenCalledTimes(1);
+    expect(readdirSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the walk for a pattern where find -iname and our matcher disagree', async () => {
+    const { context, readdirSpy } = instrumented();
+
+    // Our matcher escapes brackets and treats this literally; find -iname would
+    // read [1] as a character class. Different engines, so no fast path.
+    const result = await new FileFindTool().execute(
+      { pattern: 'weird[1].ts', path: testDir, maxDepth: 10 },
+      context
+    );
+
+    expect(result.status).toBe('completed');
+    expect(result.content[0].text).toContain('weird[1].ts');
+    expect(readdirSpy).toHaveBeenCalled();
+  });
+
+  // maxDepth counts RECURSION STEPS, not path depth: maxDepth 1 lists the root's
+  // entries AND reaches one subdirectory down. The fast path must reproduce this
+  // exactly, so `find -maxdepth` is maxDepth + 1. (MIN_DEPTH is 1, so 0 is not a
+  // legal input to compare against.)
+  it('honours maxDepth identically to the walk (1 = one level down)', async () => {
+    const { context } = instrumented();
+    const result = await new FileFindTool().execute(
+      { pattern: '*.ts', path: testDir, maxDepth: 1 },
+      context
+    );
+    const text = result.content[0].text ?? '';
+    expect(text).toContain('top.ts');
+    expect(text).toContain('mid.ts');
+    expect(text).not.toContain('low.ts');
+  });
+
+  it('falls back to the walk when the single exec fails', async () => {
+    const { context, execSpy, readdirSpy } = instrumented();
+    execSpy.mockResolvedValueOnce({ exitCode: 127, stdout: '', stderr: 'find: not found' });
+
+    const result = await new FileFindTool().execute(
+      { pattern: '*.ts', path: testDir, maxDepth: 10 },
+      context
+    );
+
+    expect(result.status).toBe('completed');
+    expect(result.content[0].text).toContain('top.ts');
+    expect(readdirSpy).toHaveBeenCalled();
   });
 });

--- a/packages/agent/src/tools/file-find.test.ts
+++ b/packages/agent/src/tools/file-find.test.ts
@@ -859,3 +859,65 @@ describe('FileFindTool honours the runtime call ceiling (PRI-2975)', () => {
     expect(result.content[0].text).toContain('Search stopped early');
   });
 });
+
+// PRI-2975 review follow-up: GNU find exits 1 when it cannot read ANY
+// subdirectory during traversal, while still printing correct output for
+// everything it could read. Verified: a tree with one chmod-000 directory gives
+// exit=1 and valid stdout. Discarding that output and falling back to the walk
+// would reintroduce the per-entry pathology on any tree with a permission
+// problem — common in node_modules and container mounts.
+describe('FileFindTool tolerates find partial failure (PRI-2975)', () => {
+  const tempDir = createTestTempDir('file_find-partial-');
+  let testDir: string;
+  let rtId = 0;
+
+  beforeEach(async () => {
+    testDir = await tempDir.getPath();
+    await writeFile(join(testDir, 'reachable.ts'), 'x');
+  });
+
+  afterEach(async () => {
+    await tempDir.cleanup();
+  });
+
+  function instrumented() {
+    const runtime = new HostToolRuntime({ id: `rt_partial_${rtId++}`, cwd: testDir });
+    const execSpy = vi.spyOn(runtime.process, 'exec');
+    const readdirSpy = vi.spyOn(runtime.fs, 'readdir');
+    return {
+      context: { signal: new AbortController().signal, runtime } as ToolContext,
+      execSpy,
+      readdirSpy,
+    };
+  }
+
+  it('uses the output when find exits non-zero but still produced results', async () => {
+    const { context, execSpy, readdirSpy } = instrumented();
+    const record = `f\t1\t1700000000\t${join(testDir, 'reachable.ts')}\0`;
+    execSpy.mockResolvedValueOnce({ exitCode: 1, stdout: record, stderr: 'Permission denied' });
+
+    const result = await new FileFindTool().execute(
+      { pattern: '*.ts', path: testDir, maxDepth: 10 },
+      context
+    );
+
+    expect(result.status).toBe('completed');
+    expect(result.content[0].text).toContain('reachable.ts');
+    // The whole point: do NOT drop to the per-entry walk.
+    expect(readdirSpy).not.toHaveBeenCalled();
+  });
+
+  it('still falls back when find produced nothing usable', async () => {
+    const { context, execSpy, readdirSpy } = instrumented();
+    execSpy.mockResolvedValueOnce({ exitCode: 127, stdout: '', stderr: 'find: not found' });
+
+    const result = await new FileFindTool().execute(
+      { pattern: '*.ts', path: testDir, maxDepth: 10 },
+      context
+    );
+
+    expect(result.status).toBe('completed');
+    expect(result.content[0].text).toContain('reachable.ts');
+    expect(readdirSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/agent/src/tools/file-find.test.ts
+++ b/packages/agent/src/tools/file-find.test.ts
@@ -205,8 +205,11 @@ describe('FileFindTool with schema validation', () => {
       expect(result.content[0].text).not.toContain('/runtime/src/app.ts');
       expect(runtime.paths.resolve).toHaveBeenCalledTimes(1);
       expect(runtime.paths.resolve).toHaveBeenCalledWith('.');
-      expect(runtime.fs.stat).toHaveBeenCalledWith(expect.objectContaining(srcPath));
+      // Only the MATCHING entry is statted. `src` is a directory that does not
+      // match '*.ts', and statting it merely to learn it is a directory is the
+      // per-entry exec that PRI-2975 removed — readdir already said so.
       expect(runtime.fs.stat).toHaveBeenCalledWith(expect.objectContaining(appPath));
+      expect(runtime.fs.stat).not.toHaveBeenCalledWith(expect.objectContaining(srcPath));
     });
 
     it('should find files by exact name', async () => {
@@ -570,5 +573,138 @@ describe('FileFindTool with schema validation', () => {
 
       expect(result.status).toBe('aborted');
     });
+  });
+});
+
+// PRI-2975: file_find issued one container exec per entry, wedging ada-sen for
+// 96 minutes on a node_modules tree. Every runtime.fs call is a process spawn on
+// container runtimes (~160ms), so the walk's call COUNT is a correctness
+// property, not a performance nicety. These assert the call pattern against a
+// real filesystem.
+describe('FileFindTool call efficiency (PRI-2975)', () => {
+  const tempDir = createTestTempDir('file_find-efficiency-');
+  let tool: FileFindTool;
+  let testDir: string;
+  let rtId = 0;
+
+  beforeEach(async () => {
+    tool = new FileFindTool();
+    testDir = await tempDir.getPath();
+    // 3 directories x 20 files, exactly one of which matches the pattern.
+    for (const d of ['a', 'b', 'c']) {
+      await mkdir(join(testDir, d), { recursive: true });
+      for (let i = 0; i < 20; i++) {
+        await writeFile(join(testDir, d, `filler-${i}.txt`), 'x');
+      }
+    }
+    await writeFile(join(testDir, 'a', 'needle.special'), 'found me');
+  });
+
+  afterEach(async () => {
+    await tempDir.cleanup();
+  });
+
+  function instrumented() {
+    const runtime = new HostToolRuntime({ id: `rt_eff_${rtId++}`, cwd: testDir });
+    const statSpy = vi.spyOn(runtime.fs, 'stat');
+    const readdirSpy = vi.spyOn(runtime.fs, 'readdir');
+    const context: ToolContext = { signal: new AbortController().signal, runtime };
+    return { context, statSpy, readdirSpy };
+  }
+
+  it('does not stat entries whose name cannot match the pattern', async () => {
+    const { context, statSpy } = instrumented();
+
+    const result = await tool.execute(
+      { pattern: '*.special', path: testDir, maxDepth: 10 },
+      context
+    );
+    expect(result.status).not.toBe('failed');
+
+    // 61 files + 3 dirs exist; exactly 1 matches. Statting every entry is the
+    // bug. Allow generous headroom for the root and matched entries.
+    expect(statSpy.mock.calls.length).toBeLessThanOrEqual(10);
+  });
+
+  it('scales with directory count, not entry count', async () => {
+    const { context, statSpy, readdirSpy } = instrumented();
+
+    await tool.execute({ pattern: 'needle.special', path: testDir, maxDepth: 10 }, context);
+
+    // One readdir per directory (root + a + b + c) is inherent to a walk.
+    expect(readdirSpy.mock.calls.length).toBeLessThanOrEqual(5);
+    // stat must not track the 60 non-matching files.
+    expect(statSpy.mock.calls.length).toBeLessThan(20);
+  });
+
+  it('still reports size and mtime for entries that do match', async () => {
+    const { context } = instrumented();
+
+    const result = await tool.execute({ pattern: '*.special', path: testDir }, context);
+
+    expect(result.status).not.toBe('failed');
+    const text = result.content[0].text ?? '';
+    expect(text).toContain('needle.special');
+    // size/mtime come from stat; a match must still carry them.
+    expect(text).toMatch(/\b8\b|bytes|B\b/);
+  });
+});
+
+// PRI-2975 (B2): a walk must be bounded. Before this, file_find would keep
+// walking for as long as the tree took — 96 minutes on ada-sen — with the agent
+// loop blocked the whole time and no partial result.
+describe('FileFindTool search budget (PRI-2975)', () => {
+  // Assert an exact sentinel, not a loose regex: the temp directory name is
+  // interpolated into every result line, so /budget/i matched the PATH and gave
+  // a false pass before the feature existed.
+  const INCOMPLETE_MARKER = 'Search stopped early';
+
+  const tempDir = createTestTempDir('file_find-cap-');
+  let testDir: string;
+  let rtId = 0;
+
+  beforeEach(async () => {
+    testDir = await tempDir.getPath();
+    await mkdir(join(testDir, 'deep'), { recursive: true });
+    for (let i = 0; i < 30; i++) {
+      await writeFile(join(testDir, 'deep', `f-${i}.txt`), 'x');
+    }
+  });
+
+  afterEach(async () => {
+    await tempDir.cleanup();
+  });
+
+  function ctx() {
+    return {
+      signal: new AbortController().signal,
+      runtime: new HostToolRuntime({ id: `rt_cap_${rtId++}`, cwd: testDir }),
+    } as ToolContext;
+  }
+
+  it('stops and says so when the budget is exhausted, instead of running to completion', async () => {
+    class InstantBudgetFind extends FileFindTool {
+      protected override budgetMs(): number {
+        return 0;
+      }
+    }
+
+    const result = await new InstantBudgetFind().execute(
+      { pattern: '*.txt', path: testDir },
+      ctx()
+    );
+
+    // Bounded, not failed: the model gets a usable partial answer plus a clear
+    // signal that it is partial.
+    expect(result.status).toBe('completed');
+    expect(result.content[0].text).toContain(INCOMPLETE_MARKER);
+  });
+
+  it('completes normally and says nothing about budgets when it finishes in time', async () => {
+    const result = await new FileFindTool().execute({ pattern: '*.txt', path: testDir }, ctx());
+
+    expect(result.status).toBe('completed');
+    expect(result.content[0].text).not.toContain(INCOMPLETE_MARKER);
+    expect(result.content[0].text).toContain('f-0.txt');
   });
 });

--- a/packages/agent/src/tools/file-find.test.ts
+++ b/packages/agent/src/tools/file-find.test.ts
@@ -921,3 +921,68 @@ describe('FileFindTool tolerates find partial failure (PRI-2975)', () => {
     expect(readdirSpy).toHaveBeenCalled();
   });
 });
+
+// PRI-2975 review follow-up: fastFind has its own deadline handling, and it must
+// tell "our budget expired" apart from "the caller cancelled" — the subtlest
+// branch in the change. The walk's budget test does not reach it.
+describe('FileFindTool fast-path budget (PRI-2975)', () => {
+  const tempDir = createTestTempDir('file_find-fastcap-');
+  let testDir: string;
+  let rtId = 0;
+
+  beforeEach(async () => {
+    testDir = await tempDir.getPath();
+    await writeFile(join(testDir, 'a.ts'), 'x');
+  });
+
+  afterEach(async () => {
+    await tempDir.cleanup();
+  });
+
+  /** A find that never returns on its own; only an abort ends it. */
+  function hangingRuntime() {
+    const runtime = new HostToolRuntime({ id: `rt_fastcap_${rtId++}`, cwd: testDir });
+    vi.spyOn(runtime.process, 'exec').mockImplementation(
+      (_cmd: string[], opts?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          opts?.signal?.addEventListener('abort', () => reject(new Error('aborted')), {
+            once: true,
+          });
+        })
+    );
+    return runtime;
+  }
+
+  it('reports incomplete when its own budget expires, without falling back to the walk', async () => {
+    class TinyBudgetFind extends FileFindTool {
+      protected override budgetMs(): number {
+        return 25;
+      }
+    }
+    const runtime = hangingRuntime();
+    const readdirSpy = vi.spyOn(runtime.fs, 'readdir');
+
+    const result = await new TinyBudgetFind().execute({ pattern: '*.ts', path: testDir }, {
+      signal: new AbortController().signal,
+      runtime,
+    } as ToolContext);
+
+    expect(result.status).toBe('completed');
+    expect(result.content[0].text).toContain('Search stopped early');
+    // Timing out must not send us down the slower path we just removed.
+    expect(readdirSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports caller cancellation as cancelled, not as an exhausted budget', async () => {
+    const runtime = hangingRuntime();
+    const controller = new AbortController();
+    const pending = new FileFindTool().execute({ pattern: '*.ts', path: testDir }, {
+      signal: controller.signal,
+      runtime,
+    } as ToolContext);
+    setTimeout(() => controller.abort(), 25);
+
+    const result = await pending;
+    expect(result.content[0].text).not.toContain('Search stopped early');
+  });
+});

--- a/packages/agent/src/tools/implementations/file_find.ts
+++ b/packages/agent/src/tools/implementations/file_find.ts
@@ -291,6 +291,11 @@ export class FileFindTool extends Tool {
    * outlier, and on container runtimes each of those calls is a process spawn
    * (PRI-2975). Returns null when the fast path does not apply, and the caller
    * falls back to the walk.
+   *
+   * `-printf` is GNU-only, so on a BSD find (a macOS HostToolRuntime) the exec
+   * fails and the walk takes over. Accepted: the pathological cost this exists
+   * to remove is a container-runtime problem, and locally each fs call is a
+   * cheap syscall rather than a process spawn.
    */
   private async fastFind(
     runtime: ToolRuntime,

--- a/packages/agent/src/tools/implementations/file_find.ts
+++ b/packages/agent/src/tools/implementations/file_find.ts
@@ -6,6 +6,7 @@ import { join } from 'path';
 import { Tool } from '../tool';
 import { NonEmptyString, FilePath } from '../schemas/common';
 import type { ToolResult, ToolContext, ToolAnnotations } from '../types';
+import { FilesystemCallCeilingError } from '../runtime/types';
 import type { RuntimePath, ToolRuntime } from '../runtime/types';
 import { formatFileSize } from '@lace/agent/tools/utils/format-file-size';
 
@@ -261,12 +262,21 @@ export class FileFindTool extends Tool {
               return matches;
             }
           }
-        } catch {
-          // Skip items we can't stat (permission issues, broken symlinks, etc.)
+        } catch (error: unknown) {
+          // The call ceiling means the whole walk must stop; everything else
+          // (permissions, broken symlinks) is a per-entry problem to skip.
+          if (error instanceof FilesystemCallCeilingError) {
+            options.budget.exhausted = true;
+            return matches;
+          }
           continue;
         }
       }
-    } catch {
+    } catch (error: unknown) {
+      if (error instanceof FilesystemCallCeilingError) {
+        options.budget.exhausted = true;
+        return matches;
+      }
       // Skip directories we can't read
     }
 

--- a/packages/agent/src/tools/implementations/file_find.ts
+++ b/packages/agent/src/tools/implementations/file_find.ts
@@ -353,7 +353,15 @@ export class FileFindTool extends Tool {
         options.budget.exhausted = true;
         return [];
       }
-      return null;
+      // GNU find exits 1 when it cannot read ANY directory during the
+      // traversal, while still printing correct output for everything it could
+      // read — verified: one chmod-000 subdirectory gives exit 1 plus valid
+      // results. Treating that as "fast path unavailable" would throw away a
+      // good answer and drop to the per-entry walk, reintroducing the exact
+      // pathology this exists to remove, on any tree with a permission problem.
+      // The walk skips unreadable directories silently too, so using the
+      // partial output matches its semantics rather than changing them.
+      if (result.stdout.length === 0) return null;
     }
 
     const matches: FileMatch[] = [];

--- a/packages/agent/src/tools/implementations/file_find.ts
+++ b/packages/agent/src/tools/implementations/file_find.ts
@@ -21,6 +21,18 @@ const MAX_RESULTS = 1000;
 // have. Wall-clock rather than an operation count, because the per-operation
 // cost differs by four orders of magnitude between host and container runtimes.
 const SEARCH_BUDGET_MS = 30_000;
+
+/**
+ * Patterns where our matcher and `find -iname` provably agree, so the traversal
+ * can be pushed into a single `find`.
+ *
+ * matchesPattern ESCAPES `[`, `]` and `\\` and gives meaning only to `*` and
+ * `?`; `find -iname` treats brackets as a character class and backslash as an
+ * escape. For `a\\*b` that makes -iname strictly NARROWER, which would silently
+ * drop matches. Restricting the fast path to characters both engines read the
+ * same way keeps it exact; anything else falls back to the walk.
+ */
+const FIND_SAFE_PATTERN = /^[A-Za-z0-9._\-*?]+$/;
 const DEFAULT_RESULTS = 50;
 
 type FileMatch = {
@@ -92,19 +104,28 @@ export class FileFindTool extends Tool {
 
       const budget = { deadline: Date.now() + this.budgetMs(), exhausted: false };
 
-      const matches = await this.findFiles(
+      const fast = await this.fastFind(
         context.runtime,
         rootPath,
-        {
-          pattern,
-          maxDepth,
-          includeHidden,
-          maxResults,
-          currentDepth: 0,
-          budget,
-        },
+        { pattern, maxDepth, includeHidden, budget },
         context.signal
       );
+
+      const matches =
+        fast ??
+        (await this.findFiles(
+          context.runtime,
+          rootPath,
+          {
+            pattern,
+            maxDepth,
+            includeHidden,
+            maxResults,
+            currentDepth: 0,
+            budget,
+          },
+          context.signal
+        ));
 
       // Sort by modification time (newest first)
       matches.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
@@ -249,6 +270,112 @@ export class FileFindTool extends Tool {
       // Skip directories we can't read
     }
 
+    return matches;
+  }
+
+  /**
+   * Whole-tree search in ONE exec.
+   *
+   * ripgrep_search already delegates traversal to a single in-container
+   * process; file_find walking directory-by-directory over runtime.fs was the
+   * outlier, and on container runtimes each of those calls is a process spawn
+   * (PRI-2975). Returns null when the fast path does not apply, and the caller
+   * falls back to the walk.
+   */
+  private async fastFind(
+    runtime: ToolRuntime,
+    rootPath: RuntimePath,
+    options: {
+      pattern: string;
+      maxDepth: number;
+      includeHidden: boolean;
+      budget: { deadline: number; exhausted: boolean };
+    },
+    signal?: AbortSignal
+  ): Promise<FileMatch[] | null> {
+    if (!FIND_SAFE_PATTERN.test(options.pattern)) return null;
+    // Out of budget before we start: let the walk report the exhaustion.
+    if (Date.now() >= options.budget.deadline) return null;
+
+    const root = rootPath.runtimePath;
+
+    // find itself can run long on a huge tree, so it gets the same ceiling as
+    // the walk. Abort is distinguished from failure below: a timeout means
+    // "incomplete", not "fall back to something slower".
+    const deadlineController = new AbortController();
+    const remaining = options.budget.deadline - Date.now();
+    const timer = setTimeout(() => deadlineController.abort(), remaining);
+    const onOuterAbort = () => deadlineController.abort();
+    signal?.addEventListener('abort', onOuterAbort, { once: true });
+
+    let result: { exitCode: number; stdout: string };
+    try {
+      result = await runtime.process.exec(
+        [
+          'find',
+          root,
+          '-mindepth',
+          '1',
+          // maxDepth counts recursion steps, not path depth: the walk's
+          // maxDepth 1 still lists entries one directory down.
+          '-maxdepth',
+          String(options.maxDepth + 1),
+          '-iname',
+          options.pattern,
+          '-printf',
+          '%y\\t%s\\t%T@\\t%p\\0',
+        ],
+        { cwd: runtime.cwd, signal: deadlineController.signal }
+      );
+    } catch {
+      // Our own deadline fired: report incomplete rather than retrying slower.
+      if (deadlineController.signal.aborted && !signal?.aborted) {
+        options.budget.exhausted = true;
+        return [];
+      }
+      return null;
+    } finally {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onOuterAbort);
+    }
+    if (result.exitCode !== 0) {
+      if (deadlineController.signal.aborted && !signal?.aborted) {
+        options.budget.exhausted = true;
+        return [];
+      }
+      return null;
+    }
+
+    const matches: FileMatch[] = [];
+    for (const record of result.stdout.split('\0')) {
+      if (!record) continue;
+      const parts = record.split('\t');
+      if (parts.length < 4) continue;
+      const [type, size, mtime] = parts;
+      // %p may itself contain tabs; rejoin everything after the third field.
+      const absolute = parts.slice(3).join('\t');
+
+      const relative = absolute.startsWith(root) ? absolute.slice(root.length) : absolute;
+      const segments = relative.split('/').filter((seg) => seg.length > 0);
+      if (segments.length === 0) continue;
+
+      // The walk skips hidden entries and never descends into them, so a hidden
+      // component anywhere in the relative path excludes the entry.
+      if (!options.includeHidden && segments.some((seg) => seg.startsWith('.'))) continue;
+
+      const name = segments[segments.length - 1] ?? '';
+      // -iname is only a prefilter; our matcher stays authoritative.
+      if (!this.matchesPattern(name, options.pattern)) continue;
+
+      matches.push({
+        path: segments.reduce<RuntimePath>((acc, seg) => this.childPath(acc, seg), rootPath),
+        size: Number(size),
+        mtime: new Date(Number(mtime) * 1000),
+        // %y reports the link itself; a symlink counts as a file, matching the
+        // walk's behaviour since PRI-2975.
+        isDirectory: type === 'd',
+      });
+    }
     return matches;
   }
 

--- a/packages/agent/src/tools/implementations/file_find.ts
+++ b/packages/agent/src/tools/implementations/file_find.ts
@@ -15,6 +15,12 @@ const DEFAULT_DEPTH = 10;
 
 const MIN_RESULTS = 1;
 const MAX_RESULTS = 1000;
+// PRI-2975: every runtime.fs call is a process spawn on container runtimes, so a
+// large tree can take tens of minutes. The agent loop awaits tool results, so an
+// unbounded walk takes the whole session offline. Bound it and return what we
+// have. Wall-clock rather than an operation count, because the per-operation
+// cost differs by four orders of magnitude between host and container runtimes.
+const SEARCH_BUDGET_MS = 30_000;
 const DEFAULT_RESULTS = 50;
 
 type FileMatch = {
@@ -84,6 +90,8 @@ export class FileFindTool extends Tool {
         throw error;
       }
 
+      const budget = { deadline: Date.now() + this.budgetMs(), exhausted: false };
+
       const matches = await this.findFiles(
         context.runtime,
         rootPath,
@@ -93,6 +101,7 @@ export class FileFindTool extends Tool {
           includeHidden,
           maxResults,
           currentDepth: 0,
+          budget,
         },
         context.signal
       );
@@ -116,6 +125,14 @@ export class FileFindTool extends Tool {
         resultLines.push(`No files found matching pattern: ${pattern}`);
       }
 
+      // Say so loudly: a partial result presented as complete is worse than a
+      // slow one, because the model will conclude the file does not exist.
+      if (budget.exhausted) {
+        resultLines.push(
+          `\nSearch stopped early after ${Math.round(this.budgetMs() / 1000)}s; these results are incomplete. Narrow the search with a more specific path or pattern, or raise maxDepth only where needed.`
+        );
+      }
+
       return this.createResult(resultLines.join('\n'));
     } catch (error: unknown) {
       // Handle cancellation
@@ -126,12 +143,18 @@ export class FileFindTool extends Tool {
     }
   }
 
+  /** Wall-clock ceiling for one search. Overridable so tests can force the cap. */
+  protected budgetMs(): number {
+    return SEARCH_BUDGET_MS;
+  }
+
   private async findFiles(
     runtime: ToolRuntime,
     dirPath: RuntimePath,
     options: {
       pattern: string;
       maxDepth: number;
+      budget: { deadline: number; exhausted: boolean };
       includeHidden: boolean;
       maxResults: number;
       currentDepth: number;
@@ -149,6 +172,11 @@ export class FileFindTool extends Tool {
       return matches;
     }
 
+    if (Date.now() >= options.budget.deadline) {
+      options.budget.exhausted = true;
+      return matches;
+    }
+
     try {
       const items = await runtime.fs.readdir(dirPath);
 
@@ -157,6 +185,10 @@ export class FileFindTool extends Tool {
         if (signal?.aborted) {
           throw new Error('Aborted');
         }
+        if (Date.now() >= options.budget.deadline) {
+          options.budget.exhausted = true;
+          return matches;
+        }
         if (!options.includeHidden && item.name.startsWith('.')) {
           continue;
         }
@@ -164,11 +196,19 @@ export class FileFindTool extends Tool {
         const childPath = this.childPath(dirPath, item.name);
 
         try {
-          const stats = await runtime.fs.stat(childPath);
-          const isDirectory = stats.type === 'directory';
+          // readdir already reported the type. Re-deriving it with stat costs a
+          // whole container exec per entry on container-backed runtimes, which
+          // is what wedged ada-sen for 96 minutes on a node_modules tree
+          // (PRI-2975). Note this reports a symlink as a file rather than
+          // following it: deliberate, since the walk keeps no visited-set and
+          // following directory symlinks can cycle.
+          const isDirectory = item.type === 'directory';
 
           // Case-insensitive pattern matching
           if (this.matchesPattern(item.name, options.pattern)) {
+            // stat only for entries we actually return — size and mtime are
+            // reported in the results and are needed nowhere else.
+            const stats = await runtime.fs.stat(childPath);
             matches.push({
               path: childPath,
               size: stats.size,

--- a/packages/agent/src/tools/runtime/__tests__/container-exec-fs-call-ceiling.test.ts
+++ b/packages/agent/src/tools/runtime/__tests__/container-exec-fs-call-ceiling.test.ts
@@ -1,0 +1,72 @@
+// ABOUTME: A per-tool-call ceiling on high-latency filesystem calls (PRI-2975).
+// ABOUTME: Documentation and a doctor check catch a per-entry loop only after it
+// ABOUTME: has already wedged a coworker. This makes the abstraction refuse.
+
+import { describe, it, expect, vi } from 'vitest';
+import { ContainerExecFileSystem, FS_CALLS_PER_TOOL_CALL_CEILING } from '../container-exec-fs';
+import type { RuntimePath, RuntimeProcessRunner } from '../types';
+
+function path(p: string): RuntimePath {
+  return { original: p, runtimePath: p, displayPath: p };
+}
+
+function stubRunner(): RuntimeProcessRunner {
+  return {
+    exec: vi.fn().mockResolvedValue({
+      exitCode: 0,
+      stdout: '12|regular file|1700000000',
+      stderr: '',
+    }),
+    start: vi.fn(),
+  } as unknown as RuntimeProcessRunner;
+}
+
+describe('ContainerExecFileSystem per-tool-call ceiling (PRI-2975)', () => {
+  it('allows ordinary usage well below the ceiling', async () => {
+    const fs = new ContainerExecFileSystem(stubRunner());
+    for (let i = 0; i < 50; i++) {
+      await fs.stat(path(`/w/f${i}`));
+    }
+    await expect(fs.stat(path('/w/again'))).resolves.toBeDefined();
+  });
+
+  it('refuses once one tool call crosses the ceiling', async () => {
+    const fs = new ContainerExecFileSystem(stubRunner());
+    for (let i = 0; i < FS_CALLS_PER_TOOL_CALL_CEILING; i++) {
+      await fs.stat(path(`/w/f${i}`));
+    }
+
+    await expect(fs.stat(path('/w/one-too-many'))).rejects.toThrow(
+      /filesystem calls in a single tool call/i
+    );
+  });
+
+  it('names the remedy rather than just failing', async () => {
+    const fs = new ContainerExecFileSystem(stubRunner());
+    for (let i = 0; i < FS_CALLS_PER_TOOL_CALL_CEILING; i++) {
+      await fs.stat(path(`/w/f${i}`));
+    }
+
+    await expect(fs.stat(path('/w/boom'))).rejects.toThrow(/runtime\.process\.exec/);
+  });
+
+  it('resets per tool call, so a long session is not penalised', async () => {
+    const fs = new ContainerExecFileSystem(stubRunner());
+    for (let i = 0; i < FS_CALLS_PER_TOOL_CALL_CEILING; i++) {
+      await fs.stat(path(`/w/f${i}`));
+    }
+
+    fs.beginToolCall();
+
+    await expect(fs.stat(path('/w/fresh'))).resolves.toBeDefined();
+  });
+
+  it('counts every method, not just stat', async () => {
+    const fs = new ContainerExecFileSystem(stubRunner());
+    for (let i = 0; i < FS_CALLS_PER_TOOL_CALL_CEILING; i++) {
+      await fs.readdir(path(`/w/d${i}`));
+    }
+
+    await expect(fs.readdir(path('/w/more'))).rejects.toThrow(/single tool call/i);
+  });
+});

--- a/packages/agent/src/tools/runtime/container-exec-fs.ts
+++ b/packages/agent/src/tools/runtime/container-exec-fs.ts
@@ -1,15 +1,58 @@
 // ABOUTME: RuntimeFileSystem implemented by shelling stock binaries through a brokered process runner.
 // ABOUTME: Byte-bearing payloads are base64-wrapped so the runner's utf8 stdout/stdin transport is lossless.
 
+import { FilesystemCallCeilingError } from './types';
 import type { RuntimeFileSystem, RuntimePath, RuntimeProcessRunner } from './types';
 import { nodeErrorFromExec, streamToString, writeStreamAndClose } from './container-exec-shared';
 
+/**
+ * Most filesystem calls one tool call may make against a container runtime.
+ *
+ * Every method here is a process spawn across a container boundary (~160ms), so
+ * a per-entry loop is not slow, it is a hang: file_find's walk made 20,821 of
+ * them in one call and ada-sen was silent for 96 minutes (PRI-2975). Nothing in
+ * the node-`fs` shape of this interface hints at that, and a comment saying so
+ * is only advice.
+ *
+ * 500 is far above any legitimate use — the repaired file_find makes at most a
+ * few dozen, file_read and file_write make one or two — and far below the
+ * pathological case. Crossing it means the caller is looping where it should
+ * push the work into a single `runtime.process.exec`, so it fails immediately
+ * and says so, instead of running for an hour and taking the coworker with it.
+ */
+export const FS_CALLS_PER_TOOL_CALL_CEILING = 500;
+
 export class ContainerExecFileSystem implements RuntimeFileSystem {
+  private callsThisToolCall = 0;
+
   constructor(private readonly process: RuntimeProcessRunner) {}
+
+  /** Reset the per-tool-call budget. Called by the executor before each tool. */
+  beginToolCall(): void {
+    this.callsThisToolCall = 0;
+  }
+
+  /**
+   * Account for one container round-trip, refusing past the ceiling.
+   *
+   * Throws rather than warns: a warning here would be written to a log nobody
+   * reads while the coworker goes quiet, which is exactly what happened.
+   */
+  private charge(op: string, target: string): void {
+    this.callsThisToolCall += 1;
+    if (this.callsThisToolCall > FS_CALLS_PER_TOOL_CALL_CEILING) {
+      throw new FilesystemCallCeilingError(
+        `Refusing ${op}(${target}): over ${FS_CALLS_PER_TOOL_CALL_CEILING} filesystem calls in a single tool call. ` +
+          `Each one is a process spawn into the container, so this pattern hangs the agent loop rather than merely running slowly. ` +
+          `Do the traversal in one runtime.process.exec instead (see file_find's fast path or ripgrep_search). See PRI-2975.`
+      );
+    }
+  }
 
   async stat(
     path: RuntimePath
   ): Promise<{ type: 'file' | 'directory'; size: number; mtime: Date }> {
+    this.charge('stat', path.runtimePath);
     const p = path.runtimePath;
     const result = await this.process.exec(['stat', '-c', '%s|%F|%Y', p]);
     if (result.exitCode !== 0) {
@@ -24,6 +67,7 @@ export class ContainerExecFileSystem implements RuntimeFileSystem {
   }
 
   async readTextFile(path: RuntimePath): Promise<string> {
+    this.charge('readTextFile', path.runtimePath);
     const p = path.runtimePath;
     const result = await this.process.exec(['base64', p]);
     if (result.exitCode !== 0) {
@@ -33,6 +77,7 @@ export class ContainerExecFileSystem implements RuntimeFileSystem {
   }
 
   async writeTextFile(path: RuntimePath, content: string): Promise<void> {
+    this.charge('writeTextFile', path.runtimePath);
     const p = path.runtimePath;
     const handle = await this.process.start(['sh', '-c', 'base64 -d > "$0"', p]);
     if (!handle.stdin) {
@@ -48,6 +93,7 @@ export class ContainerExecFileSystem implements RuntimeFileSystem {
   }
 
   async mkdir(path: RuntimePath, opts?: { recursive?: boolean }): Promise<void> {
+    this.charge('mkdir', path.runtimePath);
     const p = path.runtimePath;
     const result = await this.process.exec(['mkdir', ...(opts?.recursive ? ['-p'] : []), p]);
     if (result.exitCode !== 0) {
@@ -56,6 +102,7 @@ export class ContainerExecFileSystem implements RuntimeFileSystem {
   }
 
   async readdir(path: RuntimePath): Promise<Array<{ name: string; type: 'file' | 'directory' }>> {
+    this.charge('readdir', path.runtimePath);
     const p = path.runtimePath;
     const result = await this.process.exec([
       'find',

--- a/packages/agent/src/tools/runtime/types.ts
+++ b/packages/agent/src/tools/runtime/types.ts
@@ -99,6 +99,18 @@ export interface RuntimePathService {
 }
 
 /**
+ * Thrown when one tool call makes more high-latency filesystem calls than the
+ * runtime permits (PRI-2975).
+ *
+ * Distinguishable on purpose: callers that walk trees swallow ordinary per-entry
+ * errors (unreadable directories, broken symlinks) and must NOT swallow this
+ * one, or a truncated result gets reported as a complete one.
+ */
+export class FilesystemCallCeilingError extends Error {
+  readonly name = 'FilesystemCallCeilingError';
+}
+
+/**
  * Filesystem access for the runtime a tool is executing against.
  *
  * COST WARNING: these are node-`fs`-shaped, but they are NOT node `fs`. On a
@@ -118,6 +130,12 @@ export interface RuntimePathService {
  * than looping here.
  */
 export interface RuntimeFileSystem {
+  /**
+   * Reset the per-tool-call call budget, where the implementation enforces one.
+   * The executor calls this before each tool so a long session is not penalised
+   * for the sum of many well-behaved calls.
+   */
+  beginToolCall?(): void;
   stat(path: RuntimePath): Promise<{ type: 'file' | 'directory'; size: number; mtime: Date }>;
   readTextFile(path: RuntimePath): Promise<string>;
   writeTextFile(path: RuntimePath, content: string): Promise<void>;

--- a/packages/agent/src/tools/runtime/types.ts
+++ b/packages/agent/src/tools/runtime/types.ts
@@ -98,6 +98,25 @@ export interface RuntimePathService {
   canonicalKey(path: RuntimePath): string;
 }
 
+/**
+ * Filesystem access for the runtime a tool is executing against.
+ *
+ * COST WARNING: these are node-`fs`-shaped, but they are NOT node `fs`. On a
+ * container-backed runtime every method here is a separate process spawn across
+ * a container boundary — roughly 160ms each, four orders of magnitude more than
+ * a local syscall. The shape invites per-entry loops that are perfectly
+ * reasonable against a local disk and pathological here.
+ *
+ * PRI-2975: file_find called `stat` once per entry while walking. On one
+ * node_modules tree that was 20,821 spawns and 96 minutes, during which the
+ * agent loop — which awaits tool results — was blocked and the coworker was
+ * silent.
+ *
+ * So: treat the call COUNT as a correctness property, not a performance detail.
+ * If you need to traverse or inspect many paths, push the work into a single
+ * `runtime.process.exec` (see file_find's fast path, or ripgrep_search) rather
+ * than looping here.
+ */
 export interface RuntimeFileSystem {
   stat(path: RuntimePath): Promise<{ type: 'file' | 'directory'; size: number; mtime: Date }>;
   readTextFile(path: RuntimePath): Promise<string>;


### PR DESCRIPTION
ada-sen was unresponsive for 96 minutes (00:21:17 → 01:57:31 UTC, 2026-08-26) inside a single `file_find` call. She recovered on her own — this is a finite walk with a brutal constant, not an infinite loop. Docker reported `Up 22 hours (healthy)` and `doctor` passed throughout.

## Root cause

`file_find` called `runtime.fs.stat()` on **every entry** it walked. On container runtimes each fs call is a process spawn (~160ms), so one `node_modules` subtree cost 1,969 `readdir` + 18,852 `stat` = **20,821 execs**.

`stat` was doing two jobs: re-deriving the entry type that `readdir` had already returned, and fetching size/mtime — which are only reported for entries matching the pattern (~50 against 18,852).

Underneath that: `container-exec-fs` presents a node-`fs`-shaped API. A per-entry `stat` is textbook against a local disk where it costs microseconds. The shape hides that each call is now a cross-container spawn.

**A local-filesystem-shaped abstraction over a high-latency transport, consumed by code written as though calls were free.**

## What changed

| Commit | |
|---|---|
| `5c89e19` | type comes from `readdir`; `stat` only on a match; 30s wall-clock budget |
| `0dbdb36` | whole traversal in **one** `find` exec, mirroring `ripgrep_search` |
| `60600c1` | executor names a tool still running; `RuntimeFileSystem` documents its real cost |
| `89aa85a` | **the guard**: 500 fs calls per tool call, then refuse |

Measured against lace's own `node_modules` after the fix:

```
process.exec=1  fs.readdir=0  fs.stat=1  wall=169ms  complete results
```

## Notes for review

- **The ceiling throws rather than warns.** A warning lands in a log nobody reads while the coworker goes quiet — precisely what happened. It's a distinct error type because tree-walking callers swallow ordinary per-entry failures (permissions, broken symlinks) and must not swallow this one; `file_find` now reports the search as **incomplete** rather than presenting a truncated result as complete.
- **The fast path is gated on the pattern.** `find -iname` is not equivalent to our `matchesPattern`: ours escapes `[`, `]` and backslash, `-iname` treats them as syntax, making it strictly *narrower* for `a\*b` and silently dropping matches. Only patterns both engines read identically take the fast path.
- **`find -maxdepth` is `maxDepth + 1`.** The walk's `maxDepth` counts recursion steps, so `maxDepth: 1` already lists entries one directory down. Pinned by a test.
- **Deliberate semantic change:** taking type from `readdir` means a symlink reports as a file rather than being followed. The walk keeps no visited-set, so following directory symlinks can cycle. In ada's tree: 26 symlinks, 0 pointing at directories.
- The display-path test now stubs `exec` as unavailable so it still exercises the walk it was written for. The fake runtime returns `exitCode: 0, stdout: ''` for *any* command, which now reads as "find ran and matched nothing" — a trap worth revisiting separately.

## Testing

`packages/agent/src/tools/` — **782 passing**. Efficiency tests assert the call pattern against a real filesystem, not a mock.

The full agent suite shows 38 failures across e2e/integration files; **all pass in isolation** (docker container-name conflicts under parallel runs, same known class as sen-core's `main-boot` flake). Verified individually, not assumed.

PRI-2975