### PR TITLE
test(agent): budget the E2E initialize timeout for agent cold boot

### DIFF
--- a/packages/agent/src/__tests__/agent-process.abort.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.abort.e2e.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -34,7 +35,7 @@ describe('agent abort reliability (E2E)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -107,7 +108,7 @@ describe('agent abort reliability (E2E)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'ask' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -190,7 +191,7 @@ describe('agent abort reliability (E2E)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'ask' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -253,7 +254,7 @@ describe('agent abort reliability (E2E)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -318,7 +319,7 @@ describe('agent abort reliability (E2E)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -359,7 +360,7 @@ describe('agent abort reliability (E2E)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize (restart)'
     );
 

--- a/packages/agent/src/__tests__/agent-process.async-workflow.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.async-workflow.e2e.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { join } from 'node:path';
 import { readDurableEvents } from '../storage/event-log';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -35,7 +36,7 @@ describe('async job workflow (E2E)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'allow' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -112,7 +113,7 @@ describe('async job workflow (E2E)', () => {
           'initialize',
           defaultInitializeParams({ config: { approvalMode: 'allow' } })
         ),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
 
@@ -204,7 +205,7 @@ describe('async job workflow (E2E)', () => {
           'initialize',
           defaultInitializeParams({ config: { approvalMode: 'allow' } })
         ),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
 
@@ -316,7 +317,7 @@ describe('async job workflow (E2E)', () => {
           'initialize',
           defaultInitializeParams({ config: { approvalMode: 'allow' } })
         ),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
 
@@ -387,7 +388,7 @@ describe('async job workflow (E2E)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'allow' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -442,7 +443,7 @@ describe('async job workflow (E2E)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize (restart)'
     );
 
@@ -498,7 +499,7 @@ describe('async job workflow (E2E)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'allow' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -581,7 +582,7 @@ describe('async job workflow (E2E)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'allow' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -670,7 +671,7 @@ describe('async job workflow (E2E)', () => {
           'initialize',
           defaultInitializeParams({ config: { approvalMode: 'allow' } })
         ),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
 
@@ -768,7 +769,7 @@ describe('async job workflow (E2E)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'allow' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -871,7 +872,7 @@ describe('async job workflow (E2E)', () => {
           'initialize',
           defaultInitializeParams({ config: { approvalMode: 'allow' } })
         ),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
 

--- a/packages/agent/src/__tests__/agent-process.budget.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.budget.e2e.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -22,7 +23,7 @@ describe('lace-agent token budget tracking (E2E)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -53,7 +54,7 @@ describe('lace-agent token budget tracking (E2E)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -106,7 +107,7 @@ describe('lace-agent token budget tracking (E2E)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -161,7 +162,7 @@ describe('lace-agent token budget tracking (E2E)', () => {
 
       await withTimeout(
         ctx.agent.peer.request('initialize', defaultInitializeParams()),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
 
@@ -198,7 +199,7 @@ describe('lace-agent token budget tracking (E2E)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 

--- a/packages/agent/src/__tests__/agent-process.delegate-config.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.delegate-config.e2e.test.ts
@@ -2,6 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -41,7 +42,7 @@ describe('lace-agent delegate connectionId/modelId (E2E over stdio)', () => {
           'initialize',
           defaultInitializeParams({ config: { approvalMode: 'ask' } })
         ),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
 
@@ -157,7 +158,7 @@ describe('lace-agent delegate connectionId/modelId (E2E over stdio)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'ask' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -232,7 +233,7 @@ describe('lace-agent delegate connectionId/modelId (E2E over stdio)', () => {
             config: { approvalMode: 'ask', connectionId: 'server-conn', modelId: 'server-model' },
           })
         ),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
 

--- a/packages/agent/src/__tests__/agent-process.delegate.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.delegate.e2e.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -72,7 +73,7 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'ask' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
     await withTimeout(
@@ -165,7 +166,7 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
           'initialize',
           defaultInitializeParams({ config: { approvalMode: 'ask' } })
         ),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
       await withTimeout(
@@ -244,7 +245,7 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'ask' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
     await withTimeout(
@@ -344,7 +345,7 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'ask' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
     await withTimeout(
@@ -470,7 +471,7 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
           'initialize',
           defaultInitializeParams({ config: { approvalMode: 'ask' } })
         ),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
       const sessionResult = (await withTimeout(

--- a/packages/agent/src/__tests__/agent-process.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.e2e.test.ts
@@ -3,6 +3,7 @@ import { writeFileSync, existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { EntErrorCodes } from '@lace/ent-protocol';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -21,7 +22,7 @@ describe('lace-agent process (E2E over stdio)', () => {
     await expect(
       withTimeout(
         ctx.agent.peer.request('initialize', { protocolVersion: '1.0' } as any),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       )
     ).rejects.toMatchObject({ code: -32602, message: 'InvalidParams' });
@@ -32,14 +33,14 @@ describe('lace-agent process (E2E over stdio)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
     await expect(
       withTimeout(
         ctx.agent.peer.request('initialize', defaultInitializeParams()),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize again'
       )
     ).rejects.toMatchObject({
@@ -62,7 +63,7 @@ describe('lace-agent process (E2E over stdio)', () => {
 
       await withTimeout(
         ctx.agent.peer.request('initialize', defaultInitializeParams()),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
 
@@ -140,7 +141,7 @@ describe('lace-agent process (E2E over stdio)', () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -166,7 +167,7 @@ describe('lace-agent process (E2E over stdio)', () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize (restart)'
     );
 
@@ -207,7 +208,7 @@ describe('lace-agent process (E2E over stdio)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
     await withTimeout(
@@ -256,7 +257,7 @@ describe('lace-agent process (E2E over stdio)', () => {
           'initialize',
           defaultInitializeParams({ config: { approvalMode: 'ask' } })
         ),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
 
@@ -355,7 +356,7 @@ describe('lace-agent process (E2E over stdio)', () => {
           'initialize',
           defaultInitializeParams({ config: { approvalMode: 'ask' } })
         ),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
 
@@ -425,7 +426,7 @@ describe('lace-agent process (E2E over stdio)', () => {
           'initialize',
           defaultInitializeParams({ config: { approvalMode: 'ask' } })
         ),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
 
@@ -518,7 +519,7 @@ describe('lace-agent process (E2E over stdio)', () => {
           'initialize',
           defaultInitializeParams({ config: { approvalMode: 'ask' } })
         ),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize (restart)'
       );
       await withTimeout(
@@ -600,7 +601,7 @@ describe('lace-agent process (E2E over stdio)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'ask' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -658,7 +659,7 @@ describe('lace-agent process (E2E over stdio)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
     await withTimeout(
@@ -717,7 +718,7 @@ describe('lace-agent process (E2E over stdio)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'ask' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -788,7 +789,7 @@ describe('lace-agent process (E2E over stdio)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'ask' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
     await withTimeout(
@@ -845,7 +846,7 @@ describe('lace-agent process (E2E over stdio)', () => {
           'initialize',
           defaultInitializeParams({ config: { approvalMode: 'ask' } })
         ),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
       await withTimeout(

--- a/packages/agent/src/__tests__/agent-process.error-recovery.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.error-recovery.e2e.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -32,7 +33,7 @@ describe('lace-agent error recovery (E2E)', () => {
 
       await withTimeout(
         ctx.agent.peer.request('initialize', defaultInitializeParams()),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
 
@@ -119,7 +120,7 @@ describe('lace-agent error recovery (E2E)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'ask' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -204,7 +205,7 @@ describe('lace-agent error recovery (E2E)', () => {
 
       await withTimeout(
         ctx.agent.peer.request('initialize', defaultInitializeParams()),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
 

--- a/packages/agent/src/__tests__/agent-process.event-seq.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.event-seq.e2e.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -26,7 +27,7 @@ describe('lace-agent durable event sequencing (E2E over stdio)', () => {
           'initialize',
           defaultInitializeParams({ config: { approvalMode: 'ask' } })
         ),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
       await withTimeout(

--- a/packages/agent/src/__tests__/agent-process.inject-drain-prefill.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.inject-drain-prefill.e2e.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -108,7 +109,7 @@ describe('inject-drain prefill wedge (E2E)', () => {
 
       await withTimeout(
         ctx.agent.peer.request('initialize', defaultInitializeParams()),
-        5_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
       await withTimeout(
@@ -200,7 +201,7 @@ describe('inject-drain prefill wedge (E2E)', () => {
 
       await withTimeout(
         ctx.agent.peer.request('initialize', defaultInitializeParams()),
-        5_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
       await withTimeout(

--- a/packages/agent/src/__tests__/agent-process.jobs.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.jobs.e2e.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -34,7 +35,7 @@ describe('lace-agent jobs (E2E over stdio)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'ask' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -96,7 +97,7 @@ describe('lace-agent jobs (E2E over stdio)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize (restart)'
     );
     await withTimeout(
@@ -155,7 +156,7 @@ describe('lace-agent jobs (E2E over stdio)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'ask' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -226,7 +227,7 @@ describe('lace-agent jobs (E2E over stdio)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'ask' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -288,7 +289,7 @@ describe('lace-agent jobs (E2E over stdio)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize (restart)'
     );
     await withTimeout(

--- a/packages/agent/src/__tests__/agent-process.metrics.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.metrics.e2e.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -25,7 +26,7 @@ describe('lace-agent session metrics (E2E)', () => {
 
       await withTimeout(
         ctx.agent.peer.request('initialize', defaultInitializeParams()),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
 
@@ -66,7 +67,7 @@ describe('lace-agent session metrics (E2E)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -104,7 +105,7 @@ describe('lace-agent session metrics (E2E)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 

--- a/packages/agent/src/__tests__/agent-process.model-gating.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.model-gating.e2e.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -42,7 +43,7 @@ describe('ent/models enable/disable (provider-global gating)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'approve', connectionId: instances[0] } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 

--- a/packages/agent/src/__tests__/agent-process.providers.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.providers.e2e.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -16,7 +17,7 @@ describe('lace-agent provider config (E2E over stdio)', () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -74,7 +75,7 @@ describe('lace-agent provider config (E2E over stdio)', () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 

--- a/packages/agent/src/__tests__/agent-process.retry.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.retry.e2e.test.ts
@@ -3,6 +3,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -34,7 +35,7 @@ describe('agent retry behavior (E2E)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -71,7 +72,7 @@ describe('agent retry behavior (E2E)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -110,7 +111,7 @@ describe('agent retry behavior (E2E)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -147,7 +148,7 @@ describe('agent retry behavior (E2E)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -184,7 +185,7 @@ describe('agent retry behavior (E2E)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 

--- a/packages/agent/src/__tests__/agent-process.streaming-order.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.streaming-order.e2e.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -49,7 +50,7 @@ describe('lace-agent streaming update ordering (E2E over stdio)', () => {
 
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
     await withTimeout(

--- a/packages/agent/src/__tests__/agent-process.subagent-early-stop.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.subagent-early-stop.e2e.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -64,7 +65,7 @@ describe('lace-agent subagent early-stop bug (kata #31)', () => {
           'initialize',
           defaultInitializeParams({ config: { approvalMode: 'allow' } })
         ),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
       await withTimeout(

--- a/packages/agent/src/__tests__/agent-process.subagent-intent-text-stop.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.subagent-intent-text-stop.e2e.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -116,7 +117,7 @@ describe('lace-agent subagent intent-text-stop (kata #31 round 2)', () => {
           'initialize',
           defaultInitializeParams({ config: { approvalMode: 'allow' } })
         ),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
       await withTimeout(
@@ -271,7 +272,7 @@ describe('lace-agent subagent intent-text-stop (kata #31 round 2)', () => {
           'initialize',
           defaultInitializeParams({ config: { approvalMode: 'allow' } })
         ),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
       await withTimeout(

--- a/packages/agent/src/__tests__/agent-process.subagent.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.subagent.e2e.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -37,7 +38,7 @@ describe('lace-agent subagents (E2E over stdio)', () => {
           'initialize',
           defaultInitializeParams({ config: { approvalMode: 'ask' } })
         ),
-        2_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
       await withTimeout(
@@ -106,7 +107,7 @@ describe('lace-agent subagents (E2E over stdio)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'ask' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
     await withTimeout(

--- a/packages/agent/src/__tests__/agent-process.todo.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.todo.e2e.test.ts
@@ -5,6 +5,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -50,7 +51,7 @@ describe('lace-agent todo tools (E2E over stdio)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'ask' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -118,7 +119,7 @@ describe('lace-agent todo tools (E2E over stdio)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'ask' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -191,7 +192,7 @@ describe('lace-agent todo tools (E2E over stdio)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'ask' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -264,7 +265,7 @@ describe('lace-agent todo tools (E2E over stdio)', () => {
         'initialize',
         defaultInitializeParams({ config: { approvalMode: 'ask' } })
       ),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 

--- a/packages/agent/src/__tests__/credential-broker-socket-chain.e2e.test.ts
+++ b/packages/agent/src/__tests__/credential-broker-socket-chain.e2e.test.ts
@@ -8,6 +8,7 @@ import { mkdtempSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -81,7 +82,7 @@ describe('credentialBrokerSocket full chain (initialize → session/new → prom
           }),
           credentialToolsPaths: [fixtureDir],
         }),
-        5_000,
+        AGENT_BOOT_TIMEOUT_MS,
         'initialize'
       );
 

--- a/packages/agent/src/__tests__/credential-integration.e2e.test.ts
+++ b/packages/agent/src/__tests__/credential-integration.e2e.test.ts
@@ -17,6 +17,7 @@ import { registries, resetRegistriesForTest } from '@lace/agent/plugins';
 import { registerExecDirInto } from '../tools/exec/register-exec';
 import { registerBuiltinTools } from '../tools/builtins';
 import {
+  AGENT_BOOT_TIMEOUT_MS,
   createE2EContext,
   spawnAgentProcess,
   withTimeout,
@@ -259,7 +260,7 @@ describe('Part B credential integration (lace wiring + subagent path)', () => {
             }),
             credentialToolsPaths: [fixtureDir],
           }),
-          5_000,
+          AGENT_BOOT_TIMEOUT_MS,
           'initialize'
         );
         await withTimeout(

--- a/packages/agent/src/__tests__/ent-protocol.spec.ts
+++ b/packages/agent/src/__tests__/ent-protocol.spec.ts
@@ -5,7 +5,12 @@ import { join } from 'node:path';
 import { mkdirSync } from 'node:fs';
 import { appendDurableEvent } from '../storage/event-log';
 import { ensureSessionFiles, writeSessionMeta, writeSessionState } from '../storage/session-store';
-import { spawnAgentProcess, withTimeout, type SpawnedAgent } from './helpers/agent-process';
+import {
+  AGENT_BOOT_TIMEOUT_MS,
+  spawnAgentProcess,
+  withTimeout,
+  type SpawnedAgent,
+} from './helpers/agent-process';
 import { defaultInitializeParams } from './helpers/initialize';
 import * as MethodSchemas from '@lace/ent-protocol';
 
@@ -43,7 +48,10 @@ async function requestOk<T>(options: {
   timeoutMs?: number;
   label?: string;
 }): Promise<T> {
-  const timeoutMs = options.timeoutMs ?? 2_000;
+  // `initialize` is the first request to a just-spawned agent, so its budget has
+  // to cover the child's cold boot, not just the round trip.
+  const timeoutMs =
+    options.timeoutMs ?? (options.method === 'initialize' ? AGENT_BOOT_TIMEOUT_MS : 2_000);
   const label = options.label ?? options.method;
   const parsedParams = parseParams(options.requestSchema, options.params);
   const result = await withTimeout(

--- a/packages/agent/src/__tests__/helpers/agent-process.ts
+++ b/packages/agent/src/__tests__/helpers/agent-process.ts
@@ -1,6 +1,29 @@
+// ABOUTME: Spawns a real lace-agent child process over stdio for the E2E tests
+// ABOUTME: and gives them a request timeout guard plus an orderly shutdown.
+
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { createNdjsonStdioTransport, JsonRpcPeer } from '@lace/ent-protocol';
+
+/**
+ * Budget for the FIRST request to a freshly spawned agent (`initialize`).
+ *
+ * `spawnAgentProcess` returns as soon as `spawn()` does, so this budget has to
+ * cover the child's entire cold boot before the round trip even starts: node
+ * startup, importing the whole `dist` module graph, `loadPlugins()`, and
+ * `runStartupReaper()`'s container-runtime probe. The agent only wires its
+ * JSON-RPC peer after all of that (see `boot()` in src/main.ts), so a slow boot
+ * looks exactly like a hung request.
+ *
+ * Measured on a 16-core box, spawn to `initialize` response: ~0.4s for a lone
+ * agent, p50 1.1s / max 1.2s with 16 booting at once, p50 3.3s / max 3.6s with
+ * 48 — which is what the E2E files and their subagent children produce when
+ * vitest runs them in parallel. The hard-coded 2s budgets these call sites used
+ * to carry were sized for an idle machine and blew nondeterministically under
+ * suite load. This is deliberately far above the measured worst case: it exists
+ * to catch an agent that never answers, not to police boot latency.
+ */
+export const AGENT_BOOT_TIMEOUT_MS = 30_000;
 
 export type SpawnedAgent = {
   peer: JsonRpcPeer;

--- a/packages/agent/src/__tests__/helpers/index.ts
+++ b/packages/agent/src/__tests__/helpers/index.ts
@@ -1,6 +1,11 @@
 // ABOUTME: Barrel export for E2E test helpers
 
-export { spawnAgentProcess, withTimeout, type SpawnedAgent } from './agent-process';
+export {
+  spawnAgentProcess,
+  withTimeout,
+  AGENT_BOOT_TIMEOUT_MS,
+  type SpawnedAgent,
+} from './agent-process';
 export { createE2EContext, type E2ETestContext, type E2EContextOptions } from './e2e-context';
 export {
   defaultInitializeParams,

--- a/packages/agent/src/__tests__/system-prompt-injection.test.ts
+++ b/packages/agent/src/__tests__/system-prompt-injection.test.ts
@@ -6,7 +6,12 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { spawnAgentProcess, withTimeout, type SpawnedAgent } from './helpers/agent-process';
+import {
+  AGENT_BOOT_TIMEOUT_MS,
+  spawnAgentProcess,
+  withTimeout,
+  type SpawnedAgent,
+} from './helpers/agent-process';
 import { defaultInitializeParams } from './helpers/initialize';
 import { buildProviderMessagesFromDurableEvents } from '@lace/agent/server';
 
@@ -61,7 +66,7 @@ describe('system prompt injection on session/new', () => {
 
     await withTimeout(
       agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -97,7 +102,7 @@ describe('system prompt injection on session/new', () => {
 
     await withTimeout(
       agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -127,7 +132,7 @@ describe('system prompt injection on session/new', () => {
 
     await withTimeout(
       agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -167,7 +172,7 @@ describe('system prompt injection on session/new', () => {
 
     await withTimeout(
       agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -204,7 +209,7 @@ describe('system prompt injection on session/new', () => {
 
     await withTimeout(
       agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -228,7 +233,7 @@ describe('system prompt injection on session/new', () => {
 
     await withTimeout(
       agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 
@@ -258,7 +263,7 @@ describe('system prompt injection on session/new', () => {
 
     await withTimeout(
       agent.peer.request('initialize', defaultInitializeParams()),
-      2_000,
+      AGENT_BOOT_TIMEOUT_MS,
       'initialize'
     );
 


### PR DESCRIPTION
## The problem

lace's `packages/agent` suite fails differently run to run, in both directions — a test that fails in one full-suite run passes in the next. That makes any lace change hard to prove clean: you can't tell "my change broke something" from "the suite is noisy."

Measured before this change, 6 consecutive `npm test` runs: 2 flaked, both with `Error: Timed out after 2000ms: initialize`. On the `npx vitest run` path (single parallel pass — what a person or an agent naturally types) it was far worse: 37 / 27 / 33 / 35 failures, different membership every run.

## Root cause

`spawnAgentProcess` returns the instant `spawn()` returns, and the test immediately sends `initialize` under a hard-coded `withTimeout(..., 2_000)`. But the child doesn't wire its JSON-RPC peer until `boot()` in `src/main.ts` finishes: importing the whole `dist` module graph, `loadPlugins()`, and `runStartupReaper()`'s container-runtime probe.

So the 2s budget was never measuring an RPC round trip. It was measuring Node cold start plus the agent's entire boot — which makes a slow boot indistinguishable from a hung agent.

Spawn-to-`initialize`-response, measured against the built `dist/main.js` on a 16-core box:

| concurrent boots | min | p50 | p90 | max |
|---|---|---|---|---|
| 1 | 381 ms | 386 | 394 | 394 |
| 16 | 955 ms | 1114 | 1187 | 1243 |
| 48 | 2390 ms | 3280 | 3503 | 3602 |

48-way is roughly what the E2E files plus their delegate/subagent children produce under full file parallelism. **Every 48-way boot exceeds 2s.** At 16-way there's only ~1.7x headroom, which is why the serialized pass still flaked 2 in 6.

This is the uncommon case where "the timeout is too short" genuinely is the root cause rather than a symptom. Leaked child processes and unawaited promises were both checked and cleared: after 16 full runs no stray `dist/main.js` or vitest processes survived, and the `spawnAgentProcess` shutdown path does kill running jobs before SIGTERM.

Worth noting: b4ddb5bf6 ("serialize subprocess-spawning tests to fix parallelism flakes") addressed this by reducing concurrency rather than fixing the budget. That lowered the flake rate on the sanctioned path and left the naive `npx vitest run` path much worse than it appears.

## The change

Adds `AGENT_BOOT_TIMEOUT_MS = 30_000` to `helpers/agent-process.ts`, documented with the measurements above and with why the budget must cover boot rather than just the round trip. Replaces the timeout at all 87 `initialize` call sites across 22 E2E files. `ent-protocol.spec.ts` routes through its own `requestOk`, so that helper now defaults to the boot budget for `method === 'initialize'` and keeps 2s for everything else.

30s is deliberately far above the 3.6s worst case. The guard exists to catch an agent that never answers, not to police boot latency — a budget set near the measured maximum just reintroduces the same flake on a busier machine.

No retries added, nothing skipped, no assertions weakened, no non-`initialize` budget touched.

## Verification

6 consecutive `npm test` runs, all green (3621 + 276 passing):

| run | 1-min load at start |
|---|---|
| 1 | 1.32 |
| 2 | 1.66 |
| 3 | 1.46 |
| 4 | 2.18 |
| 5 | 4.28 |
| 6 | 4.45 |

Runs 5 and 6 started under heavier load than either baseline run that flaked, and still passed.

Full-parallel stress, 4 consecutive runs: 37/27/33/35 failures → 7/7/5/6.

Typecheck and eslint clean.

## Not fixed here

- **~6 residual full-parallel failures.** Mostly `Test timed out in 5000ms` — vitest's *default* `testTimeout`, on E2E tests that never declared one. At 48-way concurrency the cold boot alone eats 3.3s of that 5s. Same root cause one layer up; ~23 files. Tracked separately.
- **A real Docker teardown race**, surfaced by `persona-container-sharing.integration.test.ts` (4/4 failures under parallelism, 0/6 on the sanctioned path). Forced container removal returns before the daemon releases the container *name*, so an immediate re-create conflicts. That's a product bug on the resume-after-TTL path, not a test bug. Tracked separately.
- **Temp-directory leaks** — several suites `mkdtemp` per test and never remove. No evidence they cause flakes. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
