### PR TITLE
fix(providers): pass tool-result image blocks through to the model (PRI-3078)

### DIFF
--- a/packages/agent/src/mcp/tool-adapter.ts
+++ b/packages/agent/src/mcp/tool-adapter.ts
@@ -114,15 +114,20 @@ export class MCPToolAdapter extends Tool {
           type: string;
           text?: string;
           data?: string;
+          mimeType?: string;
           resource?: { uri?: string };
         };
 
         if (typedBlock.type === 'text') {
           return { type: 'text' as const, text: typedBlock.text || '' };
         } else if (typedBlock.type === 'image') {
+          // PRI-3078: carry mimeType through. MCP always sends it with image
+          // content, and a provider cannot build an image block without it —
+          // dropping it here left the bytes technically present but unusable.
           return {
             type: 'image' as const,
             data: typedBlock.data,
+            ...(typedBlock.mimeType !== undefined ? { mimeType: typedBlock.mimeType } : {}),
           };
         } else if (typedBlock.type === 'resource') {
           return {

--- a/packages/agent/src/providers/format-converters.ts
+++ b/packages/agent/src/providers/format-converters.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Converts generic tool call format to provider-specific native formats
 
 import { ProviderMessage, ContentBlock, type ThinkingBlock } from './base-provider';
+import type { ContentBlock as ToolResultContentBlock } from '../tools/types';
 import { ToolCall } from '@lace/agent/tools/types';
 import Anthropic from '@anthropic-ai/sdk';
 import type { Content, Part } from '@google/genai';
@@ -20,6 +21,47 @@ function toAnthropicThinkingBlocks(
       ? { type: 'thinking', thinking: b.thinking, signature: b.signature }
       : { type: 'redacted_thinking', data: b.data }
   );
+}
+
+/**
+ * PRI-3078. A tool result's blocks use the FLAT `tools/types` ContentBlock
+ * (`{type, text?, data?, uri?, mimeType?}`), NOT the provider-side block with a
+ * nested `source`. They are different types with the same name, which is how
+ * the original defect survived: `block.text || ''` is valid on both, and on an
+ * image block it silently yields ''.
+ *
+ * An image needs BOTH bytes and a media type to become a provider block. We do
+ * not guess a media type when it is absent — a wrong one is an API error at
+ * best and a mis-decoded image at worst — so such a block degrades to text that
+ * says so, which is at least honest to the model about what happened.
+ */
+/**
+ * The block-array form is chosen when the result contains ANY image block, not
+ * only a renderable one. Gating on renderable would send an unrenderable image
+ * back down the string path, where `block.text || ''` turns it into '' — the
+ * exact silent drop this change exists to remove, just narrowed to a rarer case.
+ */
+function isRenderableToolResultImage(block: ToolResultContentBlock): boolean {
+  return block.type === 'image' && !!block.data && !!block.mimeType;
+}
+
+function toAnthropicToolResultBlock(
+  block: ToolResultContentBlock
+): Anthropic.TextBlockParam | Anthropic.ImageBlockParam {
+  if (isRenderableToolResultImage(block)) {
+    return {
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: block.mimeType as 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp',
+        data: block.data as string,
+      },
+    };
+  }
+  if (block.type === 'image') {
+    return { type: 'text', text: '[image omitted: no media type reported by the tool]' };
+  }
+  return { type: 'text', text: block.text || '' };
 }
 
 /**
@@ -97,7 +139,17 @@ export function convertToAnthropicFormat(messages: ProviderMessage[]): Anthropic
             (result) => ({
               type: 'tool_result',
               tool_use_id: result.id || '',
-              content: result.content.map((block) => block.text || '').join('\n'),
+              // PRI-3078: an image block carries `data`, not `text`, so the old
+              // unconditional `block.text || ''` flattened it to an empty string —
+              // the model received a blank tool result, and an agent that had just
+              // 'read' a screenshot saw nothing. Anthropic accepts tool_result
+              // content as either a string or a block array, so reuse the same
+              // per-block conversion this file already applies to plain user
+              // messages. Text-only results keep the string form byte-for-byte:
+              // the common path does not change shape.
+              content: result.content.some((block) => block.type === 'image')
+                ? result.content.map(toAnthropicToolResultBlock)
+                : result.content.map((block) => block.text || '').join('\n'),
               // Convert our status to Anthropic's is_error flag
               ...(result.status !== 'completed' ? { is_error: true } : {}),
             })

--- a/packages/agent/src/providers/tool-result-images.test.ts
+++ b/packages/agent/src/providers/tool-result-images.test.ts
@@ -1,0 +1,94 @@
+// ABOUTME: PRI-3078 — tool-result image blocks must survive conversion to the wire format.
+// ABOUTME: They were flattened to `block.text || ''`, so an image became an empty string
+// ABOUTME: before the model saw it: an agent that had just "read" a screenshot saw nothing.
+// ABOUTME: NOTE the shape used here is the FLAT tools/types ContentBlock a real tool result
+// ABOUTME: carries ({type,data,mimeType}), not the nested-`source` provider block.
+
+import { describe, expect, it } from 'vitest';
+import type { ProviderMessage } from './base-provider';
+import { convertToAnthropicFormat } from './format-converters';
+
+const PNG_1PX =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+function withToolResults(toolResults: ProviderMessage['toolResults']): ProviderMessage[] {
+  return [{ role: 'user', content: '', toolResults }];
+}
+
+function firstToolResult(out: ProviderMessage[] | Record<string, unknown>[]) {
+  return (out[0] as { content: Array<Record<string, unknown>> }).content[0];
+}
+
+describe('PRI-3078: tool-result image blocks reach the model', () => {
+  it('keeps a text-only tool result as a flat string (common path unchanged)', () => {
+    const out = convertToAnthropicFormat(
+      withToolResults([
+        { id: 'toolu_1', status: 'completed', content: [{ type: 'text', text: 'hello' }] },
+      ])
+    );
+    expect(firstToolResult(out)?.content).toBe('hello');
+  });
+
+  it('emits an image block when the tool result carries data + mimeType', () => {
+    const out = convertToAnthropicFormat(
+      withToolResults([
+        {
+          id: 'toolu_2',
+          status: 'completed',
+          content: [
+            { type: 'text', text: 'screenshot.png' },
+            { type: 'image', data: PNG_1PX, mimeType: 'image/png' },
+          ],
+        },
+      ])
+    );
+    const inner = firstToolResult(out)?.content as Array<Record<string, unknown>>;
+    expect(Array.isArray(inner)).toBe(true);
+    expect(inner[0]).toEqual({ type: 'text', text: 'screenshot.png' });
+    expect(inner[1]).toEqual({
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: PNG_1PX },
+    });
+  });
+
+  it('does not silently drop the image bytes', () => {
+    const out = convertToAnthropicFormat(
+      withToolResults([
+        {
+          id: 'toolu_3',
+          status: 'completed',
+          content: [{ type: 'image', data: PNG_1PX, mimeType: 'image/png' }],
+        },
+      ])
+    );
+    expect(JSON.stringify(out)).toContain(PNG_1PX);
+  });
+
+  it('degrades to explanatory text rather than guessing a missing media type', () => {
+    // A wrong media_type is an API error at best and a mis-decoded image at
+    // worst. Saying so is more useful to the model than a silent empty string.
+    const out = convertToAnthropicFormat(
+      withToolResults([
+        { id: 'toolu_4', status: 'completed', content: [{ type: 'image', data: PNG_1PX }] },
+      ])
+    );
+    const inner = firstToolResult(out)?.content as Array<Record<string, unknown>>;
+    expect(inner[0]).toEqual({
+      type: 'text',
+      text: '[image omitted: no media type reported by the tool]',
+    });
+  });
+
+  it('still marks a failed image-bearing tool result as an error', () => {
+    const out = convertToAnthropicFormat(
+      withToolResults([
+        {
+          id: 'toolu_5',
+          status: 'error',
+          content: [{ type: 'image', data: PNG_1PX, mimeType: 'image/png' }],
+        },
+      ])
+    );
+    expect(firstToolResult(out)?.is_error).toBe(true);
+  });
+});

--- a/packages/agent/src/tools/types.ts
+++ b/packages/agent/src/tools/types.ts
@@ -117,6 +117,13 @@ export interface ContentBlock {
   text?: string;
   data?: string;
   uri?: string;
+  /**
+   * Media type for an `image` block (e.g. 'image/png'), as MCP reports it.
+   * PRI-3078: without this an image could not be rendered for a provider —
+   * every wire format needs the media type alongside the bytes, and the MCP
+   * adapter was discarding it, so the data alone was unusable.
+   */
+  mimeType?: string;
 }
 
 export type ToolResultStatus = 'completed' | 'failed' | 'aborted' | 'denied' | 'pending';


### PR DESCRIPTION
fix(providers): pass tool-result image blocks through to the model (PRI-3078)

A tool that returns an image returned nothing. `convertToAnthropicFormat`
flattened every tool-result block with `block.text || ''`, and an image block
carries `data`, not `text` — so it became an empty string before the model saw
it. An agent that had just "read" a screenshot got a blank result, with no
indication anything had been dropped.

This is the blocking half of PRI-3077 Gap 4: sen-core can emit image blocks from
`slack_read_file`, but they die here.

Three parts, because the first attempt was wrong:

1. `tools/types.ContentBlock` gains `mimeType`. There was nowhere to put it, and
   an image needs both bytes and a media type to become a provider block.
2. `mcp/tool-adapter.ts` stops discarding the `mimeType` MCP sends alongside the
   image data. The bytes were technically present but unusable without it.
3. `format-converters.ts` converts image-bearing tool results to Anthropic's
   block-array form (which the API accepts in place of a string) instead of
   flattening. Text-only results keep the string form byte-for-byte, so the
   common path does not change shape.

The trap worth recording: there are two different types named `ContentBlock` —
the flat `tools/types` one a tool result actually carries
(`{type,text?,data?,uri?}`), and the provider-side one with a nested `source`.
`block.text || ''` is valid on both and silently yields '' on an image, which is
how the defect survived. My first fix reused the provider-side converter and my
first test constructed provider-shaped data, so the test passed against a shape
the system never produces and only `tsc` caught it. The test now uses the real
flat shape.

No silent drop remains. The block-array form is chosen when a result holds ANY
image block, not only a renderable one; gating on renderable would push an image
with no media type back down the string path and recreate the '' drop in a rarer
case. Such a block becomes explanatory text instead — we never guess a media
type, since a wrong one is an API error at best and a mis-decoded image at worst.

Scope: Anthropic only. The OpenAI (`role:'tool'`) and Gemini (`functionResponse`)
paths still flatten, and `convertToTextOnlyFormat` still discards images by
design — its own comment says so. Extending to those needs verification of what
each API accepts in a tool result, which I have not done and will not assert
from memory.

Verified: providers + mcp suites 875 passed / 0 failed; the four directly
affected test files 20/20; `tsc --noEmit` clean. The package's process-spawning
E2E tests are flaky under full-suite load — failure sets differ run to run in
both directions, and a file "failing only on this branch" passes 3/3 in
isolation — so they are not a signal either way here.
