### PR TITLE
fix(gemini): carry tool-result images in functionResponse.parts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,13 @@
     "": {
       "name": "lace-monorepo",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
         "@anthropic-ai/sdk": "^0.114.0",
-        "@google/genai": "^1.19.0",
+        "@google/genai": "^2.21.0",
         "@lmstudio/sdk": "^1.2.1",
         "@typescript-eslint/utils": "^8.39.1",
         "mustache": "^4.2.0",
@@ -1553,17 +1554,22 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.20.0",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.21.0.tgz",
+      "integrity": "sha512-+PDtco2/Z0ONdzCGekCoCT+O1VJS9xJQNN4XzQpXG/t3El/SWWMkCWlFRO1KmivOHPa4Q0VjUYu1HBKCZ/v33Q==",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "google-auth-library": "^9.14.2",
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
         "ws": "^8.18.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.11.4"
+        "@modelcontextprotocol/sdk": "^1.25.2"
       },
       "peerDependenciesMeta": {
         "@modelcontextprotocol/sdk": {
@@ -1572,10 +1578,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.7",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1963,10 +1971,12 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.25.1",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.7",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -1974,14 +1984,15 @@
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "jose": "^6.1.1",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
         "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.0"
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
@@ -2412,6 +2423,63 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.50.2",
@@ -3352,11 +3420,16 @@
     },
     "node_modules/@types/node": {
       "version": "22.18.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
     },
     "node_modules/@types/sarif": {
       "version": "2.1.7",
@@ -4111,28 +4184,13 @@
     },
     "node_modules/accepts": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
       },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/accepts/node_modules/mime-types": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/accepts/node_modules/negotiator": {
-      "version": "1.0.0",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -4152,6 +4210,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -4483,6 +4550,8 @@
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -4542,21 +4611,40 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.0",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/bowser": {
@@ -4605,6 +4693,8 @@
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/bun-types": {
@@ -4941,17 +5031,22 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.0",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4966,6 +5061,8 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
@@ -5153,6 +5250,8 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5219,6 +5318,8 @@
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -5226,6 +5327,8 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
@@ -5235,6 +5338,8 @@
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5445,6 +5550,8 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -5815,6 +5922,8 @@
     },
     "node_modules/etag": {
       "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5899,16 +6008,19 @@
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -5939,8 +6051,14 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
       "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -5951,18 +6069,10 @@
         "express": ">= 4.11"
       }
     },
-    "node_modules/express/node_modules/mime-types": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/extend": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
     "node_modules/extend-shallow": {
@@ -6144,7 +6254,9 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.1.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -6155,7 +6267,11 @@
         "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -6242,6 +6358,8 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6249,6 +6367,8 @@
     },
     "node_modules/fresh": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6318,92 +6438,31 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "6.7.1",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9",
-        "uuid": "^9.0.1"
+        "node-fetch": "^3.3.2"
       },
       "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/gaxios/node_modules/agent-base": {
-      "version": "7.1.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/gaxios/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/gaxios/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/gaxios/node_modules/tr46": {
-      "version": "0.0.3",
-      "license": "MIT"
-    },
-    "node_modules/gaxios/node_modules/uuid": {
-      "version": "9.0.1",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/gaxios/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/gaxios/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "6.1.1",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "gaxios": "^6.1.1",
-        "google-logging-utils": "^0.0.2",
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
         "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/get-caller-file": {
@@ -6589,22 +6648,26 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.15.1",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^6.1.1",
-        "gcp-metadata": "^6.1.0",
-        "gtoken": "^7.0.0",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/google-logging-utils": {
-      "version": "0.0.2",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -6667,17 +6730,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/gtoken": {
-      "version": "7.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "gaxios": "^6.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/has-bigints": {
@@ -6763,9 +6815,10 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.11.3",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6776,24 +6829,36 @@
       "license": "MIT"
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -6819,13 +6884,19 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -6902,8 +6973,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -7198,6 +7280,8 @@
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -7244,6 +7328,7 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7475,6 +7560,8 @@
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0"
@@ -7545,6 +7632,8 @@
     },
     "node_modules/jwa": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
@@ -7553,10 +7642,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "4.0.0",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^2.0.0",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -7744,6 +7835,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "dev": true,
@@ -7799,14 +7896,22 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7850,9 +7955,27 @@
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-fn": {
@@ -8065,6 +8188,35 @@
       "version": "1.4.0",
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/node-abi": {
       "version": "3.92.0",
       "license": "MIT",
@@ -8262,6 +8414,8 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -8405,6 +8559,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "dev": true,
@@ -8422,6 +8589,8 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -8641,8 +8810,33 @@
         "asap": "~2.0.3"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
+      "integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -8780,10 +8974,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -8819,37 +9016,31 @@
       "license": "MIT"
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.7.0",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/rc": {
@@ -8994,6 +9185,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/rettime": {
       "version": "0.7.0",
       "dev": true,
@@ -9053,6 +9253,8 @@
     },
     "node_modules/router": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -9066,7 +9268,9 @@
       }
     },
     "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.3.0",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -9163,6 +9367,8 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/section-matter": {
@@ -9185,37 +9391,35 @@
       }
     },
     "node_modules/send": {
-      "version": "1.2.0",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
+        "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
         "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "statuses": "^2.0.2"
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/send/node_modules/mime-types": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
       },
-      "engines": {
-        "node": ">= 0.6"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/serve-static": {
-      "version": "2.2.0",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -9225,6 +9429,10 @@
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-function-length": {
@@ -9272,6 +9480,8 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
     "node_modules/shebang-command": {
@@ -9292,12 +9502,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -9309,11 +9521,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9897,6 +10111,8 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -10136,25 +10352,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/type-is/node_modules/mime-types": {
-      "version": "3.0.1",
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -10279,7 +10504,6 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -10292,6 +10516,8 @@
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -10948,7 +11174,7 @@
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.32.0",
         "@anthropic-ai/sdk": "^0.114.0",
-        "@google/genai": "^1.19.0",
+        "@google/genai": "^2.21.0",
         "@lace/ent-protocol": "file:../ent-protocol",
         "@lmstudio/sdk": "^1.2.1",
         "@modelcontextprotocol/sdk": "^1.17.5",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.114.0",
-    "@google/genai": "^1.19.0",
+    "@google/genai": "^2.21.0",
     "@lmstudio/sdk": "^1.2.1",
     "@typescript-eslint/utils": "^8.39.1",
     "mustache": "^4.2.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@anthropic-ai/bedrock-sdk": "^0.32.0",
     "@anthropic-ai/sdk": "^0.114.0",
-    "@google/genai": "^1.19.0",
+    "@google/genai": "^2.21.0",
     "@lace/ent-protocol": "file:../ent-protocol",
     "@lmstudio/sdk": "^1.2.1",
     "@modelcontextprotocol/sdk": "^1.17.5",

--- a/packages/agent/src/providers/__tests__/assistant-content-normalization.test.ts
+++ b/packages/agent/src/providers/__tests__/assistant-content-normalization.test.ts
@@ -60,14 +60,14 @@ describe('assistant text content: string and single-text-block array convert ide
   });
 
   it('Gemini — plain assistant text', () => {
-    expect(JSON.stringify(convertToGeminiFormat(asString))).toBe(
-      JSON.stringify(convertToGeminiFormat(asBlocks))
+    expect(JSON.stringify(convertToGeminiFormat(asString, 'gemini-3-pro-preview'))).toBe(
+      JSON.stringify(convertToGeminiFormat(asBlocks, 'gemini-3-pro-preview'))
     );
   });
 
   it('Gemini — assistant text with tool call', () => {
-    expect(JSON.stringify(convertToGeminiFormat(asStringWithCall))).toBe(
-      JSON.stringify(convertToGeminiFormat(asBlocksWithCall))
+    expect(JSON.stringify(convertToGeminiFormat(asStringWithCall, 'gemini-3-pro-preview'))).toBe(
+      JSON.stringify(convertToGeminiFormat(asBlocksWithCall, 'gemini-3-pro-preview'))
     );
   });
 

--- a/packages/agent/src/providers/__tests__/converter-determinism.test.ts
+++ b/packages/agent/src/providers/__tests__/converter-determinism.test.ts
@@ -24,8 +24,8 @@ describe('converter determinism: each converter is a pure function of its input'
       expect(JSON.stringify(convertToOpenAIFormat(fixture.messages))).toBe(
         JSON.stringify(convertToOpenAIFormat(fixture.messages))
       );
-      expect(JSON.stringify(convertToGeminiFormat(fixture.messages))).toBe(
-        JSON.stringify(convertToGeminiFormat(fixture.messages))
+      expect(JSON.stringify(convertToGeminiFormat(fixture.messages, 'gemini-3-pro-preview'))).toBe(
+        JSON.stringify(convertToGeminiFormat(fixture.messages, 'gemini-3-pro-preview'))
       );
       expect(JSON.stringify(convertToTextOnlyFormat(fixture.messages))).toBe(
         JSON.stringify(convertToTextOnlyFormat(fixture.messages))
@@ -55,8 +55,8 @@ describe('converter determinism: each converter is a pure function of its input'
         ],
       },
     ];
-    expect(JSON.stringify(convertToGeminiFormat(messages))).toBe(
-      JSON.stringify(convertToGeminiFormat(messages))
+    expect(JSON.stringify(convertToGeminiFormat(messages, 'gemini-3-pro-preview'))).toBe(
+      JSON.stringify(convertToGeminiFormat(messages, 'gemini-3-pro-preview'))
     );
   });
 });

--- a/packages/agent/src/providers/__tests__/format-converters.test.ts
+++ b/packages/agent/src/providers/__tests__/format-converters.test.ts
@@ -31,7 +31,7 @@ describe('Format Converters', () => {
         },
       ];
 
-      const result = convertToGeminiFormat(messages);
+      const result = convertToGeminiFormat(messages, 'gemini-3-pro-preview');
 
       expect(result).toHaveLength(1);
       expect(result[0].role).toBe('user');
@@ -67,7 +67,7 @@ describe('Format Converters', () => {
         },
       ];
 
-      const result = convertToGeminiFormat(messages);
+      const result = convertToGeminiFormat(messages, 'gemini-3-pro-preview');
 
       expect(result).toHaveLength(1);
       expect(result[0].parts).toHaveLength(1);
@@ -92,7 +92,7 @@ describe('Format Converters', () => {
         },
       ];
 
-      const result = convertToGeminiFormat(messages);
+      const result = convertToGeminiFormat(messages, 'gemini-3-pro-preview');
 
       expect(result[0].parts[0].functionResponse?.name).toBe('file_write');
       expect(result[0].parts[0].functionResponse?.response?.error).toBe('Tool execution failed');
@@ -119,7 +119,7 @@ describe('Format Converters', () => {
         },
       ];
 
-      const result = convertToGeminiFormat(messages);
+      const result = convertToGeminiFormat(messages, 'gemini-3-pro-preview');
 
       expect(result).toHaveLength(1);
       expect(result[0].role).toBe('user');

--- a/packages/agent/src/providers/format-converters.ts
+++ b/packages/agent/src/providers/format-converters.ts
@@ -5,7 +5,7 @@ import { ProviderMessage, ContentBlock, type ThinkingBlock } from './base-provid
 import type { ContentBlock as ToolResultContentBlock } from '../tools/types';
 import { ToolCall } from '@lace/agent/tools/types';
 import Anthropic from '@anthropic-ai/sdk';
-import type { Content, Part } from '@google/genai';
+import type { Content, FunctionResponsePart, Part } from '@google/genai';
 import type {
   ResponseFunctionCallOutputItem,
   ResponseInputContent,
@@ -88,10 +88,10 @@ function hasText(block: { type: string; text?: string }): boolean {
 }
 
 /**
- * PRI-3079. Some tool-result wire formats are text-only: OpenAI's
- * `ChatCompletionToolMessageParam.content` is `string | ContentPartText[]`, and
- * `@google/genai@1.x` `FunctionResponse` carries only a JSON `response` object.
- * An image cannot travel through those at all.
+ * PRI-3079. Some tool-result wire formats cannot carry an image at all: OpenAI's
+ * `ChatCompletionToolMessageParam.content` is `string | ContentPartText[]`, and a
+ * Gemini `functionResponse` reduces to its JSON `response` object on every model
+ * before the Gemini 3 series (see `toGeminiToolResultResponse`).
  */
 const TOOL_RESULT_IMAGE_UNSUPPORTED = 'this provider cannot carry an image in a tool result';
 
@@ -567,9 +567,64 @@ export function convertToTextOnlyFormat(messages: ProviderMessage[]): ProviderMe
 }
 
 /**
- * Converts enhanced ProviderMessage format to Gemini Content/Part format
+ * PRI-3079. Google documents multimodal function responses as available for
+ * "Gemini 3 series models" only, and this catalog's default models are
+ * gemini-2.5-pro/flash, so the older path is the common one and must not be
+ * handed a shape the model would reject.
+ *
+ * Matched on the id because the model catalog has no capability flag for it:
+ * `supports_attachments` is true for every Gemini entry and describes USER
+ * attachments, which 2.5 does carry. The `[.-]` tail keeps a future
+ * `gemini-3.5-*` in and keeps a hypothetical `gemini-30-*` out.
  */
-export function convertToGeminiFormat(messages: ProviderMessage[]): Content[] {
+function supportsMultimodalFunctionResponse(model: string): boolean {
+  return /(?:^|\/)gemini-3(?:[.-]|$)/.test(model);
+}
+
+/**
+ * PRI-3079. The `response`/`parts` pair for one Gemini functionResponse.
+ *
+ * `@google/genai@2.x` declares `FunctionResponse.parts?: FunctionResponsePart[]`
+ * with `FunctionResponsePart.inlineData?: FunctionResponseBlob {data, mimeType}` —
+ * image bytes nested INSIDE the functionResponse. Note that a sibling `inlineData`
+ * part typechecks just as well (that is how a *user* image travels, above) and is
+ * the wrong shape. `FunctionResponsePart` has no `text` member, so the text half
+ * of a mixed result stays in `response.output`.
+ *
+ * A rendered image still gets a line in `output`: it keeps the tool's own ordering
+ * of text and images legible, and it means an image-only result never produces the
+ * empty string PRI-3078 exists to remove.
+ */
+function toGeminiToolResultResponse(
+  content: ToolResultContentBlock[],
+  model: string
+): { output: string; parts?: FunctionResponsePart[] } {
+  if (!supportsMultimodalFunctionResponse(model)) {
+    return { output: content.map(toolResultBlockAsText).join('\n') };
+  }
+  const parts: FunctionResponsePart[] = [];
+  const lines = content.map((block) => {
+    if (block.type !== 'image') return nonImageToolResultBlockAsText(block);
+    // On Gemini 3 the wire format is no longer the obstacle, so the honest reason
+    // for an omission is the block's own: undecodable bytes, or no bytes at all.
+    const reason = unrenderableImageReason(block);
+    if (reason) return describeOmittedToolResultImage(block, reason);
+    parts.push({
+      inlineData: { data: block.data as string, mimeType: block.mimeType as string },
+    });
+    return `[image: ${block.mimeType as string}]`;
+  });
+  return { output: lines.join('\n'), ...(parts.length > 0 ? { parts } : {}) };
+}
+
+/**
+ * Converts enhanced ProviderMessage format to Gemini Content/Part format.
+ *
+ * `model` decides whether a tool-result image can travel as bytes; see
+ * `toGeminiToolResultResponse`. It is required rather than optional so a new call
+ * site cannot silently drop images by forgetting it.
+ */
+export function convertToGeminiFormat(messages: ProviderMessage[], model: string): Content[] {
   return messages
     .filter((msg) => msg.role !== 'system') // System handled separately in Gemini
     .map((msg): Content => {
@@ -629,18 +684,17 @@ export function convertToGeminiFormat(messages: ProviderMessage[]): Content[] {
             }
           }
 
+          const { output, parts: responseParts } = toGeminiToolResultResponse(
+            result.content,
+            model
+          );
           parts.push({
             functionResponse: {
               name: toolName, // Function name for Gemini API
               id: correlationId, // Tool call ID for correlation
+              ...(responseParts ? { parts: responseParts } : {}),
               response: {
-                // PRI-3079: `@google/genai@1.x` FunctionResponse is
-                // `{id?, name?, response?: Record<string, unknown>, ...}` — no `parts`
-                // field, so inline image bytes cannot be expressed in a function
-                // response with the SDK in use. (Gemini 3 plus a 2.x SDK adds
-                // `functionResponse.parts[].inlineData`; adopting it is an SDK major
-                // bump, not this change.) Report the image instead of dropping it to ''.
-                output: result.content.map(toolResultBlockAsText).join('\n'),
+                output,
                 ...(result.status !== 'completed' ? { error: 'Tool execution failed' } : {}),
               },
             },

--- a/packages/agent/src/providers/gemini-provider.ts
+++ b/packages/agent/src/providers/gemini-provider.ts
@@ -52,7 +52,7 @@ export class GeminiProvider extends AIProvider {
 
   private _createRequestPayload(messages: ProviderMessage[], tools: WireTool[], model: string) {
     // Convert our enhanced generic messages to Gemini format
-    const contents = convertToGeminiFormat(messages);
+    const contents = convertToGeminiFormat(messages, model);
 
     // Extract system message if present
     const systemInstruction = this.getEffectiveSystemPrompt(messages);

--- a/packages/agent/src/providers/tool-result-images.test.ts
+++ b/packages/agent/src/providers/tool-result-images.test.ts
@@ -4,8 +4,24 @@
 // ABOUTME: NOTE the shape used here is the FLAT tools/types ContentBlock a real tool result
 // ABOUTME: carries ({type,data,mimeType}), not the nested-`source` provider block.
 
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// GeminiProvider constructs a real SDK client; the production call-site test below
+// only needs the request object it hands the SDK. Factory copied from
+// gemini-provider.test.ts:13-20. format-converters imports @google/genai for TYPES
+// only, so the converter tests are unaffected by this mock.
+const mockGenerateContent = vi.fn();
+vi.mock('@google/genai', () => ({
+  GoogleGenAI: vi.fn().mockImplementation(() => ({
+    models: {
+      generateContent: mockGenerateContent,
+      generateContentStream: vi.fn(),
+    },
+  })),
+}));
+
 import type { ProviderMessage } from './base-provider';
+import { GeminiProvider } from './gemini-provider';
 import type { ContentBlock as ToolResultContentBlock } from '../tools/types';
 import {
   convertToAnthropicFormat,
@@ -214,10 +230,11 @@ describe('PRI-3079: OpenAI chat-completions tool message', () => {
   });
 });
 
-describe('PRI-3079: Gemini functionResponse', () => {
+describe('PRI-3079: Gemini functionResponse on a pre-Gemini-3 model', () => {
   function geminiFunctionResponseOutput(content: ToolResultContentBlock[]): unknown {
     const out = convertToGeminiFormat(
-      withToolResults([{ id: 'gemini_read_file_123_abc', status: 'completed', content }])
+      withToolResults([{ id: 'gemini_read_file_123_abc', status: 'completed', content }]),
+      'gemini-2.5-flash'
     );
     const part = out[0]?.parts?.[0] as { functionResponse?: { response?: { output?: unknown } } };
     return part.functionResponse?.response?.output;
@@ -272,7 +289,8 @@ describe('PRI-3079: resource blocks are not flattened to an empty string', () =>
 
   function geminiOutput(content: ToolResultContentBlock[]): unknown {
     const out = convertToGeminiFormat(
-      withToolResults([{ id: 'gemini_read_file_123_abc', status: 'completed', content }])
+      withToolResults([{ id: 'gemini_read_file_123_abc', status: 'completed', content }]),
+      'gemini-2.5-flash'
     );
     const part = out[0]?.parts?.[0] as { functionResponse?: { response?: { output?: unknown } } };
     return part.functionResponse?.response?.output;
@@ -364,5 +382,158 @@ describe('PRI-3079: empty text blocks stay off the wire', () => {
   it('omits the empty text item from the OpenAI Responses item list', () => {
     const out = toOpenAIResponsesToolOutput(EMPTY_AND_IMAGE);
     expect(out).toEqual([{ type: 'input_image', image_url: `data:image/png;base64,${PNG_1PX}` }]);
+  });
+});
+
+describe('PRI-3079: Gemini 3 carries tool-result images inside the functionResponse', () => {
+  const GEMINI_3 = 'gemini-3-pro-preview';
+  const GEMINI_2_5 = 'gemini-2.5-pro';
+
+  function geminiFunctionResponse(
+    content: ToolResultContentBlock[],
+    model: string
+  ): { response?: { output?: unknown }; parts?: unknown } {
+    const out = convertToGeminiFormat(
+      withToolResults([{ id: 'gemini_read_file_123_abc', status: 'completed', content }]),
+      model
+    );
+    const parts = out[0]?.parts ?? [];
+    // The bytes must be INSIDE the functionResponse. A sibling `inlineData` part is
+    // how a *user* image travels, typechecks identically, and is the wrong shape here,
+    // so the count is asserted rather than just indexing at [0].
+    expect(parts).toHaveLength(1);
+    return (parts[0] as { functionResponse: { response?: { output?: unknown }; parts?: unknown } })
+      .functionResponse;
+  }
+
+  const IMAGE: ToolResultContentBlock = { type: 'image', data: PNG_1PX, mimeType: 'image/png' };
+
+  it('nests the bytes in functionResponse.parts[].inlineData', () => {
+    expect(geminiFunctionResponse([IMAGE], GEMINI_3).parts).toEqual([
+      { inlineData: { data: PNG_1PX, mimeType: 'image/png' } },
+    ]);
+  });
+
+  it('still names the image in the text output, so it is never an empty string', () => {
+    expect(geminiFunctionResponse([IMAGE], GEMINI_3).response?.output).toBe('[image: image/png]');
+  });
+
+  it('keeps text and image in the order the tool produced them', () => {
+    const fr = geminiFunctionResponse(
+      [{ type: 'text', text: 'screenshot.png' }, IMAGE, { type: 'text', text: 'done' }],
+      GEMINI_3
+    );
+    expect(fr.response?.output).toBe('screenshot.png\n[image: image/png]\ndone');
+    expect(fr.parts).toEqual([{ inlineData: { data: PNG_1PX, mimeType: 'image/png' } }]);
+  });
+
+  it('emits no parts field at all when the result has no image', () => {
+    const fr = geminiFunctionResponse([{ type: 'text', text: 'hello' }], GEMINI_3);
+    expect(fr.parts).toBeUndefined();
+    expect(fr.response?.output).toBe('hello');
+  });
+
+  it('does not send the nested shape to a model that would reject it', () => {
+    // Google documents multimodal function responses as Gemini 3 series only, and
+    // gemini-2.5-* are this catalog's DEFAULT models, so the older path is the
+    // common one. It degrades to text rather than to an unsupported shape.
+    const fr = geminiFunctionResponse([IMAGE], GEMINI_2_5);
+    expect(fr.parts).toBeUndefined();
+    expect(fr.response?.output).toBe(
+      '[image omitted: this provider cannot carry an image in a tool result (image/png)]'
+    );
+  });
+
+  it('reports a missing media type as such on Gemini 3, and never guesses one', () => {
+    // On Gemini 3 the format is not the obstacle, so "this provider cannot carry an
+    // image" would be a lie: the honest reason is that the bytes are undecodable.
+    const fr = geminiFunctionResponse([{ type: 'image', data: PNG_1PX }], GEMINI_3);
+    expect(fr.parts).toBeUndefined();
+    expect(fr.response?.output).toBe('[image omitted: no media type reported by the tool]');
+    expect(JSON.stringify(fr)).not.toContain(PNG_1PX);
+  });
+
+  it('reports missing bytes on Gemini 3 without inventing an empty inlineData', () => {
+    const fr = geminiFunctionResponse([{ type: 'image', mimeType: 'image/png' }], GEMINI_3);
+    expect(fr.parts).toBeUndefined();
+    expect(fr.response?.output).toBe(
+      '[image omitted: no image data reported by the tool (image/png)]'
+    );
+  });
+
+  it('names a resource block on the Gemini 3 path too', () => {
+    const fr = geminiFunctionResponse(
+      [{ type: 'resource', uri: 'file:///tmp/notes.txt' }, IMAGE],
+      GEMINI_3
+    );
+    expect(fr.response?.output).toBe('[resource: file:///tmp/notes.txt]\n[image: image/png]');
+    expect(fr.parts).toEqual([{ inlineData: { data: PNG_1PX, mimeType: 'image/png' } }]);
+  });
+
+  it('still marks a failed image-bearing tool result as an error', () => {
+    const out = convertToGeminiFormat(
+      withToolResults([{ id: 'gemini_read_file_1_a', status: 'error', content: [IMAGE] }]),
+      GEMINI_3
+    );
+    const fr = (out[0]?.parts?.[0] as { functionResponse: { response: Record<string, unknown> } })
+      .functionResponse;
+    expect(fr.response.error).toBe('Tool execution failed');
+  });
+
+  it('treats a Gemini 3 minor release as Gemini 3, and 2.5 as not', () => {
+    expect(geminiFunctionResponse([IMAGE], 'gemini-3-flash-preview').parts).toBeDefined();
+    expect(geminiFunctionResponse([IMAGE], 'models/gemini-3-pro-preview').parts).toBeDefined();
+    expect(geminiFunctionResponse([IMAGE], 'gemini-2.5-flash').parts).toBeUndefined();
+    // pins the `[.-]` boundary: a "3" that is only a prefix of the major is not Gemini 3
+    expect(geminiFunctionResponse([IMAGE], 'gemini-30-pro').parts).toBeUndefined();
+  });
+
+  // The production call site, not the helper: on PRI-3078 the helper was well
+  // tested while the line that actually calls it had no coverage at all. The model
+  // is only known to the provider, so this is where the threading can break.
+  describe('the GeminiProvider request object', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      mockGenerateContent.mockResolvedValue({
+        candidates: [{ content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' }],
+        usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+      });
+    });
+
+    async function requestFor(model: string): Promise<string> {
+      const provider = new GeminiProvider({ apiKey: 'test-api-key' });
+      await provider.createResponse(
+        [
+          {
+            role: 'user',
+            content: '',
+            toolResults: [
+              { id: 'gemini_read_file_123_abc', status: 'completed', content: [IMAGE] },
+            ],
+          },
+        ],
+        [],
+        model
+      );
+      const call = mockGenerateContent.mock.calls.at(-1);
+      if (!call) throw new Error('mockGenerateContent was not called');
+      return JSON.stringify(call[0]);
+    }
+
+    it('carries the image bytes to the SDK when the model is Gemini 3', async () => {
+      const body = await requestFor(GEMINI_3);
+      expect(body).toContain(PNG_1PX);
+      expect(JSON.parse(body)).toMatchObject({
+        contents: [
+          { parts: [{ functionResponse: { parts: [{ inlineData: { mimeType: 'image/png' } }] } }] },
+        ],
+      });
+    });
+
+    it('sends no image bytes to a pre-Gemini-3 model', async () => {
+      const body = await requestFor(GEMINI_2_5);
+      expect(body).not.toContain(PNG_1PX);
+      expect(body).toContain('image omitted');
+    });
   });
 });


### PR DESCRIPTION
**Stacked on #385** — base is `wip/tool-result-images-openai-gemini`. Two commits: the dependency bump alone, then the feature.

## The premise this started from was wrong

This was scoped as "Gemini tool-result images require a major `@google/genai` bump." That is false, and the record should say so.

`FunctionResponse.parts?: FunctionResponsePart[]` shipped in **1.21.0** — one patch release after the pinned 1.20.0. Bisected against the published `.d.ts` files:

```
1.20.0 → no `parts`
1.21.0 → `parts?: FunctionResponsePart[]`   (and every release since)
```

`package.json` already declared `^1.19.0`, so a lockfile refresh alone would have picked this up. The earlier conclusion — reached independently by three agents — correctly established that *1.20.0* lacks `parts` and then wrongly generalised to "therefore 2.x."

The 2.x bump was separately approved and is clean, so it is here. But the two commits are separable if you would rather ship the fix against 1.x and take the major bump on its own schedule.

## The 2.x upgrade broke nothing

The 2.0.0 breaking changes are confined to the **Interactions API** — renamed `interaction.created` / `interaction.completed` SSE events, deprecated `response_format` — which lace does not use.

Everything lace touches is unchanged: `GoogleGenAI`, `GenerateContentResponse`, `Content`, `Part`, `models.generateContent`, `models.generateContentStream`, and client construction with `{apiKey, vertexai: false}`. Typecheck, lint and the providers+mcp suites all passed with **zero source edits**, which is why the bump is committed on its own.

Lockfile churn is entirely downstream of genai's own dependencies: `google-auth-library ^9→^10`, plus new `p-retry` and `protobufjs`.

## The wire shape

From `node_modules/@google/genai/dist/genai.d.ts` at 2.21.0:

- `FunctionResponse` (L5306) — `parts?: FunctionResponsePart[]`
- `FunctionResponsePart` (L5342) — `{fileData?: FunctionResponseFileData; inlineData?: FunctionResponseBlob}`. **No `text` member**, so the text half of a mixed result stays in `response.output`.
- `FunctionResponseBlob` — `{data?: string /* base64 */; mimeType?: string; displayName?: string}`

Verified by running the SDK's own `createPartFromFunctionResponse` + `createFunctionResponsePartFromBase64` against the installed version:

```json
{"functionResponse":{"id":"id1","name":"tool","response":{"output":"hi"},
 "parts":[{"inlineData":{"data":"AAAA","mimeType":"image/png"}}]}}
```

Those helpers are **not** imported at runtime: the Gemini tests `vi.mock('@google/genai')` and the mock exports only `GoogleGenAI`, so importing them would break the suite. The literal is written out and annotated `FunctionResponsePart`, which gets identical tsc checking with no runtime dependency.

Note the nesting. `parts` lives **inside** the functionResponse. Appending an `inlineData` part as a *sibling* — which is what the existing user-image code does, 300 lines away — compiles cleanly and is wrong. That trap is covered by a mutation test (M4 below).

## Model gating is mandatory, not optional

Google documents this as "available for Gemini 3 series models." The catalog (`providers/catalog/data/gemini.json`) defaults to **`gemini-2.5-pro` / `gemini-2.5-flash`**, so the *unsupported* path is the common one.

There is no capability flag to key off — `supports_attachments` is `true` for all four catalog entries and refers to *user* attachments, which 2.5 genuinely does carry. So the gate matches the model id: `/(?:^|\/)gemini-3(?:[.-]|$)/`. The `[.-]` tail admits a future `gemini-3.5-*` and excludes a hypothetical `gemini-30-*`; both are asserted.

`convertToGeminiFormat` now takes `model` as a **required** parameter. Only the provider knows it, and an optional parameter would let a future call site silently drop images by forgetting to pass it.

## Degradation depends on the model, deliberately

- **Pre-Gemini-3** — unchanged from #385: `[image omitted: this provider cannot carry an image in a tool result (image/png)]`. The pinned golden request bodies (which run on `gemini-2.5-flash`) did not move, which is good evidence the old path is byte-identical.
- **Gemini 3** — the wire format is no longer the obstacle, so "this provider cannot carry an image" would be a lie. The reason becomes the block's own defect: `[image omitted: no media type reported by the tool]`, or `[image omitted: no image data reported by the tool (image/png)]`.
- A rendered image still contributes `[image: image/png]` to `output`, so an image-only result never yields `''` and interleaved text/image ordering stays legible.
- `resource` blocks route through `nonImageToolResultBlockAsText` on the Gemini 3 path too — `[resource: <uri>]`, not `''`. Asserted.

A media type is never guessed.

## Mutation evidence

12 mutations scripted against the implementation. **Zero survivors**; each of the 12 new tests is killed by at least one.

| Mutation | Tests killed |
|---|---|
| M1 gate always `false` | 7 |
| M2 gate always `true` | 5 |
| M3 regex loses the `[.-]` boundary | 1 |
| M4 **inlineData as a sibling part, not nested** | 5 |
| M5 rendered image contributes no text line | 3 |
| M6 Gemini 3 reuses the "cannot carry" reason | 2 |
| M7 `parts` always emitted, even when empty | 3 |
| M8 **production call site drops the model** | 1 |
| M9 unrenderable image silently dropped | 2 |
| M10 ordering lost | 3 |
| M11 error flag dropped | 1 |
| M12 resource flattened to `block.text \|\| ''` | 8 |

Two of these are worth calling out. **M3** survived an earlier draft — the boundary assertion was added *because* the mutation lived. **M8** is caught only by the two tests that build a real `GeminiProvider` against the mocked SDK and assert on the captured request object; that is the #385 lesson about covering the production call site, not just the pure helper.

Test inputs are built from the **flat** `tools/types` `ContentBlock`, matching the existing file.

## Results

- `src/providers` + `src/mcp`: **916 passed, 19 skipped, 0 failed**
- typecheck clean, lint clean
- Full agent suite at HEAD vs. base: **identical failure counts** (24 files / 102 tests), with +12 passing — exactly the new tests. The failures are the known E2E noise being fixed in #384 and #387.

## Not verified

1. **No live API call was made.** This is types + docs + mocked SDK throughout. Neither "Gemini 3 accepts this body" nor "2.5 rejects the nested shape" was observed; the gate rests on Google's documented statement.
2. **`displayName` / `$ref`.** The docs say each multimodal part "requires a unique `displayName`" so the structured `response` can reference it as `{"$ref": "<displayName>"}`. But the SDK's own `.d.ts` marks `FunctionResponseBlob.displayName` as "not supported in Gemini API", and `createFunctionResponsePartFromBase64` emits none. This follows the SDK: no `displayName`, no `$ref`. **If the API turns out to require it, that is the first thing to add.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
