### PR TITLE
test(agent): clean up temp directories the test suites leak

### DIFF
--- a/packages/agent/src/__tests__/server.reminder-scheduler-rebind.test.ts
+++ b/packages/agent/src/__tests__/server.reminder-scheduler-rebind.test.ts
@@ -2,15 +2,27 @@
 // ABOUTME: when the timezone is unset, per spec §1.4.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ensureReminderSchedulerForActiveSession } from '../server';
 import type { AgentServerState } from '../server-types';
 
+// Tempdirs handed out by tempSessionDir, tracked so the file-level afterEach
+// below removes them even when a test throws.
+const tempSessionDirs: string[] = [];
+
 function tempSessionDir(): string {
-  return mkdtempSync(join(tmpdir(), 'lace-tz-degrade-'));
+  const dir = mkdtempSync(join(tmpdir(), 'lace-tz-degrade-'));
+  tempSessionDirs.push(dir);
+  return dir;
 }
+
+afterEach(() => {
+  for (const dir of tempSessionDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 function makeMinimalState(dir: string): AgentServerState {
   return {

--- a/packages/agent/src/notifications/__tests__/inject-notification.test.ts
+++ b/packages/agent/src/notifications/__tests__/inject-notification.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Unit tests for injectNotification — writes context_injected event with
 // ABOUTME: priority='immediate' and triggers idle-wake when targeting active session.
 
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -9,8 +9,19 @@ import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { injectNotification } from '../inject-notification';
 import { readDurableEvents, invalidatePersonaCache } from '../../storage/event-log';
 
+// Lace dirs handed out by tempSessionDir, tracked so the file-level afterEach
+// below removes them even when a test throws.
+const tempLaceDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempLaceDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 function tempSessionDir(): { laceDir: string; sessionDir: string } {
   const laceDir = mkdtempSync(join(tmpdir(), 'lace-inject-test-'));
+  tempLaceDirs.push(laceDir);
   const sessionId = `sess_${randomUUID()}`;
   const sessionDir = join(laceDir, 'agent-sessions', sessionId);
   mkdirSync(sessionDir, { recursive: true });

--- a/packages/agent/src/projects/project.test.ts
+++ b/packages/agent/src/projects/project.test.ts
@@ -1,10 +1,10 @@
 // ABOUTME: Tests for Project class functionality including CRUD operations
 // ABOUTME: Covers project creation, persistence, updates, and cleanup with proper test isolation
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Project } from './project';
 import { setupCoreTest } from '@lace/agent/test-utils/core-test-setup';
-import { existsSync, mkdirSync, mkdtempSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { getProcessTempDir } from '@lace/agent/config/lace-dir';
@@ -327,8 +327,20 @@ describe('Project', () => {
   });
 
   describe('MCP Server Management', () => {
+    // Tempdirs handed out by makeUniqueTempProjectDir, removed by afterEach even
+    // when a test throws.
+    const projectTempDirs: string[] = [];
+
+    afterEach(() => {
+      for (const dir of projectTempDirs.splice(0)) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     function makeUniqueTempProjectDir(): string {
-      return mkdtempSync(join(tmpdir(), 'lace-project-test-'));
+      const dir = mkdtempSync(join(tmpdir(), 'lace-project-test-'));
+      projectTempDirs.push(dir);
+      return dir;
     }
     it('should start async discovery when adding MCP server', async () => {
       const { ToolCatalog } = await import('@lace/agent/tools/tool-catalog');

--- a/packages/agent/src/reminders/__tests__/e2e.test.ts
+++ b/packages/agent/src/reminders/__tests__/e2e.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: → notifier composes a valid <notification kind="reminder"> via wrapper.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ReminderScheduler } from '../scheduler';
@@ -10,9 +10,21 @@ import { ManageRemindersTool } from '@lace/agent/tools/implementations/manage_re
 import { buildNotification, composeReminderBody } from '@lace/agent/notifications';
 import type { ToolContext } from '@lace/agent/tools/types';
 
+// Tempdirs handed out by tempSessionDir, tracked so the file-level afterEach
+// below removes them even when a test throws.
+const tempSessionDirs: string[] = [];
+
 function tempSessionDir(): string {
-  return mkdtempSync(join(tmpdir(), 'lace-reminders-e2e-'));
+  const dir = mkdtempSync(join(tmpdir(), 'lace-reminders-e2e-'));
+  tempSessionDirs.push(dir);
+  return dir;
 }
+
+afterEach(() => {
+  for (const dir of tempSessionDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe('Reminders end-to-end (tool → scheduler → notifier)', () => {
   const origTZ = process.env.TZ;

--- a/packages/agent/src/reminders/__tests__/scheduler.test.ts
+++ b/packages/agent/src/reminders/__tests__/scheduler.test.ts
@@ -4,7 +4,7 @@
 // ABOUTME: Also covers schedule/cancel/list APIs (Task 7).
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ReminderScheduler } from '../scheduler';
@@ -12,9 +12,21 @@ import { ReminderStore } from '../store';
 import type { ReminderRow } from '../types';
 import { logger } from '@lace/agent/utils/logger';
 
+// Tempdirs handed out by tempSessionDir, tracked so the file-level afterEach
+// below removes them even when a test throws.
+const tempSessionDirs: string[] = [];
+
 function tempSessionDir(): string {
-  return mkdtempSync(join(tmpdir(), 'lace-rsched-'));
+  const dir = mkdtempSync(join(tmpdir(), 'lace-rsched-'));
+  tempSessionDirs.push(dir);
+  return dir;
 }
+
+afterEach(() => {
+  for (const dir of tempSessionDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 function makeRow(overrides: Partial<ReminderRow> = {}): ReminderRow {
   return {

--- a/packages/agent/src/reminders/__tests__/store.test.ts
+++ b/packages/agent/src/reminders/__tests__/store.test.ts
@@ -1,13 +1,25 @@
-import { describe, it, expect } from 'vitest';
-import { mkdtempSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { afterEach, describe, it, expect } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ReminderStore } from '../store';
 import type { ReminderRow } from '../types';
 
+// Tempdirs handed out by tempSessionDir, tracked so the file-level afterEach
+// below removes them even when a test throws.
+const tempSessionDirs: string[] = [];
+
 function tempSessionDir(): string {
-  return mkdtempSync(join(tmpdir(), 'lace-reminders-'));
+  const dir = mkdtempSync(join(tmpdir(), 'lace-reminders-'));
+  tempSessionDirs.push(dir);
+  return dir;
 }
+
+afterEach(() => {
+  for (const dir of tempSessionDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 function exampleRow(id = 'reminder_abc123abc123'): ReminderRow {
   return {

--- a/packages/agent/src/storage/__tests__/inject-tailer.test.ts
+++ b/packages/agent/src/storage/__tests__/inject-tailer.test.ts
@@ -45,11 +45,13 @@ function writeShard(
 }
 
 describe('readNewCompleteLines', () => {
+  let dir: string;
   let f: string;
   beforeEach(() => {
-    f = join(mkdtempSync(join(tmpdir(), 'lace-tail-')), 'events.jsonl');
+    dir = mkdtempSync(join(tmpdir(), 'lace-tail-'));
+    f = join(dir, 'events.jsonl');
   });
-  afterEach(() => rmSync(f, { recursive: true, force: true }));
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
   it('returns only newline-terminated lines and advances the offset past them', () => {
     writeFileSync(f, 'a\nb\n', 'utf8');

--- a/packages/agent/src/tools/__tests__/executor-persona-wiring.test.ts
+++ b/packages/agent/src/tools/__tests__/executor-persona-wiring.test.ts
@@ -12,11 +12,16 @@ import { DelegateTool } from '../implementations/delegate';
 import type { JobManager } from '@lace/agent/jobs/job-manager';
 import type { JobState } from '@lace/agent/server-types';
 
+// Tempdirs created by makePersonaRegistry within a single test, so afterEach
+// can clean them up. Reset per-test in beforeEach.
+let bundleTempdirs: string[] = [];
+
 function makePersonaRegistry(userPersonasDir: string): PersonaRegistry {
   // bundledPersonasPath points at a real directory containing only system
   // personas — pointing it at userPersonasDir would shadow what we're trying
   // to assert. The registry tolerates an empty bundled path.
   const emptyBundle = mkdtempSync(join(tmpdir(), 'lace-bundle-empty-'));
+  bundleTempdirs.push(emptyBundle);
   return new PersonaRegistry({
     bundledPersonasPath: emptyBundle,
     userPersonasPaths: [userPersonasDir],
@@ -28,6 +33,7 @@ describe('ToolExecutor.registerAllAvailableTools threads PersonaRegistry into De
   let userPersonasDir: string;
 
   beforeEach(() => {
+    bundleTempdirs = [];
     tempDir = mkdtempSync(join(tmpdir(), 'lace-tool-persona-'));
     userPersonasDir = join(tempDir, 'personas');
     mkdirSync(userPersonasDir, { recursive: true });
@@ -35,7 +41,9 @@ describe('ToolExecutor.registerAllAvailableTools threads PersonaRegistry into De
   });
 
   afterEach(() => {
-    rmSync(tempDir, { recursive: true, force: true });
+    for (const dir of [tempDir, ...bundleTempdirs]) {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('DelegateTool resolves a user persona that only exists in the supplied registry', async () => {

--- a/packages/agent/src/tools/exec/__tests__/exec-tool-adapter-cwd.test.ts
+++ b/packages/agent/src/tools/exec/__tests__/exec-tool-adapter-cwd.test.ts
@@ -23,12 +23,12 @@ process.stdin.on('end', () => {
 });
 `;
 
-function makeBin(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'lace-cwd-bin-'));
-  const bin = join(dir, 'echo-cwd');
+function makeBin(): { binDir: string; bin: string } {
+  const binDir = mkdtempSync(join(tmpdir(), 'lace-cwd-bin-'));
+  const bin = join(binDir, 'echo-cwd');
   writeFileSync(bin, CWD_ECHO_SCRIPT);
   chmodSync(bin, 0o755);
-  return bin;
+  return { binDir, bin };
 }
 
 const credentialDescriptor: ExecToolDescriptor = {
@@ -49,18 +49,30 @@ function resultText(result: ToolResult): string {
 }
 
 describe('ExecToolAdapter spawn cwd (M1)', () => {
+  let binDir: string;
   let binPath: string;
   let hostTmp: string;
+  // Extra tempdirs a single test creates, removed by afterEach even on failure.
+  const extraTempDirs: string[] = [];
 
   beforeEach(() => {
-    binPath = makeBin();
+    ({ binDir, bin: binPath } = makeBin());
     hostTmp = realpathSync(mkdtempSync(join(tmpdir(), 'lace-cwd-tmp-')));
   });
 
   afterEach(() => {
-    rmSync(binPath, { recursive: true, force: true });
+    rmSync(binDir, { recursive: true, force: true });
     rmSync(hostTmp, { recursive: true, force: true });
+    for (const dir of extraTempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
+
+  function makeOtherToolTempDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'lace-cwd-other-'));
+    extraTempDirs.push(dir);
+    return realpathSync(dir);
+  }
 
   it('uses host-valid toolTempDir (not the container workingDirectory) for a trusted credential tool', async () => {
     const adapter = new ExecToolAdapter(binPath, credentialDescriptor, 'request_credential', true);
@@ -87,7 +99,7 @@ describe('ExecToolAdapter spawn cwd (M1)', () => {
         activeSessionId: 'sess-1',
         persona: 'engineer',
         workingDirectory: hostTmp, // host-valid working dir
-        toolTempDir: realpathSync(mkdtempSync(join(tmpdir(), 'lace-cwd-other-'))),
+        toolTempDir: makeOtherToolTempDir(),
       }
     );
     const cwd = realpathSync(resultText(result));

--- a/packages/agent/src/tools/implementations/__tests__/manage_reminders.test.ts
+++ b/packages/agent/src/tools/implementations/__tests__/manage_reminders.test.ts
@@ -2,14 +2,26 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { parseManageRemindersInput, ManageRemindersTool } from '../manage_reminders';
 import { ReminderScheduler, ReminderStore } from '@lace/agent/reminders';
 import type { ReminderRow } from '@lace/agent/reminders';
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { ToolContext } from '@lace/agent/tools/types';
 
+// Tempdirs handed out by tempSessionDir, tracked so the file-level afterEach
+// below removes them even when a test throws.
+const tempSessionDirs: string[] = [];
+
 function tempSessionDir(): string {
-  return mkdtempSync(join(tmpdir(), 'lace-mr-tool-'));
+  const dir = mkdtempSync(join(tmpdir(), 'lace-mr-tool-'));
+  tempSessionDirs.push(dir);
+  return dir;
 }
+
+afterEach(() => {
+  for (const dir of tempSessionDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 function ctxWithScheduler(sched: ReminderScheduler): ToolContext {
   return {
@@ -260,7 +272,7 @@ describe('ManageRemindersTool cancel persist_failed', () => {
   });
 
   it('cancel surfaces retry_safe:true on persist_failed', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'lace-mr-tool-'));
+    const dir = tempSessionDir();
     const sched = new ReminderScheduler({
       sessionDir: dir,
       now: () => 0,

--- a/packages/agent/src/tools/runtime/__tests__/bounded-host.test.ts
+++ b/packages/agent/src/tools/runtime/__tests__/bounded-host.test.ts
@@ -1,19 +1,38 @@
-import { access, mkdtemp, mkdir, realpath, symlink, writeFile } from 'node:fs/promises';
+import { access, mkdtemp, mkdir, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { BoundedHostToolRuntime } from '../bounded-host';
 
+// Tempdirs created by makeRuntime and makeOutsideDir, tracked so afterEach
+// removes them even when a test throws.
+const tempDirs: string[] = [];
+
+async function makeOutsideDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'lace-bounded-host-outside-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
 describe('BoundedHostToolRuntime', () => {
+  afterEach(async () => {
+    for (const dir of tempDirs.splice(0)) {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   function makeRuntime(prefix = 'lace-bounded-host-runtime-') {
-    return mkdtemp(join(tmpdir(), prefix)).then((root) => ({
-      root,
-      runtime: new BoundedHostToolRuntime({
-        id: 'rt_bounded',
+    return mkdtemp(join(tmpdir(), prefix)).then((root) => {
+      tempDirs.push(root);
+      return {
         root,
-        cwd: root,
-      }),
-    }));
+        runtime: new BoundedHostToolRuntime({
+          id: 'rt_bounded',
+          root,
+          cwd: root,
+        }),
+      };
+    });
   }
 
   it('resolves relative paths against cwd', async () => {
@@ -41,7 +60,7 @@ describe('BoundedHostToolRuntime', () => {
 
   it('rejects absolute paths outside the bounded root', async () => {
     const { runtime } = await makeRuntime();
-    const outside = await mkdtemp(join(tmpdir(), 'lace-bounded-host-outside-'));
+    const outside = await makeOutsideDir();
 
     await expect(runtime.paths.resolve(outside)).rejects.toThrow(/outside bounded host root/i);
   });
@@ -56,7 +75,7 @@ describe('BoundedHostToolRuntime', () => {
 
   it('rejects symlink reads that escape the bounded root', async () => {
     const { runtime, root } = await makeRuntime();
-    const outsideRoot = await mkdtemp(join(tmpdir(), 'lace-bounded-host-outside-'));
+    const outsideRoot = await makeOutsideDir();
     const outsideFile = join(outsideRoot, 'secret.txt');
     await writeFile(outsideFile, 'outside secret', 'utf8');
     await symlink(outsideFile, join(root, 'secret-link.txt'));
@@ -68,7 +87,7 @@ describe('BoundedHostToolRuntime', () => {
 
   it('rejects symlink stats that escape the bounded root', async () => {
     const { runtime, root } = await makeRuntime();
-    const outsideRoot = await mkdtemp(join(tmpdir(), 'lace-bounded-host-outside-'));
+    const outsideRoot = await makeOutsideDir();
     const outsideFile = join(outsideRoot, 'secret.txt');
     await writeFile(outsideFile, 'outside secret', 'utf8');
     await symlink(outsideFile, join(root, 'secret-link.txt'));
@@ -80,7 +99,7 @@ describe('BoundedHostToolRuntime', () => {
 
   it('rejects symlink readdir that escape the bounded root', async () => {
     const { runtime, root } = await makeRuntime();
-    const outsideRoot = await mkdtemp(join(tmpdir(), 'lace-bounded-host-outside-'));
+    const outsideRoot = await makeOutsideDir();
     const outsideDir = join(outsideRoot, 'nested');
     await mkdir(outsideDir);
     await symlink(outsideDir, join(root, 'outside-link'));
@@ -92,7 +111,7 @@ describe('BoundedHostToolRuntime', () => {
 
   it('rejects symlinked writes that escape the bounded root', async () => {
     const { runtime, root } = await makeRuntime();
-    const outsideRoot = await mkdtemp(join(tmpdir(), 'lace-bounded-host-outside-'));
+    const outsideRoot = await makeOutsideDir();
     await symlink(outsideRoot, join(root, 'outside-link'));
 
     const path = await runtime.paths.resolve('outside-link/new.txt');
@@ -105,7 +124,7 @@ describe('BoundedHostToolRuntime', () => {
 
   it('rejects process cwd overrides that escape bounded root', async () => {
     const { runtime } = await makeRuntime();
-    const outside = await mkdtemp(join(tmpdir(), 'lace-bounded-host-outside-'));
+    const outside = await makeOutsideDir();
 
     await expect(
       runtime.process.exec(['node', '-e', "process.stdout.write('spawned')"], { cwd: outside })

--- a/packages/agent/src/tools/runtime/__tests__/host.test.ts
+++ b/packages/agent/src/tools/runtime/__tests__/host.test.ts
@@ -1,16 +1,29 @@
-import { mkdtemp, readFile, realpath, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { HostToolRuntime } from '../host';
 
+// Tempdirs handed out by makeTempDir, tracked so afterEach removes them even
+// when a test throws.
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'lace-host-runtime-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
 describe('HostToolRuntime', () => {
-  afterEach(() => {
+  afterEach(async () => {
     vi.unstubAllGlobals();
+    for (const dir of tempDirs.splice(0)) {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   it('resolves relative paths against cwd and reads files', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'lace-host-runtime-'));
+    const dir = await makeTempDir();
     await writeFile(join(dir, 'file.txt'), 'hello', 'utf8');
 
     const runtime = new HostToolRuntime({ id: 'rt_host', cwd: dir });
@@ -22,7 +35,7 @@ describe('HostToolRuntime', () => {
   });
 
   it('executes commands in cwd', async () => {
-    const dir = await realpath(await mkdtemp(join(tmpdir(), 'lace-host-runtime-')));
+    const dir = await realpath(await makeTempDir());
     const runtime = new HostToolRuntime({ id: 'rt_host', cwd: dir });
 
     const result = await runtime.process.exec([
@@ -36,7 +49,7 @@ describe('HostToolRuntime', () => {
   });
 
   it('returns structured results for commands that exit non-zero', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'lace-host-runtime-'));
+    const dir = await makeTempDir();
     const runtime = new HostToolRuntime({ id: 'rt_host', cwd: dir });
 
     const result = await runtime.process.exec([
@@ -51,7 +64,7 @@ describe('HostToolRuntime', () => {
   });
 
   it('applies default environment to exec commands', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'lace-host-runtime-'));
+    const dir = await makeTempDir();
     const runtime = new HostToolRuntime({
       id: 'rt_host',
       cwd: dir,
@@ -69,7 +82,7 @@ describe('HostToolRuntime', () => {
   });
 
   it('does not expose default environment through JSON serialization', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'lace-host-runtime-'));
+    const dir = await makeTempDir();
     const runtime = new HostToolRuntime({
       id: 'rt_host',
       cwd: dir,
@@ -80,7 +93,7 @@ describe('HostToolRuntime', () => {
   });
 
   it('rejects start completion when spawn fails', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'lace-host-runtime-'));
+    const dir = await makeTempDir();
     const runtime = new HostToolRuntime({ id: 'rt_host', cwd: dir });
 
     const handle = await runtime.process.start(['lace-host-runtime-missing-command']);
@@ -89,7 +102,7 @@ describe('HostToolRuntime', () => {
   });
 
   it('rejects start completion when the process is aborted', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'lace-host-runtime-'));
+    const dir = await makeTempDir();
     const runtime = new HostToolRuntime({ id: 'rt_host', cwd: dir });
     const abortController = new AbortController();
 
@@ -102,7 +115,7 @@ describe('HostToolRuntime', () => {
   });
 
   it('writes text files through runtime fs', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'lace-host-runtime-'));
+    const dir = await makeTempDir();
     const runtime = new HostToolRuntime({ id: 'rt_host', cwd: dir });
     const path = await runtime.paths.resolve('out.txt');
 
@@ -112,7 +125,7 @@ describe('HostToolRuntime', () => {
   });
 
   it('passes redirect mode to global fetch', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'lace-host-runtime-'));
+    const dir = await makeTempDir();
     const runtime = new HostToolRuntime({ id: 'rt_host', cwd: dir });
     const mockFetch = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>().mockResolvedValue(
       new Response('ok', {
@@ -133,7 +146,7 @@ describe('HostToolRuntime', () => {
   });
 
   it('enforces fetch maxBytes while streaming the response body', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'lace-host-runtime-'));
+    const dir = await makeTempDir();
     const runtime = new HostToolRuntime({ id: 'rt_host', cwd: dir });
     const arrayBuffer = vi.fn(() => {
       throw new Error('arrayBuffer should not be called');


### PR DESCRIPTION
## The problem

Several test suites `mkdtemp` per test and never remove the directory. `/tmp` on the dev box that surfaced this holds **4,455** `lace-*` directories going back three weeks; a single measured session of 16 full-suite runs left ~1,900 behind.

No test failures result from this — it is unbounded disk growth on dev boxes and CI.

## Scope

141 files under `packages/agent/src` call `mkdtemp`; only 15 prefixes actually leak. The majority already clean up correctly, so this follows the convention already present in `runner.persona-registry.test.ts` — a tracked array of directories drained in `afterEach` — rather than inventing one.

Every removal uses the value `mkdtemp`/`mkdtempSync` actually returned. No path is ever constructed from a prefix, a glob, or a pattern.

Cleanup lives in `afterEach` so a throwing test still cleans up. Nothing in these files suggested deliberate retention for debugging — no comments to that effect anywhere — so nothing was left leaking on purpose.

## Two sites were removing the wrong path

Which is why they leaked while looking like they cleaned up:

- **`exec-tool-adapter-cwd.test.ts`** — `makeBin()` returned the binary path and `afterEach` removed *the file*, orphaning its parent tempdir. Now returns `{ binDir, bin }`.
- **`inject-tailer.test.ts`** — `afterEach` removed `events.jsonl`, orphaning the directory that held it. Now captures and removes the directory.

## Prefix → file, all confirmed by grep

| Prefix | File (under `packages/agent/src/`) |
|---|---|
| `lace-rsched-` | `reminders/__tests__/scheduler.test.ts` |
| `lace-reminders-` | `reminders/__tests__/store.test.ts` |
| `lace-reminders-e2e-` | `reminders/__tests__/e2e.test.ts` |
| `lace-mr-tool-` | `tools/implementations/__tests__/manage_reminders.test.ts` |
| `lace-tz-degrade-` | `__tests__/server.reminder-scheduler-rebind.test.ts` |
| `lace-inject-test-` | `notifications/__tests__/inject-notification.test.ts` |
| `lace-host-runtime-` | `tools/runtime/__tests__/host.test.ts` |
| `lace-bounded-host-runtime-`, `lace-bounded-host-outside-` | `tools/runtime/__tests__/bounded-host.test.ts` |
| `lace-cwd-bin-`, `lace-cwd-other-` | `tools/exec/__tests__/exec-tool-adapter-cwd.test.ts` |
| `lace-tail-` | `storage/__tests__/inject-tailer.test.ts` |
| `lace-project-test-` | `projects/project.test.ts` |
| `lace-bundle-empty-` | `tools/__tests__/executor-persona-wiring.test.ts` |
| `lace-agent-delegate-store-` | **no source in the repo** |

That last row is worth noting: nothing in the tree, docs included, contains that string. Those directories are archaeology — left by code that no longer exists, or by sen-core rather than lace.

## Measurement

Measured with `TMPDIR` pointed at a private scratch directory, so other agents running suites on the same box could not skew the count. Same full `packages/agent` suite, baseline vs. fixed:

- **Before: 86** leaked `lace-*` directories (25 `rsched`, 11 `bounded-host-runtime`, 10 `host-runtime`, 6 each of `reminders` / `mr-tool` / `inject-test` / `bounded-host-outside`, plus the rest).
- **After: 7.** All 15 targeted prefixes at **zero**.

The 7 residual are `lace-runtime-<pid>-<ts>-` directories — a different leak, from no file touched here. Small but real.

`npm run typecheck` and `npm run lint` clean. The 12 touched suites: 122 tests, all passing.

## The existing backlog was not touched

Nothing was deleted from `/tmp`. The count moved between 4,500 and 4,900 *during* the measurement session, meaning other processes are actively creating and using `lace-*` directories — an unconditional sweep would pull a directory out from under a running process.

If the backlog is to be cleared, restricting to directories older than a day is the safe form:

```
find /tmp -maxdepth 1 -name 'lace-*' -type d -mmin +1440 -exec rm -rf {} +
```

That is left as an operator decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
