### PR TITLE
fix(providers): stop flattening tool-result images for OpenAI and Gemini

### DIFF
--- a/packages/agent/src/providers/__tests__/openai-responses-input-items.test.ts
+++ b/packages/agent/src/providers/__tests__/openai-responses-input-items.test.ts
@@ -1,0 +1,175 @@
+// ABOUTME: PRI-3079 — covers the PRODUCTION Responses-API call site, not just the pure helpers.
+// ABOUTME: Every earlier test called the converters directly, so replacing the provider's
+// ABOUTME: `output: toOpenAIResponsesToolOutput(...)` with `output: ''` left the whole suite
+// ABOUTME: green. These assert on the payload actually handed to `openai.responses.create`,
+// ABOUTME: including user-attached images, which the text-only extraction silently dropped.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { OpenAIProvider } from '../openai-provider';
+import type { ProviderMessage } from '../base-provider';
+
+const mockResponsesCreate = vi.fn();
+
+vi.mock('openai', () => {
+  return {
+    default: class MockOpenAI {
+      responses = {
+        create: mockResponsesCreate,
+      };
+      chat = {
+        completions: {
+          create: vi.fn(),
+        },
+      };
+    },
+  };
+});
+
+vi.mock('../../utils/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    trace: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('../../utils/provider-logging.js', () => ({
+  logProviderRequest: vi.fn(),
+  logProviderResponse: vi.fn(),
+}));
+
+const PNG_1PX =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+interface InputItem {
+  type?: string;
+  role?: string;
+  content?: unknown;
+  output?: unknown;
+}
+
+describe('OpenAI Responses API input items', () => {
+  let provider: OpenAIProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResponsesCreate.mockResolvedValue({
+      id: 'resp_1',
+      status: 'completed',
+      output: [{ type: 'message', content: [{ type: 'output_text', text: 'ok' }] }],
+      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+    });
+    provider = new OpenAIProvider({ apiKey: 'test-key' });
+    provider.setSystemPrompt('Test system prompt');
+  });
+
+  afterEach(() => {
+    provider.removeAllListeners();
+  });
+
+  async function inputItems(messages: ProviderMessage[]): Promise<InputItem[]> {
+    await provider.createResponse(messages, [], 'gpt-4o');
+    const payload = mockResponsesCreate.mock.calls[0]?.[0] as { input?: InputItem[] };
+    return payload.input ?? [];
+  }
+
+  it('sends the tool-result image through the real request payload', async () => {
+    const items = await inputItems([
+      { role: 'user', content: 'take a screenshot' },
+      {
+        role: 'assistant',
+        content: '',
+        toolCalls: [{ id: 'call_1', name: 'shot', arguments: {} }],
+      },
+      {
+        role: 'user',
+        content: '',
+        toolResults: [
+          {
+            id: 'call_1',
+            status: 'completed',
+            content: [
+              { type: 'text', text: 'screenshot.png' },
+              { type: 'image', data: PNG_1PX, mimeType: 'image/png' },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const output = items.find((item) => item.type === 'function_call_output');
+    expect(output?.output).toEqual([
+      { type: 'input_text', text: 'screenshot.png' },
+      { type: 'input_image', image_url: `data:image/png;base64,${PNG_1PX}` },
+    ]);
+  });
+
+  it('never sends an empty tool-result output', async () => {
+    const items = await inputItems([
+      {
+        role: 'user',
+        content: '',
+        toolResults: [
+          {
+            id: 'call_2',
+            status: 'completed',
+            content: [{ type: 'image', data: PNG_1PX, mimeType: 'image/png' }],
+          },
+        ],
+      },
+    ]);
+
+    const output = items.find((item) => item.type === 'function_call_output');
+    expect(output?.output).not.toBe('');
+  });
+
+  it('sends a user-attached image alongside the text', async () => {
+    // The Responses API is the default path for real OpenAI, and it extracted text
+    // blocks only — a pasted image never reached the model.
+    const items = await inputItems([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'what is this?' },
+          { type: 'image', source: { type: 'base64', media_type: 'image/png', data: PNG_1PX } },
+        ],
+      },
+    ]);
+
+    expect(items[0]).toEqual({
+      role: 'user',
+      content: [
+        { type: 'input_text', text: 'what is this?' },
+        { type: 'input_image', detail: 'auto', image_url: `data:image/png;base64,${PNG_1PX}` },
+      ],
+    });
+  });
+
+  it('sends an image-only user message instead of dropping it entirely', async () => {
+    // `textContent.trim()` is empty for an image-only message, so nothing was pushed
+    // at all: the turn vanished from the conversation the model saw.
+    const items = await inputItems([
+      {
+        role: 'user',
+        content: [
+          { type: 'image', source: { type: 'base64', media_type: 'image/png', data: PNG_1PX } },
+        ],
+      },
+    ]);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toEqual({
+      role: 'user',
+      content: [
+        { type: 'input_image', detail: 'auto', image_url: `data:image/png;base64,${PNG_1PX}` },
+      ],
+    });
+  });
+
+  it('keeps a plain text message in the flat string form', async () => {
+    const items = await inputItems([{ role: 'user', content: 'hello' }]);
+    expect(items[0]).toEqual({ role: 'user', content: 'hello' });
+  });
+});

--- a/packages/agent/src/providers/format-converters.ts
+++ b/packages/agent/src/providers/format-converters.ts
@@ -6,6 +6,10 @@ import type { ContentBlock as ToolResultContentBlock } from '../tools/types';
 import { ToolCall } from '@lace/agent/tools/types';
 import Anthropic from '@anthropic-ai/sdk';
 import type { Content, Part } from '@google/genai';
+import type {
+  ResponseFunctionCallOutputItem,
+  ResponseInputItem,
+} from 'openai/resources/responses/responses';
 import { getTextContent } from '@lace/agent/providers/utils/content-helpers';
 
 /**
@@ -34,34 +38,107 @@ function toAnthropicThinkingBlocks(
  * not guess a media type when it is absent — a wrong one is an API error at
  * best and a mis-decoded image at worst — so such a block degrades to text that
  * says so, which is at least honest to the model about what happened.
- */
-/**
+ *
  * The block-array form is chosen when the result contains ANY image block, not
  * only a renderable one. Gating on renderable would send an unrenderable image
  * back down the string path, where `block.text || ''` turns it into '' — the
  * exact silent drop this change exists to remove, just narrowed to a rarer case.
  */
-function isRenderableToolResultImage(block: ToolResultContentBlock): boolean {
-  return block.type === 'image' && !!block.data && !!block.mimeType;
+
+/**
+ * Why an image block cannot become a provider image block, or null if it can.
+ * Both halves matter: bytes with no media type are undecodable, and a media
+ * type with no bytes is nothing at all.
+ */
+function unrenderableImageReason(block: ToolResultContentBlock): string | null {
+  if (!block.data) return 'no image data reported by the tool';
+  if (!block.mimeType) return 'no media type reported by the tool';
+  return null;
+}
+
+/**
+ * PRI-3079. Some tool-result wire formats are text-only: OpenAI's
+ * `ChatCompletionToolMessageParam.content` is `string | ContentPartText[]`, and
+ * `@google/genai@1.x` `FunctionResponse` carries only a JSON `response` object.
+ * An image cannot travel through those at all.
+ */
+const TOOL_RESULT_IMAGE_UNSUPPORTED = 'this provider cannot carry an image in a tool result';
+
+/**
+ * Text stand-in for an image block that is not being sent as an image. The
+ * result is never '' — an empty string is exactly the silent drop PRI-3078
+ * removed, and the model has to be told an image existed. The media type is
+ * reported when known and never guessed.
+ */
+function describeOmittedToolResultImage(block: ToolResultContentBlock, reason: string): string {
+  const mediaType = block.mimeType ? ` (${block.mimeType})` : '';
+  return `[image omitted: ${reason}${mediaType}]`;
+}
+
+/**
+ * Flatten a tool-result block to text for a provider whose tool-result format
+ * cannot carry images at all. Image blocks become an explanation rather than ''.
+ *
+ * A missing media type is NOT the reason to report here: it would imply the
+ * image would otherwise have gone through, which is false for these providers.
+ * Missing bytes is worth reporting, because then there was no image at all.
+ */
+function toolResultBlockAsText(block: ToolResultContentBlock): string {
+  if (block.type !== 'image') return block.text || '';
+  const reason = block.data ? TOOL_RESULT_IMAGE_UNSUPPORTED : 'no image data reported by the tool';
+  return describeOmittedToolResultImage(block, reason);
 }
 
 function toAnthropicToolResultBlock(
   block: ToolResultContentBlock
 ): Anthropic.TextBlockParam | Anthropic.ImageBlockParam {
-  if (isRenderableToolResultImage(block)) {
+  if (block.type !== 'image') return { type: 'text', text: block.text || '' };
+  const reason = unrenderableImageReason(block);
+  if (reason) return { type: 'text', text: describeOmittedToolResultImage(block, reason) };
+  return {
+    type: 'image',
+    source: {
+      type: 'base64',
+      media_type: block.mimeType as 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp',
+      data: block.data as string,
+    },
+  };
+}
+
+/**
+ * PRI-3079. The Responses API is the one tool-result format among OpenAI's and
+ * Gemini's that CAN carry an image, so it gets the real bytes.
+ *
+ * The return type is the SDK's own, deliberately: `ResponseInputItem.FunctionCallOutput`
+ * declares `output: string | ResponseFunctionCallOutputItemList`, whose items are
+ * `ResponseInputTextContent | ResponseInputImageContent | ResponseInputFileContent`,
+ * and `ResponseInputImageContent.image_url` documents itself as "a fully qualified
+ * URL or base64 encoded image in a data URL". The provider pushes these items into
+ * an `Array<unknown>`, so nothing downstream would catch an invented field name —
+ * annotating here is what makes tsc check the shape against the SDK.
+ *
+ * As on the Anthropic path, the item-list form is chosen when the result holds
+ * ANY image block, not only a renderable one: gating on renderable would push an
+ * unrenderable image back down the string path, where `block.text || ''` turns
+ * it into '' and recreates the silent drop in a rarer case.
+ */
+export function toOpenAIResponsesToolOutput(
+  content: ToolResultContentBlock[]
+): ResponseInputItem.FunctionCallOutput['output'] {
+  if (!content.some((block) => block.type === 'image')) {
+    return content.map((block) => block.text || '').join('\n');
+  }
+  return content.map((block): ResponseFunctionCallOutputItem => {
+    if (block.type !== 'image') return { type: 'input_text', text: block.text || '' };
+    const reason = unrenderableImageReason(block);
+    if (reason) {
+      return { type: 'input_text', text: describeOmittedToolResultImage(block, reason) };
+    }
     return {
-      type: 'image',
-      source: {
-        type: 'base64',
-        media_type: block.mimeType as 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp',
-        data: block.data as string,
-      },
+      type: 'input_image',
+      image_url: `data:${block.mimeType as string};base64,${block.data as string}`,
     };
-  }
-  if (block.type === 'image') {
-    return { type: 'text', text: '[image omitted: no media type reported by the tool]' };
-  }
-  return { type: 'text', text: block.text || '' };
+  });
 }
 
 /**
@@ -315,7 +392,11 @@ export function convertToOpenAIFormat(messages: ProviderMessage[]): Record<strin
             .map((result) => ({
               role: 'tool',
               tool_call_id: result.id!, // Safe to use ! since we filtered
-              content: result.content.map((block) => block.text || '').join('\n'),
+              // PRI-3079: `ChatCompletionToolMessageParam.content` is
+              // `string | ChatCompletionContentPartText[]` — text only, so an image
+              // genuinely cannot travel in a chat-completions tool message. Say so
+              // rather than flattening the block to '' and telling the model nothing.
+              content: result.content.map(toolResultBlockAsText).join('\n'),
             }));
 
           // If there's also text/image content, include the user message first
@@ -484,7 +565,13 @@ export function convertToGeminiFormat(messages: ProviderMessage[]): Content[] {
               name: toolName, // Function name for Gemini API
               id: correlationId, // Tool call ID for correlation
               response: {
-                output: result.content.map((c) => c.text || '').join('\n'),
+                // PRI-3079: `@google/genai@1.x` FunctionResponse is
+                // `{id?, name?, response?: Record<string, unknown>, ...}` — no `parts`
+                // field, so inline image bytes cannot be expressed in a function
+                // response with the SDK in use. (Gemini 3 plus a 2.x SDK adds
+                // `functionResponse.parts[].inlineData`; adopting it is an SDK major
+                // bump, not this change.) Report the image instead of dropping it to ''.
+                output: result.content.map(toolResultBlockAsText).join('\n'),
                 ...(result.status !== 'completed' ? { error: 'Tool execution failed' } : {}),
               },
             },

--- a/packages/agent/src/providers/format-converters.ts
+++ b/packages/agent/src/providers/format-converters.ts
@@ -8,7 +8,9 @@ import Anthropic from '@anthropic-ai/sdk';
 import type { Content, Part } from '@google/genai';
 import type {
   ResponseFunctionCallOutputItem,
+  ResponseInputContent,
   ResponseInputItem,
+  ResponseInputMessageContentList,
 } from 'openai/resources/responses/responses';
 import { getTextContent } from '@lace/agent/providers/utils/content-helpers';
 
@@ -57,6 +59,35 @@ function unrenderableImageReason(block: ToolResultContentBlock): string | null {
 }
 
 /**
+ * A tool-result block that is not an image, rendered as text.
+ *
+ * PRI-3079 follow-up: a `resource` block carries a `uri` and no `text` (see
+ * `mcp/tool-adapter.ts`), so the unconditional `block.text || ''` flattened an
+ * MCP resource link to '' — the same silent drop as the image case, one enum
+ * member over. The uri is itself optional in the MCP payload, so a missing one
+ * is reported rather than emitted as '' or the string 'undefined'.
+ */
+function nonImageToolResultBlockAsText(block: ToolResultContentBlock): string {
+  if (block.type === 'resource') {
+    return block.uri
+      ? `[resource: ${block.uri}]`
+      : '[resource omitted: no uri reported by the tool]';
+  }
+  return block.text || '';
+}
+
+/**
+ * An empty text block carries no information on any path, and Anthropic is
+ * reported to reject one outright ("text content blocks must be non-empty"),
+ * which would turn a degraded block into a 400 for the whole request. Not
+ * confirmed against the live API — the SDK types do not encode the constraint —
+ * but there is nothing to lose by dropping it from the array forms.
+ */
+function hasText(block: { type: string; text?: string }): boolean {
+  return block.type !== 'text' || (block.text ?? '').length > 0;
+}
+
+/**
  * PRI-3079. Some tool-result wire formats are text-only: OpenAI's
  * `ChatCompletionToolMessageParam.content` is `string | ContentPartText[]`, and
  * `@google/genai@1.x` `FunctionResponse` carries only a JSON `response` object.
@@ -84,7 +115,7 @@ function describeOmittedToolResultImage(block: ToolResultContentBlock, reason: s
  * Missing bytes is worth reporting, because then there was no image at all.
  */
 function toolResultBlockAsText(block: ToolResultContentBlock): string {
-  if (block.type !== 'image') return block.text || '';
+  if (block.type !== 'image') return nonImageToolResultBlockAsText(block);
   const reason = block.data ? TOOL_RESULT_IMAGE_UNSUPPORTED : 'no image data reported by the tool';
   return describeOmittedToolResultImage(block, reason);
 }
@@ -92,7 +123,7 @@ function toolResultBlockAsText(block: ToolResultContentBlock): string {
 function toAnthropicToolResultBlock(
   block: ToolResultContentBlock
 ): Anthropic.TextBlockParam | Anthropic.ImageBlockParam {
-  if (block.type !== 'image') return { type: 'text', text: block.text || '' };
+  if (block.type !== 'image') return { type: 'text', text: nonImageToolResultBlockAsText(block) };
   const reason = unrenderableImageReason(block);
   if (reason) return { type: 'text', text: describeOmittedToolResultImage(block, reason) };
   return {
@@ -126,19 +157,57 @@ export function toOpenAIResponsesToolOutput(
   content: ToolResultContentBlock[]
 ): ResponseInputItem.FunctionCallOutput['output'] {
   if (!content.some((block) => block.type === 'image')) {
-    return content.map((block) => block.text || '').join('\n');
+    return content.map(nonImageToolResultBlockAsText).join('\n');
   }
-  return content.map((block): ResponseFunctionCallOutputItem => {
-    if (block.type !== 'image') return { type: 'input_text', text: block.text || '' };
-    const reason = unrenderableImageReason(block);
-    if (reason) {
-      return { type: 'input_text', text: describeOmittedToolResultImage(block, reason) };
-    }
-    return {
-      type: 'input_image',
-      image_url: `data:${block.mimeType as string};base64,${block.data as string}`,
-    };
-  });
+  return content
+    .map((block): ResponseFunctionCallOutputItem => {
+      if (block.type !== 'image') {
+        return { type: 'input_text', text: nonImageToolResultBlockAsText(block) };
+      }
+      const reason = unrenderableImageReason(block);
+      if (reason) {
+        return { type: 'input_text', text: describeOmittedToolResultImage(block, reason) };
+      }
+      return {
+        type: 'input_image',
+        image_url: `data:${block.mimeType as string};base64,${block.data as string}`,
+      };
+    })
+    .filter((item) => item.type !== 'input_text' || item.text.length > 0);
+}
+
+/**
+ * PRI-3079. Message content for a Responses-API user turn.
+ *
+ * The Responses path is the default for real OpenAI, and it extracted text
+ * blocks only (`getTextContent`), so a user's attached image was dropped — and
+ * an image-only message was dropped whole, because the extracted text was empty
+ * and nothing got pushed. Anthropic, Gemini and OpenAI chat completions all
+ * carry user images; this path has to as well.
+ *
+ * These blocks are the PROVIDER-side `ContentBlock` with a nested `source`, not
+ * the flat `tools/types` one a tool result carries. The return type is the SDK's
+ * own so tsc checks the item shapes — `ResponseInputImage.detail` is required.
+ *
+ * Text-only content keeps the flat string form byte-for-byte.
+ */
+export function toOpenAIResponsesMessageContent(
+  content: string | ContentBlock[]
+): string | ResponseInputMessageContentList {
+  if (typeof content === 'string') return content;
+  if (!content.some((block) => block.type === 'image')) return getTextContent(content);
+  return content
+    .map(
+      (block): ResponseInputContent =>
+        block.type === 'text'
+          ? { type: 'input_text', text: block.text }
+          : {
+              type: 'input_image',
+              detail: 'auto',
+              image_url: `data:${block.source.media_type};base64,${block.source.data}`,
+            }
+    )
+    .filter((item) => item.type !== 'input_text' || item.text.length > 0);
 }
 
 /**
@@ -225,8 +294,8 @@ export function convertToAnthropicFormat(messages: ProviderMessage[]): Anthropic
               // messages. Text-only results keep the string form byte-for-byte:
               // the common path does not change shape.
               content: result.content.some((block) => block.type === 'image')
-                ? result.content.map(toAnthropicToolResultBlock)
-                : result.content.map((block) => block.text || '').join('\n'),
+                ? result.content.map(toAnthropicToolResultBlock).filter(hasText)
+                : result.content.map(nonImageToolResultBlockAsText).join('\n'),
               // Convert our status to Anthropic's is_error flag
               ...(result.status !== 'completed' ? { is_error: true } : {}),
             })

--- a/packages/agent/src/providers/openai-provider.ts
+++ b/packages/agent/src/providers/openai-provider.ts
@@ -39,7 +39,11 @@ import { getTextContent } from '@lace/agent/providers/utils/content-helpers';
 import { ToolCall } from '@lace/agent/tools/types';
 import { logger } from '@lace/agent/utils/logger';
 import { logProviderRequest, logProviderResponse } from '@lace/agent/utils/provider-logging';
-import { convertToOpenAIFormat, toOpenAIResponsesToolOutput } from './format-converters';
+import {
+  convertToOpenAIFormat,
+  toOpenAIResponsesMessageContent,
+  toOpenAIResponsesToolOutput,
+} from './format-converters';
 
 interface OpenAIProviderConfig extends ProviderConfig {
   apiKey: string | null;
@@ -385,12 +389,20 @@ export class OpenAIProvider extends AIProvider {
 
     for (const msg of messages) {
       if (msg.role === 'user' || msg.role === 'assistant') {
-        const textContent = getTextContent(msg.content);
-        // Add text message if it has content
-        if (textContent.trim()) {
+        // PRI-3079: a user turn's images have to travel as `input_image` items.
+        // `getTextContent` keeps text blocks only, which dropped a pasted image and
+        // dropped an image-only turn entirely (its extracted text is empty, so
+        // nothing was pushed at all). Assistant turns carry no images here, so they
+        // keep the text extraction.
+        const content =
+          msg.role === 'user'
+            ? toOpenAIResponsesMessageContent(msg.content)
+            : getTextContent(msg.content);
+        // Add message if it has content
+        if (typeof content === 'string' ? content.trim() : content.length > 0) {
           inputItems.push({
             role: msg.role,
-            content: textContent,
+            content,
           });
         }
 

--- a/packages/agent/src/providers/openai-provider.ts
+++ b/packages/agent/src/providers/openai-provider.ts
@@ -39,7 +39,7 @@ import { getTextContent } from '@lace/agent/providers/utils/content-helpers';
 import { ToolCall } from '@lace/agent/tools/types';
 import { logger } from '@lace/agent/utils/logger';
 import { logProviderRequest, logProviderResponse } from '@lace/agent/utils/provider-logging';
-import { convertToOpenAIFormat } from './format-converters';
+import { convertToOpenAIFormat, toOpenAIResponsesToolOutput } from './format-converters';
 
 interface OpenAIProviderConfig extends ProviderConfig {
   apiKey: string | null;
@@ -413,7 +413,9 @@ export class OpenAIProvider extends AIProvider {
             inputItems.push({
               type: 'function_call_output',
               call_id: result.id,
-              output: result.content.map((c) => c.text || '').join('\n'),
+              // PRI-3079: the Responses API accepts an item list here, so a
+              // tool-result image reaches the model instead of flattening to ''.
+              output: toOpenAIResponsesToolOutput(result.content),
             });
           }
         }

--- a/packages/agent/src/providers/tool-result-images.test.ts
+++ b/packages/agent/src/providers/tool-result-images.test.ts
@@ -6,7 +6,13 @@
 
 import { describe, expect, it } from 'vitest';
 import type { ProviderMessage } from './base-provider';
-import { convertToAnthropicFormat } from './format-converters';
+import type { ContentBlock as ToolResultContentBlock } from '../tools/types';
+import {
+  convertToAnthropicFormat,
+  convertToGeminiFormat,
+  convertToOpenAIFormat,
+  toOpenAIResponsesToolOutput,
+} from './format-converters';
 
 const PNG_1PX =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
@@ -90,5 +96,147 @@ describe('PRI-3078: tool-result image blocks reach the model', () => {
       ])
     );
     expect(firstToolResult(out)?.is_error).toBe(true);
+  });
+});
+
+describe('PRI-3079: OpenAI Responses API tool output', () => {
+  it('keeps a text-only tool result as a flat string (common path unchanged)', () => {
+    expect(toOpenAIResponsesToolOutput([{ type: 'text', text: 'hello' }])).toBe('hello');
+  });
+
+  it('emits an input_image data URL when the block carries data + mimeType', () => {
+    // Verified against openai@6 `ResponseInputItem.FunctionCallOutput`:
+    // `output: string | ResponseFunctionCallOutputItemList`, whose items are
+    // ResponseInputTextContent | ResponseInputImageContent | ResponseInputFileContent.
+    const out = toOpenAIResponsesToolOutput([
+      { type: 'text', text: 'screenshot.png' },
+      { type: 'image', data: PNG_1PX, mimeType: 'image/png' },
+    ]);
+    expect(out).toEqual([
+      { type: 'input_text', text: 'screenshot.png' },
+      { type: 'input_image', image_url: `data:image/png;base64,${PNG_1PX}` },
+    ]);
+  });
+
+  it('does not silently drop the image bytes', () => {
+    const out = toOpenAIResponsesToolOutput([
+      { type: 'image', data: PNG_1PX, mimeType: 'image/png' },
+    ]);
+    expect(JSON.stringify(out)).toContain(PNG_1PX);
+  });
+
+  it('degrades to explanatory text when the media type is missing', () => {
+    const out = toOpenAIResponsesToolOutput([{ type: 'image', data: PNG_1PX }]);
+    expect(out).toEqual([
+      { type: 'input_text', text: '[image omitted: no media type reported by the tool]' },
+    ]);
+  });
+
+  it('degrades to explanatory text when the image data is missing', () => {
+    const out = toOpenAIResponsesToolOutput([{ type: 'image', mimeType: 'image/png' }]);
+    expect(out).toEqual([
+      {
+        type: 'input_text',
+        text: '[image omitted: no image data reported by the tool (image/png)]',
+      },
+    ]);
+  });
+});
+
+describe('PRI-3079: OpenAI chat-completions tool message', () => {
+  it('keeps a text-only tool result as a flat string (common path unchanged)', () => {
+    const out = convertToOpenAIFormat(
+      withToolResults([
+        { id: 'call_1', status: 'completed', content: [{ type: 'text', text: 'hello' }] },
+      ])
+    );
+    expect(out[0]).toEqual({ role: 'tool', tool_call_id: 'call_1', content: 'hello' });
+  });
+
+  it('tells the model an image was produced instead of sending an empty string', () => {
+    // `ChatCompletionToolMessageParam.content` is `string | ChatCompletionContentPartText[]`
+    // in openai@6 — text only, so the image genuinely cannot travel here.
+    const out = convertToOpenAIFormat(
+      withToolResults([
+        {
+          id: 'call_2',
+          status: 'completed',
+          content: [
+            { type: 'text', text: 'screenshot.png' },
+            { type: 'image', data: PNG_1PX, mimeType: 'image/png' },
+          ],
+        },
+      ])
+    );
+    expect(out[0]).toEqual({
+      role: 'tool',
+      tool_call_id: 'call_2',
+      content:
+        'screenshot.png\n[image omitted: this provider cannot carry an image in a tool result (image/png)]',
+    });
+  });
+
+  it('never yields an empty string for an image-only result', () => {
+    const out = convertToOpenAIFormat(
+      withToolResults([
+        {
+          id: 'call_3',
+          status: 'completed',
+          content: [{ type: 'image', data: PNG_1PX, mimeType: 'image/png' }],
+        },
+      ])
+    );
+    expect((out[0] as { content: string }).content).not.toBe('');
+  });
+
+  it('reports a missing media type rather than claiming one', () => {
+    const out = convertToOpenAIFormat(
+      withToolResults([
+        { id: 'call_4', status: 'completed', content: [{ type: 'image', data: PNG_1PX }] },
+      ])
+    );
+    expect((out[0] as { content: string }).content).toBe(
+      '[image omitted: this provider cannot carry an image in a tool result]'
+    );
+  });
+});
+
+describe('PRI-3079: Gemini functionResponse', () => {
+  function geminiFunctionResponseOutput(content: ToolResultContentBlock[]): unknown {
+    const out = convertToGeminiFormat(
+      withToolResults([{ id: 'gemini_read_file_123_abc', status: 'completed', content }])
+    );
+    const part = out[0]?.parts?.[0] as { functionResponse?: { response?: { output?: unknown } } };
+    return part.functionResponse?.response?.output;
+  }
+
+  it('keeps a text-only tool result as a flat string (common path unchanged)', () => {
+    expect(geminiFunctionResponseOutput([{ type: 'text', text: 'hello' }])).toBe('hello');
+  });
+
+  it('tells the model an image was produced instead of sending an empty string', () => {
+    // @google/genai@1.x `FunctionResponse` is `{id?, name?, response?: Record<string, unknown>,
+    // willContinue?, scheduling?}` — there is no `parts` field, so inline image bytes
+    // cannot be expressed here.
+    expect(
+      geminiFunctionResponseOutput([
+        { type: 'text', text: 'screenshot.png' },
+        { type: 'image', data: PNG_1PX, mimeType: 'image/png' },
+      ])
+    ).toBe(
+      'screenshot.png\n[image omitted: this provider cannot carry an image in a tool result (image/png)]'
+    );
+  });
+
+  it('never yields an empty string for an image-only result', () => {
+    expect(
+      geminiFunctionResponseOutput([{ type: 'image', data: PNG_1PX, mimeType: 'image/png' }])
+    ).not.toBe('');
+  });
+
+  it('reports a missing media type rather than claiming one', () => {
+    expect(geminiFunctionResponseOutput([{ type: 'image', data: PNG_1PX }])).toBe(
+      '[image omitted: this provider cannot carry an image in a tool result]'
+    );
   });
 });

--- a/packages/agent/src/providers/tool-result-images.test.ts
+++ b/packages/agent/src/providers/tool-result-images.test.ts
@@ -21,7 +21,7 @@ function withToolResults(toolResults: ProviderMessage['toolResults']): ProviderM
   return [{ role: 'user', content: '', toolResults }];
 }
 
-function firstToolResult(out: ProviderMessage[] | Record<string, unknown>[]) {
+function firstToolResult(out: unknown[]): Record<string, unknown> {
   return (out[0] as { content: Array<Record<string, unknown>> }).content[0];
 }
 
@@ -90,7 +90,7 @@ describe('PRI-3078: tool-result image blocks reach the model', () => {
       withToolResults([
         {
           id: 'toolu_5',
-          status: 'error',
+          status: 'failed',
           content: [{ type: 'image', data: PNG_1PX, mimeType: 'image/png' }],
         },
       ])
@@ -189,7 +189,7 @@ describe('PRI-3079: OpenAI chat-completions tool message', () => {
     expect((out[0] as { content: string }).content).not.toBe('');
   });
 
-  it('reports a missing media type rather than claiming one', () => {
+  it('reports the omission without inventing a media type it was not given', () => {
     const out = convertToOpenAIFormat(
       withToolResults([
         { id: 'call_4', status: 'completed', content: [{ type: 'image', data: PNG_1PX }] },
@@ -197,6 +197,19 @@ describe('PRI-3079: OpenAI chat-completions tool message', () => {
     );
     expect((out[0] as { content: string }).content).toBe(
       '[image omitted: this provider cannot carry an image in a tool result]'
+    );
+  });
+
+  it('reports missing bytes rather than an unsupported wire format', () => {
+    // Missing bytes is a different failure from "this format is text-only", and the
+    // model is better served by the specific one: there was no image at all.
+    const out = convertToOpenAIFormat(
+      withToolResults([
+        { id: 'call_5', status: 'completed', content: [{ type: 'image', mimeType: 'image/png' }] },
+      ])
+    );
+    expect((out[0] as { content: string }).content).toBe(
+      '[image omitted: no image data reported by the tool (image/png)]'
     );
   });
 });
@@ -234,9 +247,122 @@ describe('PRI-3079: Gemini functionResponse', () => {
     ).not.toBe('');
   });
 
-  it('reports a missing media type rather than claiming one', () => {
+  it('reports the omission without inventing a media type it was not given', () => {
     expect(geminiFunctionResponseOutput([{ type: 'image', data: PNG_1PX }])).toBe(
       '[image omitted: this provider cannot carry an image in a tool result]'
     );
+  });
+
+  it('reports missing bytes rather than an unsupported wire format', () => {
+    expect(geminiFunctionResponseOutput([{ type: 'image', mimeType: 'image/png' }])).toBe(
+      '[image omitted: no image data reported by the tool (image/png)]'
+    );
+  });
+});
+
+describe('PRI-3079: resource blocks are not flattened to an empty string', () => {
+  // mcp/tool-adapter.ts emits `{type:'resource', uri}` with NO `text`, so every
+  // `block.text || ''` on a tool-result path silently turned an MCP resource link
+  // into an empty tool result — the same defect as the image case, one enum member
+  // over. `uri` is itself optional there, so a missing one must not become
+  // '' or the string 'undefined'.
+  const RESOURCE_URI = 'file:///tmp/notes.txt';
+  const RESOURCE_BLOCK: ToolResultContentBlock = { type: 'resource', uri: RESOURCE_URI };
+  const RESOURCE_TEXT = `[resource: ${RESOURCE_URI}]`;
+
+  function geminiOutput(content: ToolResultContentBlock[]): unknown {
+    const out = convertToGeminiFormat(
+      withToolResults([{ id: 'gemini_read_file_123_abc', status: 'completed', content }])
+    );
+    const part = out[0]?.parts?.[0] as { functionResponse?: { response?: { output?: unknown } } };
+    return part.functionResponse?.response?.output;
+  }
+
+  it('names the resource on the Anthropic string path', () => {
+    const out = convertToAnthropicFormat(
+      withToolResults([{ id: 'toolu_r1', status: 'completed', content: [RESOURCE_BLOCK] }])
+    );
+    expect(firstToolResult(out)?.content).toBe(RESOURCE_TEXT);
+  });
+
+  it('names the resource alongside an image on the Anthropic block path', () => {
+    const out = convertToAnthropicFormat(
+      withToolResults([
+        {
+          id: 'toolu_r2',
+          status: 'completed',
+          content: [RESOURCE_BLOCK, { type: 'image', data: PNG_1PX, mimeType: 'image/png' }],
+        },
+      ])
+    );
+    const inner = firstToolResult(out)?.content as Array<Record<string, unknown>>;
+    expect(inner[0]).toEqual({ type: 'text', text: RESOURCE_TEXT });
+  });
+
+  it('names the resource on the OpenAI Responses string path', () => {
+    expect(toOpenAIResponsesToolOutput([RESOURCE_BLOCK])).toBe(RESOURCE_TEXT);
+  });
+
+  it('names the resource alongside an image on the OpenAI Responses item path', () => {
+    const out = toOpenAIResponsesToolOutput([
+      RESOURCE_BLOCK,
+      { type: 'image', data: PNG_1PX, mimeType: 'image/png' },
+    ]);
+    expect(out).toEqual([
+      { type: 'input_text', text: RESOURCE_TEXT },
+      { type: 'input_image', image_url: `data:image/png;base64,${PNG_1PX}` },
+    ]);
+  });
+
+  it('names the resource on the OpenAI chat-completions path', () => {
+    const out = convertToOpenAIFormat(
+      withToolResults([{ id: 'call_r1', status: 'completed', content: [RESOURCE_BLOCK] }])
+    );
+    expect((out[0] as { content: string }).content).toBe(RESOURCE_TEXT);
+  });
+
+  it('names the resource on the Gemini path', () => {
+    expect(geminiOutput([RESOURCE_BLOCK])).toBe(RESOURCE_TEXT);
+  });
+
+  it('says so when the resource has no uri, on every path', () => {
+    const noUri: ToolResultContentBlock[] = [{ type: 'resource' }];
+    const missing = '[resource omitted: no uri reported by the tool]';
+    const anthropic = convertToAnthropicFormat(
+      withToolResults([{ id: 'toolu_r3', status: 'completed', content: noUri }])
+    );
+    expect(firstToolResult(anthropic)?.content).toBe(missing);
+    expect(toOpenAIResponsesToolOutput(noUri)).toBe(missing);
+    const openai = convertToOpenAIFormat(
+      withToolResults([{ id: 'call_r2', status: 'completed', content: noUri }])
+    );
+    expect((openai[0] as { content: string }).content).toBe(missing);
+    expect(geminiOutput(noUri)).toBe(missing);
+  });
+});
+
+describe('PRI-3079: empty text blocks stay off the wire', () => {
+  // An empty text block carries no information on any path. Anthropic is reported
+  // to reject a content array holding one ("text content blocks must be
+  // non-empty"), which would turn a silent degradation into a hard 400 for the
+  // whole request; that rejection is not confirmed against the live API and the
+  // SDK types do not encode it, but dropping the block costs nothing either way.
+  const EMPTY_AND_IMAGE: ToolResultContentBlock[] = [
+    { type: 'text', text: '' },
+    { type: 'image', data: PNG_1PX, mimeType: 'image/png' },
+  ];
+
+  it('omits the empty text block from the Anthropic block array', () => {
+    const out = convertToAnthropicFormat(
+      withToolResults([{ id: 'toolu_e1', status: 'completed', content: EMPTY_AND_IMAGE }])
+    );
+    const inner = firstToolResult(out)?.content as Array<Record<string, unknown>>;
+    expect(inner).toHaveLength(1);
+    expect(inner[0]).toMatchObject({ type: 'image' });
+  });
+
+  it('omits the empty text item from the OpenAI Responses item list', () => {
+    const out = toOpenAIResponsesToolOutput(EMPTY_AND_IMAGE);
+    expect(out).toEqual([{ type: 'input_image', image_url: `data:image/png;base64,${PNG_1PX}` }]);
   });
 });


### PR DESCRIPTION
Extends #383 (PRI-3078), which fixed tool-result image passthrough for Anthropic only. OpenAI and Gemini still flattened every image to an empty string.

## The defect

There are two different types named `ContentBlock`. Tool results use the flat one from `tools/types.ts` (`{type, text?, data?, uri?, mimeType?}`); the provider-side one in `base-provider.ts` has a nested `source`. `block.text || ''` is valid on **both**, and on an image block it silently yields `''`.

So `result.content.map(b => b.text || '').join('\n')` didn't just drop the image — it dropped it without telling the model anything had happened. That's how this survived long enough to be found by hand.

## What each provider can actually carry

Three formats, three different answers. Each checked against the installed SDK's `.d.ts` — ground truth for what the client accepts — and corroborated against docs.

**OpenAI Responses API — yes.** `FunctionCallOutput.output` is `string | ResponseFunctionCallOutputItemList`, whose items include `ResponseInputImageContent` (`{type:'input_image', image_url?}`), documented as accepting "a fully qualified URL or base64 encoded image in a data URL". Confirmed by OpenAI's function-calling guide: "For functions that return images or files, you can pass an array of image or file objects instead of a string."

**OpenAI Chat Completions — no.** `ChatCompletionToolMessageParam.content` is `string | Array<ChatCompletionContentPartText>`. Text only. Both OpenAI paths are live (chat completions serves custom endpoints and the Responses-unsupported fallback), so both needed handling.

**Gemini — no, at the version we're pinned to.** In `@google/genai@1.20.0` (pinned `^1.19.0`), `FunctionResponse` is `{willContinue?, scheduling?, id?, name?, response?}`. There is no `parts` field.

This last one is worth spelling out, because the obvious implementation is wrong in a way that typechecks. `Part.inlineData` is real and is already used in this file for user images, so appending an `inlineData` part *alongside* the `functionResponse` part compiles cleanly — and would likely 400 at runtime. The actual mechanism is `functionResponse.parts[].inlineData`, nested **inside** the functionResponse, and it requires a Gemini 3 model. That exists in js-genai 2.x upstream, not in the 1.x we're on.

Real Gemini passthrough therefore needs a `@google/genai` 1.x → 2.x major bump. That's a deliberate dependency decision, not something to slip in under a bug fix, so it isn't here.

## The change

- **Responses API**: real bytes become `{type:'input_image', image_url:'data:<mime>;base64,<data>'}`.
- **Chat Completions and Gemini**: `[image omitted: this provider cannot carry an image in a tool result (image/png)]`.
- Blocks that are intrinsically broken report the specific defect (missing bytes / missing media type). A media type is never guessed — a wrong one is an API error at best and a mis-decoded image at worst.
- Text-only results keep the string form byte-for-byte on all three paths.

The rule throughout: the failure mode must never be `''`. If an image can't be represented, the model is told an image was produced and dropped, and why.

Also fixes a latent bug in the Anthropic path from #383: an image carrying a media type but no bytes reported "no media type reported by the tool".

## A note on where the type guard lives

`packages/agent/tsconfig.json` excludes `src/**/*.test.ts`, so `tsc --noEmit` never checks test files.

This matters here. The SDK assignability guard was originally written in the test, where it passed happily against a deliberately broken shape. It's now in the implementation instead — `toOpenAIResponsesToolOutput`'s return is annotated as the SDK's own `FunctionCallOutput['output']` — and that placement is proven to bite: writing `image_url` where `input_image` belongs fails with `TS2322`. The provider pushes items into `Array<unknown>`, so the call site would have caught nothing.

## Testing

TDD, following the shape of the existing `tool-result-images.test.ts`. Covers a renderable image, an image missing `mimeType`, an image missing `data`, a mixed text+image result, and text-only (to prove no regression), for each provider path.

Test inputs are constructed from the flat `tools/types` `ContentBlock`, the way real tool results are actually built — verified by tracing the construction sites. The first attempt at #383 fabricated provider-shaped inputs and went green against a shape the system never produces; only `tsc` caught it.

- providers + mcp: **888 passed, 0 failed**. New file: 18/18.
- typecheck and lint clean across all three packages.
- Full-suite E2E failures were confirmed pre-existing by stashing to main and reproducing an identical failure set. None are under `providers/`. They're the cold-boot timeout issue fixed in the companion PR.

## Out of scope, flagged not fixed

`convertToTextOnlyFormat` (`format-converters.ts:382`) and `lmstudio-provider.ts:337` still flatten images to `''`. The former documents the drop as intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
