### PR TITLE
fix(containers): wait for docker to release the container name before returning from remove

### DIFF
--- a/packages/agent/src/containers/__tests__/docker-container.test.ts
+++ b/packages/agent/src/containers/__tests__/docker-container.test.ts
@@ -47,7 +47,7 @@ vi.mock('child_process', () => ({
   spawn: mockSpawn,
 }));
 
-import { DockerContainerRuntime } from '../docker-container';
+import { DockerContainerRuntime, NAME_RELEASE_TIMEOUT_MS } from '../docker-container';
 import { ContainerError, ContainerNotFoundError } from '../types';
 
 function findCallWithSubcommand(sub: string): string[] | undefined {
@@ -354,6 +354,96 @@ describe('DockerContainerRuntime', () => {
 
     it('start throws ContainerNotFoundError on unknown container id', async () => {
       await expect(runtime.start('lace-unknown')).rejects.toBeInstanceOf(ContainerNotFoundError);
+    });
+
+    it('remove does not return until the daemon has released the container name', async () => {
+      // `docker rm -f` returns as soon as the daemon accepts the removal, but the
+      // NAME stays reserved until the removal completes. A re-create in that
+      // window fails with a name Conflict, so remove() must poll the name.
+      const id = await runtime.create({
+        name: 'svc',
+        image: 'alpine:latest',
+        workingDirectory: '/w',
+        mounts: [],
+      });
+
+      // Fake daemon: the name resolves for two more inspects after `rm -f`.
+      let nameLookupsAfterRm = 0;
+      let removed = false;
+      mockExecFile.mockImplementation((...allArgs: unknown[]) => {
+        const args = allArgs[1] as string[];
+        const last = allArgs[allArgs.length - 1] as Callback;
+        if (args[0] === 'rm') {
+          removed = true;
+          last(null, { stdout: '', stderr: '' });
+          return;
+        }
+        if (args[0] === 'inspect') {
+          if (!removed) {
+            last(null, { stdout: `/${id}\n`, stderr: '' });
+            return;
+          }
+          nameLookupsAfterRm += 1;
+          if (nameLookupsAfterRm <= 2) {
+            last(null, { stdout: `${id}\n`, stderr: '' });
+            return;
+          }
+          last(
+            Object.assign(new Error('inspect failed'), {
+              code: 1,
+              stderr: `Error: No such object: ${id}`,
+            })
+          );
+          return;
+        }
+        last(null, { stdout: '', stderr: '' });
+      });
+
+      await runtime.remove(id);
+
+      // It polled until the name was gone rather than returning on the first look.
+      expect(nameLookupsAfterRm).toBe(3);
+      const nameProbes = mockExecFile.mock.calls
+        .map((call) => call[1] as string[])
+        .filter((args) => args[0] === 'inspect' && args.includes(id));
+      expect(nameProbes.length).toBeGreaterThan(1);
+    });
+
+    it('remove throws a bounded timeout error when the name is never released', async () => {
+      vi.useFakeTimers();
+      try {
+        const id = await runtime.create({
+          name: 'svc',
+          image: 'alpine:latest',
+          workingDirectory: '/w',
+          mounts: [],
+        });
+
+        // Fake daemon: the name is held forever.
+        mockExecFile.mockImplementation((...allArgs: unknown[]) => {
+          const args = allArgs[1] as string[];
+          const last = allArgs[allArgs.length - 1] as Callback;
+          if (args[0] === 'inspect') {
+            last(null, { stdout: `/${id}\n`, stderr: '' });
+            return;
+          }
+          last(null, { stdout: '', stderr: '' });
+        });
+
+        const settled = runtime.remove(id).then(
+          () => null,
+          (error: unknown) => error
+        );
+        await vi.advanceTimersByTimeAsync(NAME_RELEASE_TIMEOUT_MS + 1000);
+
+        const error = await settled;
+        expect(error).toBeInstanceOf(ContainerError);
+        expect((error as Error).message).toMatch(
+          /waiting for docker to release the container name/
+        );
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('stop and remove are idempotent when the in-process cache is empty', async () => {

--- a/packages/agent/src/containers/docker-container.ts
+++ b/packages/agent/src/containers/docker-container.ts
@@ -23,6 +23,22 @@ const execFileAsync = promisify(execFile);
 
 const LACE_PREFIX = 'lace-';
 
+/**
+ * `docker rm -f` returns as soon as the daemon accepts the removal request, but
+ * the container's NAME stays reserved in the daemon's registry until the
+ * removal actually finishes. Re-creating under the same name inside that window
+ * fails with `Conflict. The container name "/lace-..." is already in use`, which
+ * is exactly what the create/destroy/re-create resume-after-TTL path does. So
+ * `remove()` polls the name until the daemon lets it go, bounded by this
+ * timeout so a stuck removal surfaces as an error instead of a hang.
+ */
+export const NAME_RELEASE_TIMEOUT_MS = 30_000;
+const NAME_RELEASE_POLL_INTERVAL_MS = 50;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 type ExecFileError = Error & {
   code?: number | string;
   signal?: string;
@@ -298,6 +314,11 @@ export class DockerContainerRuntime extends BaseContainerRuntime {
   }
 
   async remove(containerId: string): Promise<void> {
+    // Resolve the daemon-side NAME before removing. `containerId` may be a name
+    // or a raw docker id, and it is the name — not the id — that a subsequent
+    // create collides on, so the name is what we have to wait on afterwards.
+    const containerName = await this.lookupContainerName(containerId);
+
     // Cache may be empty after a parent restart; `docker rm -f` is idempotent
     // and the NotFound branch below handles the daemon-side "no such container".
     try {
@@ -316,6 +337,67 @@ export class DockerContainerRuntime extends BaseContainerRuntime {
 
     this.containers.delete(containerId);
     this.unregisterMounts(containerId);
+
+    // Local state is already clean, so a caller that ignores the wait still sees
+    // an idempotent remove. The wait exists so the next create under this name
+    // does not race the daemon's asynchronous name release.
+    if (containerName) {
+      await this.waitForNameRelease(containerName);
+    }
+  }
+
+  /**
+   * The daemon-side name of a container, without docker's leading `/`, or null
+   * when the daemon does not know it (already gone, or docker unreachable).
+   */
+  private async lookupContainerName(containerId: string): Promise<string | null> {
+    try {
+      const { stdout } = await execFileAsync(this.dockerBin, [
+        'inspect',
+        '--format',
+        '{{.Name}}',
+        containerId,
+      ]);
+      const name = stdout.trim().replace(/^\//, '');
+      return name.length > 0 ? name : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Poll until the daemon no longer resolves `containerName`. Inspecting by name
+   * goes through the same name registry a create checks, so a NotFound here
+   * means the name is genuinely reusable.
+   */
+  private async waitForNameRelease(containerName: string): Promise<void> {
+    const deadline = Date.now() + NAME_RELEASE_TIMEOUT_MS;
+
+    for (;;) {
+      try {
+        await execFileAsync(this.dockerBin, ['inspect', '--format', '{{.Id}}', containerName]);
+      } catch (error: unknown) {
+        if (this.isNotFoundError(error)) return;
+        // Docker itself is unhappy (missing binary, daemon down). Removal state
+        // is unknowable; don't spin, and don't turn that into a hang.
+        const stderr = (error as ExecFileError).stderr || '';
+        const errMessage = error instanceof Error ? error.message : String(error);
+        logger.warn('docker inspect failed while waiting for name release', {
+          containerId: containerName,
+          error: stderr || errMessage,
+        });
+        return;
+      }
+
+      if (Date.now() >= deadline) {
+        throw new ContainerError(
+          `Timed out after ${NAME_RELEASE_TIMEOUT_MS}ms waiting for docker to release the container name ${containerName}`,
+          containerName
+        );
+      }
+
+      await delay(NAME_RELEASE_POLL_INTERVAL_MS);
+    }
   }
 
   async exec(containerId: string, options: ExecOptions): Promise<ExecResult> {


### PR DESCRIPTION
## The bug

Forced container removal returns as soon as the daemon accepts the request, but the container's **name** stays reserved in the daemon's name registry until the removal actually completes. An immediate re-create under the same name lands inside that window and fails:

```
Conflict. The container name "/lace-..." is already in use by container <64-hex-id>
```

This is a product bug, not a test bug. That create → destroy → recreate sequence is exactly what production performs on the resume-after-TTL path. It surfaced in `persona-container-sharing.integration.test.ts > resume after TTL spawns fresh container`, which failed at the *second* `materializePerInvocation`, immediately after `containerManager.destroy(specName)`.

## The window is real, and measured

Rather than infer it, the polling loop was temporarily instrumented to report how long it actually waits. On the real test path the name was consistently still resolvable after removal returned:

```
[PROBE] name=lace-d40e0d53-test-shell-c748ec22 polls=1 waitedMs=117
[PROBE] name=lace-5cadd3ba-test-shell-b8f9e30c polls=1 waitedMs=84
[PROBE] name=lace-b1999cb5-test-shell-cf795e75 polls=1 waitedMs=83
[PROBE] name=lace-8c91afaa-test-shell-bec2b2ee polls=1 waitedMs=84
```

So the name outlives removal by roughly 80–120 ms on this daemon (Docker 29.4.1).

## The id-vs-name trap

`remove()` takes a `containerId`, but the thing that blocks a re-create is the **name**. Those are not reliably the same:

1. On every current call path the "id" passed to `remove()` is in fact a name — `create()` returns the container name as its id, `list()` reports names as ids, and `resolveBySpecName()` produces `lace-<spec>`.
2. That is an accident of the current callers, not a guarantee. `remove()`'s contract accepts a docker id, and forced removal happily takes one.

So polling the argument directly would work today and silently stop working the moment someone passes a hex id — waiting for the *container* to leave the store while the *name* is what's still held. It would look correct and fix nothing.

This change therefore resolves the daemon-side name explicitly **before** removal (`inspect --format {{.Name}}`, stripping the leading `/`) and polls that name afterwards. Inspecting by name goes through the same registry a create checks, so NotFound there means the name is genuinely reusable.

## The change

`packages/agent/src/containers/docker-container.ts`:

- `remove()` captures the daemon-side name first, performs the existing forced removal (unchanged — still NotFound-tolerant, still swallows other errors with a warning), clears local cache and mount state, then waits for the name.
- `lookupContainerName()` returns null when the daemon doesn't know the container, so the idempotent path (`remove('lace-unknown')` after a parent restart, with an empty cache) skips the wait entirely and stays a no-op.
- `waitForNameRelease()` polls every 50 ms, bounded by `NAME_RELEASE_TIMEOUT_MS = 30_000`, and throws a `ContainerError` naming the container on expiry. A bounded wait is the point: an unbounded one converts a transient race into a hang. If docker itself errors in a non-NotFound way (daemon down, binary missing) it logs and returns rather than spinning.
- Cache cleanup happens *before* the wait, deliberately, so a caller that ignores the returned promise still gets clean local state.

## Tests

Two new deterministic tests in `containers/__tests__/docker-container.test.ts` — stubbed `child_process`, no real Docker:

- A fake daemon keeps the name resolvable for two polls after removal, then reports NotFound. Asserts `remove()` polled until it was gone rather than returning on the first look.
- A fake daemon holds the name forever. With fake timers, asserts a `ContainerError` after the bounded timeout.

## Verification

Measured in the same window, with a sibling agent's full vitest suite loading the daemon:

| | `resume after TTL spawns fresh container` |
|---|---|
| Before (initial) | 0/4 passed |
| Before (event-traced loop) | 2/6 passed |
| Before (re-measured, change stashed) | 3/8 passed |
| **After** | **12/12 passed** |
| **After (second batch)** | **10/10 passed** |

Whole file: 5/5 with default parallelism, plus 8/8 serialized. `src/containers/`: 178 passed, 13 skipped. Typecheck and lint clean.

## An honest limit on the explanation

Standalone probe scripts — tight create/start/remove/create loops, with and without the `lace-` prefix, 8-way concurrent, 96 cycles each — produced **zero** conflicts. The window only opened on the real path, which does `stop -t 10` before removing. Because `sleep infinity` as PID 1 ignores SIGTERM, that stop blocks the full 10 seconds and the container is torn down under different daemon conditions.

Why the preceding stop widens the window is not explained here. The instrumented measurement is direct evidence that it does, and the fix is verified against the real failing test, but the understanding stops at "the name is held for ~100 ms after removal on this path" rather than a full account of the daemon's locking.

## Sibling paths deliberately not changed

- `stop()` — `docker stop` does not remove the container, so no name is released. No race.
- `PlaneContainerRuntime.remove()` (`plane-runtime.ts:197`) — same shape, but routed through the sen-docker shim, which owns removal semantics and lives outside this repo. Theoretically exposed; the equivalent fix belongs there.
- `AppleContainerRuntime.remove()` (`apple-container.ts:314`) — same shape against Apple's `container` CLI. macOS-only and unverifiable from here, so no guess was made about whether Apple's runtime releases names asynchronously too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
