### PR TITLE
test(agent): make the E2E test budget outlive the guards it contains

### DIFF
--- a/packages/agent/src/__tests__/agent-process.abort.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.abort.e2e.test.ts
@@ -10,15 +10,16 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
 } from './helpers';
 
-describe('agent abort reliability (E2E)', () => {
+describe('agent abort reliability (E2E)', { timeout: E2E_TEST_TIMEOUT_MS }, () => {
   const ctx = createE2EContext({ prefix: 'lace-agent-abort' });
 
   beforeEach(() => ctx.setup());
   afterEach(() => ctx.teardown());
 
-  it('aborts cleanly during LLM streaming', { timeout: 15_000 }, async () => {
+  it('aborts cleanly during LLM streaming', async () => {
     // Setup: Use test provider with streaming delay to give us time to cancel
     ctx.agent = spawnAgentProcess({
       laceDir: ctx.laceDir,
@@ -88,7 +89,7 @@ describe('agent abort reliability (E2E)', () => {
     expect(status.pendingPermissions).toEqual([]);
   });
 
-  it('aborts cleanly during tool execution', { timeout: 20_000 }, async () => {
+  it('aborts cleanly during tool execution', async () => {
     // Setup: Use test provider to trigger bash tool with a slow command
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
@@ -169,7 +170,7 @@ describe('agent abort reliability (E2E)', () => {
     expect(status.pendingPermissions).toEqual([]);
   });
 
-  it('aborts cleanly while awaiting permission', { timeout: 15_000 }, async () => {
+  it('aborts cleanly while awaiting permission', async () => {
     // Setup: Trigger tool requiring permission, never respond
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
@@ -248,7 +249,7 @@ describe('agent abort reliability (E2E)', () => {
     expect(status.currentTurn).toBeUndefined();
   });
 
-  it('handles abort when no turn is active', { timeout: 10_000 }, async () => {
+  it('handles abort when no turn is active', async () => {
     // Setup: Agent is idle
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
@@ -302,7 +303,7 @@ describe('agent abort reliability (E2E)', () => {
     expect(result.stopReason).toBe('end_turn');
   });
 
-  it('allows new turn after abort', { timeout: 20_000 }, async () => {
+  it('allows new turn after abort', async () => {
     // Setup: Start and abort a turn, then start a new one
     ctx.agent = spawnAgentProcess({
       laceDir: ctx.laceDir,

--- a/packages/agent/src/__tests__/agent-process.async-workflow.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.async-workflow.e2e.test.ts
@@ -8,15 +8,16 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
 } from './helpers';
 
-describe('async job workflow (E2E)', () => {
+describe('async job workflow (E2E)', { timeout: E2E_TEST_TIMEOUT_MS }, () => {
   const ctx = createE2EContext({ prefix: 'lace-async-workflow' });
 
   beforeEach(() => ctx.setup());
   afterEach(() => ctx.teardown());
 
-  it('persists runtimeBinding on shell job_started events', { timeout: 20_000 }, async () => {
+  it('persists runtimeBinding on shell job_started events', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     let jobId: string | undefined;
@@ -86,287 +87,275 @@ describe('async job workflow (E2E)', () => {
     });
   });
 
-  it(
-    'complete async bash workflow: spawn, list, check output, kill',
-    { timeout: 30_000 },
-    async () => {
-      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+  it('complete async bash workflow: spawn, list, check output, kill', async () => {
+    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
-      const updates: Array<Record<string, unknown>> = [];
-      let shellJobId: string | undefined;
+    const updates: Array<Record<string, unknown>> = [];
+    let shellJobId: string | undefined;
 
-      ctx.agent.peer.onRequest('session/update', async (params) => {
-        const p = params as Record<string, unknown>;
-        updates.push(p);
-        if (p.type === 'job_started' && p.jobType === 'bash' && typeof p.jobId === 'string') {
-          shellJobId = p.jobId;
-        }
-        return undefined;
-      });
+    ctx.agent.peer.onRequest('session/update', async (params) => {
+      const p = params as Record<string, unknown>;
+      updates.push(p);
+      if (p.type === 'job_started' && p.jobType === 'bash' && typeof p.jobId === 'string') {
+        shellJobId = p.jobId;
+      }
+      return undefined;
+    });
 
-      ctx.agent.peer.onRequest('session/request_permission', async () => {
-        return { decision: 'allow' };
-      });
+    ctx.agent.peer.onRequest('session/request_permission', async () => {
+      return { decision: 'allow' };
+    });
 
-      await withTimeout(
-        ctx.agent.peer.request(
-          'initialize',
-          defaultInitializeParams({ config: { approvalMode: 'allow' } })
-        ),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
+    await withTimeout(
+      ctx.agent.peer.request(
+        'initialize',
+        defaultInitializeParams({ config: { approvalMode: 'allow' } })
+      ),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
 
-      await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        2_000,
-        'session/new'
-      );
+    await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      2_000,
+      'session/new'
+    );
 
-      // Spawn a long-running job that we can kill
-      await withTimeout(
-        ctx.agent.peer.request('session/prompt', {
-          content: [{ type: 'text', text: 'job: sleep 60' }],
-        }),
-        5_000,
-        'session/prompt (spawn job)'
-      );
+    // Spawn a long-running job that we can kill
+    await withTimeout(
+      ctx.agent.peer.request('session/prompt', {
+        content: [{ type: 'text', text: 'job: sleep 60' }],
+      }),
+      5_000,
+      'session/prompt (spawn job)'
+    );
 
-      // Wait for job_started
-      await withTimeout(
-        new Promise<void>((resolve) => {
-          const interval = setInterval(() => {
-            if (shellJobId) {
-              clearInterval(interval);
-              resolve();
-            }
-          }, 10);
-        }),
-        3_000,
-        'job_started'
-      );
+    // Wait for job_started
+    await withTimeout(
+      new Promise<void>((resolve) => {
+        const interval = setInterval(() => {
+          if (shellJobId) {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 10);
+      }),
+      3_000,
+      'job_started'
+    );
 
-      expect(shellJobId).toMatch(/^job_/);
+    expect(shellJobId).toMatch(/^job_/);
 
-      // List jobs - should show running
-      const list = (await withTimeout(
-        ctx.agent.peer.request('ent/job/list'),
-        2_000,
-        'ent/job/list'
-      )) as { jobs: Array<{ jobId: string; status: string }> };
+    // List jobs - should show running
+    const list = (await withTimeout(
+      ctx.agent.peer.request('ent/job/list'),
+      2_000,
+      'ent/job/list'
+    )) as { jobs: Array<{ jobId: string; status: string }> };
 
-      const runningJob = list.jobs.find((j) => j.jobId === shellJobId);
-      expect(runningJob?.status).toBe('running');
+    const runningJob = list.jobs.find((j) => j.jobId === shellJobId);
+    expect(runningJob?.status).toBe('running');
 
-      // Kill the job
+    // Kill the job
+    const killed = (await withTimeout(
+      ctx.agent.peer.request('ent/job/kill', { jobId: shellJobId }),
+      2_000,
+      'ent/job/kill'
+    )) as { success: boolean };
+
+    expect(killed.success).toBe(true);
+
+    // Check final status
+    const output = (await withTimeout(
+      ctx.agent.peer.request('ent/job/output', { jobId: shellJobId }),
+      2_000,
+      'ent/job/output'
+    )) as { status: string };
+
+    expect(output.status).toBe('cancelled');
+  });
+
+  it('multiple concurrent jobs: spawn several, list all, verify statuses', async () => {
+    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+
+    const updates: Array<Record<string, unknown>> = [];
+    const jobIds: string[] = [];
+
+    ctx.agent.peer.onRequest('session/update', async (params) => {
+      const p = params as Record<string, unknown>;
+      updates.push(p);
+      if (p.type === 'job_started' && typeof p.jobId === 'string') {
+        jobIds.push(p.jobId as string);
+      }
+      return undefined;
+    });
+
+    ctx.agent.peer.onRequest('session/request_permission', async () => {
+      return { decision: 'allow' };
+    });
+
+    await withTimeout(
+      ctx.agent.peer.request(
+        'initialize',
+        defaultInitializeParams({ config: { approvalMode: 'allow' } })
+      ),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
+
+    await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      2_000,
+      'session/new'
+    );
+
+    // Spawn multiple jobs
+    await withTimeout(
+      ctx.agent.peer.request('session/prompt', {
+        content: [{ type: 'text', text: 'job: sleep 30' }],
+      }),
+      5_000,
+      'session/prompt (job 1)'
+    );
+
+    await withTimeout(
+      ctx.agent.peer.request('session/prompt', {
+        content: [{ type: 'text', text: 'job: sleep 30' }],
+      }),
+      5_000,
+      'session/prompt (job 2)'
+    );
+
+    await withTimeout(
+      ctx.agent.peer.request('session/prompt', {
+        content: [{ type: 'text', text: 'job: sleep 30' }],
+      }),
+      5_000,
+      'session/prompt (job 3)'
+    );
+
+    // Wait for all jobs to be started
+    await withTimeout(
+      new Promise<void>((resolve) => {
+        const interval = setInterval(() => {
+          if (jobIds.length >= 3) {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 10);
+      }),
+      5_000,
+      'all jobs started'
+    );
+
+    expect(jobIds).toHaveLength(3);
+
+    // List jobs - should show all three running
+    const list = (await withTimeout(
+      ctx.agent.peer.request('ent/job/list'),
+      2_000,
+      'ent/job/list'
+    )) as { jobs: Array<{ jobId: string; status: string }> };
+
+    const runningJobs = list.jobs.filter((j) => j.status === 'running');
+    expect(runningJobs).toHaveLength(3);
+
+    // Kill all jobs
+    for (const jobId of jobIds) {
       const killed = (await withTimeout(
-        ctx.agent.peer.request('ent/job/kill', { jobId: shellJobId }),
+        ctx.agent.peer.request('ent/job/kill', { jobId }),
         2_000,
-        'ent/job/kill'
+        `ent/job/kill (${jobId})`
       )) as { success: boolean };
-
       expect(killed.success).toBe(true);
-
-      // Check final status
-      const output = (await withTimeout(
-        ctx.agent.peer.request('ent/job/output', { jobId: shellJobId }),
-        2_000,
-        'ent/job/output'
-      )) as { status: string };
-
-      expect(output.status).toBe('cancelled');
     }
-  );
 
-  it(
-    'multiple concurrent jobs: spawn several, list all, verify statuses',
-    { timeout: 30_000 },
-    async () => {
-      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+    // Verify all are cancelled
+    const finalList = (await withTimeout(
+      ctx.agent.peer.request('ent/job/list'),
+      2_000,
+      'ent/job/list (final)'
+    )) as { jobs: Array<{ jobId: string; status: string }> };
 
-      const updates: Array<Record<string, unknown>> = [];
-      const jobIds: string[] = [];
+    for (const jobId of jobIds) {
+      const job = finalList.jobs.find((j) => j.jobId === jobId);
+      expect(job?.status).toBe('cancelled');
+    }
+  });
 
-      ctx.agent.peer.onRequest('session/update', async (params) => {
-        const p = params as Record<string, unknown>;
-        updates.push(p);
-        if (p.type === 'job_started' && typeof p.jobId === 'string') {
-          jobIds.push(p.jobId as string);
-        }
-        return undefined;
-      });
+  it('job completion: spawn short job, wait for completion, verify output', async () => {
+    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
-      ctx.agent.peer.onRequest('session/request_permission', async () => {
-        return { decision: 'allow' };
-      });
+    const updates: Array<Record<string, unknown>> = [];
+    let jobId: string | undefined;
 
-      await withTimeout(
-        ctx.agent.peer.request(
-          'initialize',
-          defaultInitializeParams({ config: { approvalMode: 'allow' } })
-        ),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
-
-      await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        2_000,
-        'session/new'
-      );
-
-      // Spawn multiple jobs
-      await withTimeout(
-        ctx.agent.peer.request('session/prompt', {
-          content: [{ type: 'text', text: 'job: sleep 30' }],
-        }),
-        5_000,
-        'session/prompt (job 1)'
-      );
-
-      await withTimeout(
-        ctx.agent.peer.request('session/prompt', {
-          content: [{ type: 'text', text: 'job: sleep 30' }],
-        }),
-        5_000,
-        'session/prompt (job 2)'
-      );
-
-      await withTimeout(
-        ctx.agent.peer.request('session/prompt', {
-          content: [{ type: 'text', text: 'job: sleep 30' }],
-        }),
-        5_000,
-        'session/prompt (job 3)'
-      );
-
-      // Wait for all jobs to be started
-      await withTimeout(
-        new Promise<void>((resolve) => {
-          const interval = setInterval(() => {
-            if (jobIds.length >= 3) {
-              clearInterval(interval);
-              resolve();
-            }
-          }, 10);
-        }),
-        5_000,
-        'all jobs started'
-      );
-
-      expect(jobIds).toHaveLength(3);
-
-      // List jobs - should show all three running
-      const list = (await withTimeout(
-        ctx.agent.peer.request('ent/job/list'),
-        2_000,
-        'ent/job/list'
-      )) as { jobs: Array<{ jobId: string; status: string }> };
-
-      const runningJobs = list.jobs.filter((j) => j.status === 'running');
-      expect(runningJobs).toHaveLength(3);
-
-      // Kill all jobs
-      for (const jobId of jobIds) {
-        const killed = (await withTimeout(
-          ctx.agent.peer.request('ent/job/kill', { jobId }),
-          2_000,
-          `ent/job/kill (${jobId})`
-        )) as { success: boolean };
-        expect(killed.success).toBe(true);
+    ctx.agent.peer.onRequest('session/update', async (params) => {
+      const p = params as Record<string, unknown>;
+      updates.push(p);
+      if (p.type === 'job_started' && typeof p.jobId === 'string') {
+        jobId = p.jobId;
       }
+      return undefined;
+    });
 
-      // Verify all are cancelled
-      const finalList = (await withTimeout(
-        ctx.agent.peer.request('ent/job/list'),
-        2_000,
-        'ent/job/list (final)'
-      )) as { jobs: Array<{ jobId: string; status: string }> };
+    ctx.agent.peer.onRequest('session/request_permission', async () => {
+      return { decision: 'allow' };
+    });
 
-      for (const jobId of jobIds) {
-        const job = finalList.jobs.find((j) => j.jobId === jobId);
-        expect(job?.status).toBe('cancelled');
-      }
-    }
-  );
+    await withTimeout(
+      ctx.agent.peer.request(
+        'initialize',
+        defaultInitializeParams({ config: { approvalMode: 'allow' } })
+      ),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
 
-  it(
-    'job completion: spawn short job, wait for completion, verify output',
-    { timeout: 30_000 },
-    async () => {
-      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+    await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      2_000,
+      'session/new'
+    );
 
-      const updates: Array<Record<string, unknown>> = [];
-      let jobId: string | undefined;
+    // Spawn a job that produces output
+    await withTimeout(
+      ctx.agent.peer.request('session/prompt', {
+        content: [{ type: 'text', text: 'job: echo "hello world"' }],
+      }),
+      5_000,
+      'session/prompt'
+    );
 
-      ctx.agent.peer.onRequest('session/update', async (params) => {
-        const p = params as Record<string, unknown>;
-        updates.push(p);
-        if (p.type === 'job_started' && typeof p.jobId === 'string') {
-          jobId = p.jobId;
-        }
-        return undefined;
-      });
+    // Wait for job_finished
+    await withTimeout(
+      new Promise<void>((resolve) => {
+        const interval = setInterval(() => {
+          if (!jobId) return;
+          const finished = updates.find((u) => u.type === 'job_finished' && u.jobId === jobId);
+          if (finished) {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 10);
+      }),
+      5_000,
+      'job_finished update'
+    );
 
-      ctx.agent.peer.onRequest('session/request_permission', async () => {
-        return { decision: 'allow' };
-      });
+    expect(jobId).toMatch(/^job_/);
 
-      await withTimeout(
-        ctx.agent.peer.request(
-          'initialize',
-          defaultInitializeParams({ config: { approvalMode: 'allow' } })
-        ),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
+    // Check output
+    const output = (await withTimeout(
+      ctx.agent.peer.request('ent/job/output', { jobId }),
+      2_000,
+      'ent/job/output'
+    )) as { status: string; output: string };
 
-      await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        2_000,
-        'session/new'
-      );
+    expect(output.status).toBe('completed');
+    expect(output.output).toContain('hello world');
+  });
 
-      // Spawn a job that produces output
-      await withTimeout(
-        ctx.agent.peer.request('session/prompt', {
-          content: [{ type: 'text', text: 'job: echo "hello world"' }],
-        }),
-        5_000,
-        'session/prompt'
-      );
-
-      // Wait for job_finished
-      await withTimeout(
-        new Promise<void>((resolve) => {
-          const interval = setInterval(() => {
-            if (!jobId) return;
-            const finished = updates.find((u) => u.type === 'job_finished' && u.jobId === jobId);
-            if (finished) {
-              clearInterval(interval);
-              resolve();
-            }
-          }, 10);
-        }),
-        5_000,
-        'job_finished update'
-      );
-
-      expect(jobId).toMatch(/^job_/);
-
-      // Check output
-      const output = (await withTimeout(
-        ctx.agent.peer.request('ent/job/output', { jobId }),
-        2_000,
-        'ent/job/output'
-      )) as { status: string; output: string };
-
-      expect(output.status).toBe('completed');
-      expect(output.output).toContain('hello world');
-    }
-  );
-
-  it('job persistence: jobs survive agent restart', { timeout: 30_000 }, async () => {
+  it('job persistence: jobs survive agent restart', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     let jobId: string | undefined;
@@ -473,7 +462,7 @@ describe('async job workflow (E2E)', () => {
     expect(outputAfterRestart.output).toContain('test');
   });
 
-  it('job error handling: job with non-zero exit code', { timeout: 30_000 }, async () => {
+  it('job error handling: job with non-zero exit code', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     let jobId: string | undefined;
@@ -560,7 +549,7 @@ describe('async job workflow (E2E)', () => {
     expect(output.exitCode).toBe(1);
   });
 
-  it('session switch kills running jobs', { timeout: 30_000 }, async () => {
+  it('session switch kills running jobs', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     let jobId: string | undefined;
@@ -644,108 +633,104 @@ describe('async job workflow (E2E)', () => {
     expect(output.status).toBe('cancelled');
   });
 
-  it(
-    'injects completion notification when background job finishes',
-    { timeout: 30_000 },
-    async () => {
-      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+  it('injects completion notification when background job finishes', async () => {
+    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
-      let jobId: string | undefined;
-      const updates: Array<Record<string, unknown>> = [];
+    let jobId: string | undefined;
+    const updates: Array<Record<string, unknown>> = [];
 
-      ctx.agent.peer.onRequest('session/update', async (params) => {
-        const p = params as Record<string, unknown>;
-        updates.push(p);
-        if (p.type === 'job_started' && typeof p.jobId === 'string') {
-          jobId = p.jobId;
-        }
-        return undefined;
-      });
+    ctx.agent.peer.onRequest('session/update', async (params) => {
+      const p = params as Record<string, unknown>;
+      updates.push(p);
+      if (p.type === 'job_started' && typeof p.jobId === 'string') {
+        jobId = p.jobId;
+      }
+      return undefined;
+    });
 
-      ctx.agent.peer.onRequest('session/request_permission', async () => {
-        return { decision: 'allow' };
-      });
+    ctx.agent.peer.onRequest('session/request_permission', async () => {
+      return { decision: 'allow' };
+    });
 
-      await withTimeout(
-        ctx.agent.peer.request(
-          'initialize',
-          defaultInitializeParams({ config: { approvalMode: 'allow' } })
-        ),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
+    await withTimeout(
+      ctx.agent.peer.request(
+        'initialize',
+        defaultInitializeParams({ config: { approvalMode: 'allow' } })
+      ),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
 
-      await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        2_000,
-        'session/new'
-      );
+    await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      2_000,
+      'session/new'
+    );
 
-      // Start a quick job that will complete
+    // Start a quick job that will complete
+    await withTimeout(
+      ctx.agent.peer.request('session/prompt', {
+        content: [{ type: 'text', text: 'job: echo "test output"' }],
+      }),
+      5_000,
+      'session/prompt (start job)'
+    );
+
+    // Wait for job to complete
+    await withTimeout(
+      new Promise<void>((resolve) => {
+        const interval = setInterval(() => {
+          if (!jobId) return;
+          const finished = updates.find((u) => u.type === 'job_finished' && u.jobId === jobId);
+          if (finished) {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 10);
+      }),
+      5_000,
+      'job_finished update'
+    );
+
+    // Send another prompt - the notification should be injected
+    // The prompt will fail because no provider is configured, but the notification
+    // is injected before provider creation, so it will be in the events
+    try {
       await withTimeout(
         ctx.agent.peer.request('session/prompt', {
-          content: [{ type: 'text', text: 'job: echo "test output"' }],
+          content: [{ type: 'text', text: 'What was the previous output?' }],
         }),
-        5_000,
-        'session/prompt (start job)'
+        10_000,
+        'session/prompt (check notification)'
       );
-
-      // Wait for job to complete
-      await withTimeout(
-        new Promise<void>((resolve) => {
-          const interval = setInterval(() => {
-            if (!jobId) return;
-            const finished = updates.find((u) => u.type === 'job_finished' && u.jobId === jobId);
-            if (finished) {
-              clearInterval(interval);
-              resolve();
-            }
-          }, 10);
-        }),
-        5_000,
-        'job_finished update'
-      );
-
-      // Send another prompt - the notification should be injected
-      // The prompt will fail because no provider is configured, but the notification
-      // is injected before provider creation, so it will be in the events
-      try {
-        await withTimeout(
-          ctx.agent.peer.request('session/prompt', {
-            content: [{ type: 'text', text: 'What was the previous output?' }],
-          }),
-          10_000,
-          'session/prompt (check notification)'
-        );
-      } catch {
-        // Expected - no provider configured
-      }
-
-      // Verify the session events show the notification was injected
-      const events = (await withTimeout(
-        ctx.agent.peer.request('ent/session/events', { limit: 100 }),
-        2_000,
-        'ent/session/events'
-      )) as { events: Array<{ type: string; data?: Record<string, unknown> }> };
-
-      // Find a context_injected event carrying the notification block.
-      const injectedNotification = events.events.find(
-        (e) =>
-          e.type === 'context_injected' &&
-          Array.isArray(e.data?.content) &&
-          (e.data?.content as Array<{ type: string; text?: string }>).some(
-            (c) =>
-              c.type === 'text' &&
-              typeof c.text === 'string' &&
-              c.text.includes('<notification kind="job-')
-          )
-      );
-
-      expect(injectedNotification).toBeDefined();
+    } catch {
+      // Expected - no provider configured
     }
-  );
 
-  it('injects failure notification when background job fails', { timeout: 30_000 }, async () => {
+    // Verify the session events show the notification was injected
+    const events = (await withTimeout(
+      ctx.agent.peer.request('ent/session/events', { limit: 100 }),
+      2_000,
+      'ent/session/events'
+    )) as { events: Array<{ type: string; data?: Record<string, unknown> }> };
+
+    // Find a context_injected event carrying the notification block.
+    const injectedNotification = events.events.find(
+      (e) =>
+        e.type === 'context_injected' &&
+        Array.isArray(e.data?.content) &&
+        (e.data?.content as Array<{ type: string; text?: string }>).some(
+          (c) =>
+            c.type === 'text' &&
+            typeof c.text === 'string' &&
+            c.text.includes('<notification kind="job-')
+        )
+    );
+
+    expect(injectedNotification).toBeDefined();
+  });
+
+  it('injects failure notification when background job fails', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     let jobId: string | undefined;
@@ -841,95 +826,91 @@ describe('async job workflow (E2E)', () => {
     expect(injectedFailureNotification).toBeDefined();
   });
 
-  it(
-    'automatically triggers a turn when job completes and agent is idle',
-    { timeout: 30_000 },
-    async () => {
-      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+  it('automatically triggers a turn when job completes and agent is idle', async () => {
+    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
-      let jobId: string | undefined;
-      const updates: Array<Record<string, unknown>> = [];
-      const turnStarts: string[] = [];
+    let jobId: string | undefined;
+    const updates: Array<Record<string, unknown>> = [];
+    const turnStarts: string[] = [];
 
-      ctx.agent.peer.onRequest('session/update', async (params) => {
-        const p = params as Record<string, unknown>;
-        updates.push(p);
-        if (p.type === 'job_started' && typeof p.jobId === 'string') {
-          jobId = p.jobId;
-        }
-        if (p.type === 'turn_start' && typeof p.turnId === 'string') {
-          turnStarts.push(p.turnId);
-        }
-        return undefined;
-      });
+    ctx.agent.peer.onRequest('session/update', async (params) => {
+      const p = params as Record<string, unknown>;
+      updates.push(p);
+      if (p.type === 'job_started' && typeof p.jobId === 'string') {
+        jobId = p.jobId;
+      }
+      if (p.type === 'turn_start' && typeof p.turnId === 'string') {
+        turnStarts.push(p.turnId);
+      }
+      return undefined;
+    });
 
-      ctx.agent.peer.onRequest('session/request_permission', async () => {
-        return { decision: 'allow' };
-      });
+    ctx.agent.peer.onRequest('session/request_permission', async () => {
+      return { decision: 'allow' };
+    });
 
-      await withTimeout(
-        ctx.agent.peer.request(
-          'initialize',
-          defaultInitializeParams({ config: { approvalMode: 'allow' } })
-        ),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
+    await withTimeout(
+      ctx.agent.peer.request(
+        'initialize',
+        defaultInitializeParams({ config: { approvalMode: 'allow' } })
+      ),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
 
-      await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        2_000,
-        'session/new'
-      );
+    await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      2_000,
+      'session/new'
+    );
 
-      // Start a quick background job - this triggers the first turn
-      await withTimeout(
-        ctx.agent.peer.request('session/prompt', {
-          content: [{ type: 'text', text: 'job: echo "quick output"' }],
-        }),
-        5_000,
-        'session/prompt (start job)'
-      );
+    // Start a quick background job - this triggers the first turn
+    await withTimeout(
+      ctx.agent.peer.request('session/prompt', {
+        content: [{ type: 'text', text: 'job: echo "quick output"' }],
+      }),
+      5_000,
+      'session/prompt (start job)'
+    );
 
-      // Record the initial turn ID
-      const initialTurnId = turnStarts[0];
-      expect(initialTurnId).toBeDefined();
+    // Record the initial turn ID
+    const initialTurnId = turnStarts[0];
+    expect(initialTurnId).toBeDefined();
 
-      // Wait for job to finish
-      await withTimeout(
-        new Promise<void>((resolve) => {
-          const interval = setInterval(() => {
-            if (!jobId) return;
-            const finished = updates.find((u) => u.type === 'job_finished' && u.jobId === jobId);
-            if (finished) {
-              clearInterval(interval);
-              resolve();
-            }
-          }, 10);
-        }),
-        5_000,
-        'job_finished update'
-      );
+    // Wait for job to finish
+    await withTimeout(
+      new Promise<void>((resolve) => {
+        const interval = setInterval(() => {
+          if (!jobId) return;
+          const finished = updates.find((u) => u.type === 'job_finished' && u.jobId === jobId);
+          if (finished) {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 10);
+      }),
+      5_000,
+      'job_finished update'
+    );
 
-      // The agent should automatically trigger a new turn to process the notification
-      // Wait for a second turn_start (different from the initial one)
-      await withTimeout(
-        new Promise<void>((resolve) => {
-          const interval = setInterval(() => {
-            // Look for a turn_start that's different from the initial turn
-            if (turnStarts.length > 1 && turnStarts[turnStarts.length - 1] !== initialTurnId) {
-              clearInterval(interval);
-              resolve();
-            }
-          }, 10);
-        }),
-        5_000,
-        'auto-triggered turn_start'
-      );
+    // The agent should automatically trigger a new turn to process the notification
+    // Wait for a second turn_start (different from the initial one)
+    await withTimeout(
+      new Promise<void>((resolve) => {
+        const interval = setInterval(() => {
+          // Look for a turn_start that's different from the initial turn
+          if (turnStarts.length > 1 && turnStarts[turnStarts.length - 1] !== initialTurnId) {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 10);
+      }),
+      5_000,
+      'auto-triggered turn_start'
+    );
 
-      // Verify a second turn was started (for processing the notification)
-      expect(turnStarts.length).toBeGreaterThanOrEqual(2);
-      expect(turnStarts[turnStarts.length - 1]).not.toBe(initialTurnId);
-    }
-  );
+    // Verify a second turn was started (for processing the notification)
+    expect(turnStarts.length).toBeGreaterThanOrEqual(2);
+    expect(turnStarts[turnStarts.length - 1]).not.toBe(initialTurnId);
+  });
 });

--- a/packages/agent/src/__tests__/agent-process.budget.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.budget.e2e.test.ts
@@ -10,15 +10,16 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
 } from './helpers';
 
-describe('lace-agent token budget tracking (E2E)', () => {
+describe('lace-agent token budget tracking (E2E)', { timeout: E2E_TEST_TIMEOUT_MS }, () => {
   const ctx = createE2EContext({ prefix: 'lace-agent-budget' });
 
   beforeEach(() => ctx.setup());
   afterEach(() => ctx.teardown());
 
-  it('returns token usage in prompt response', { timeout: 15_000 }, async () => {
+  it('returns token usage in prompt response', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     await withTimeout(
@@ -49,7 +50,7 @@ describe('lace-agent token budget tracking (E2E)', () => {
     expect(promptResult.usage.outputTokens).toBeGreaterThan(0);
   });
 
-  it('tracks budgetUsedUsd in agent status', { timeout: 15_000 }, async () => {
+  it('tracks budgetUsedUsd in agent status', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     await withTimeout(
@@ -102,7 +103,7 @@ describe('lace-agent token budget tracking (E2E)', () => {
     expect(statusAfter.limits.budgetUsedUsd).toBeGreaterThan(0);
   });
 
-  it('stops turn with budget_exceeded when budget is exhausted', { timeout: 15_000 }, async () => {
+  it('stops turn with budget_exceeded when budget is exhausted', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     await withTimeout(
@@ -154,47 +155,43 @@ describe('lace-agent token budget tracking (E2E)', () => {
     }
   });
 
-  it(
-    'continues normally when maxBudgetUsd is 0 (budget disabled)',
-    { timeout: 15_000 },
-    async () => {
-      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+  it('continues normally when maxBudgetUsd is 0 (budget disabled)', async () => {
+    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
-      await withTimeout(
-        ctx.agent.peer.request('initialize', defaultInitializeParams()),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
+    await withTimeout(
+      ctx.agent.peer.request('initialize', defaultInitializeParams()),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
 
-      await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        2_000,
-        'session/new'
-      );
+    await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      2_000,
+      'session/new'
+    );
 
-      // Configure budget to 0 (should disable budget enforcement)
-      await withTimeout(
-        ctx.agent.peer.request('ent/session/configure', { maxBudgetUsd: 0 }),
-        2_000,
-        'ent/session/configure'
-      );
+    // Configure budget to 0 (should disable budget enforcement)
+    await withTimeout(
+      ctx.agent.peer.request('ent/session/configure', { maxBudgetUsd: 0 }),
+      2_000,
+      'ent/session/configure'
+    );
 
-      writeFileSync(join(ctx.workDir, 'hello.txt'), 'hello world\n', 'utf8');
+    writeFileSync(join(ctx.workDir, 'hello.txt'), 'hello world\n', 'utf8');
 
-      const promptResult = (await withTimeout(
-        ctx.agent.peer.request('session/prompt', {
-          content: [{ type: 'text', text: 'read file hello.txt' }],
-        }),
-        10_000,
-        'session/prompt'
-      )) as { stopReason: string };
+    const promptResult = (await withTimeout(
+      ctx.agent.peer.request('session/prompt', {
+        content: [{ type: 'text', text: 'read file hello.txt' }],
+      }),
+      10_000,
+      'session/prompt'
+    )) as { stopReason: string };
 
-      // Should complete normally, not budget_exceeded
-      expect(promptResult.stopReason).not.toBe('budget_exceeded');
-    }
-  );
+    // Should complete normally, not budget_exceeded
+    expect(promptResult.stopReason).not.toBe('budget_exceeded');
+  });
 
-  it('accumulates budgetUsedUsd across multiple prompts', { timeout: 20_000 }, async () => {
+  it('accumulates budgetUsedUsd across multiple prompts', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     await withTimeout(

--- a/packages/agent/src/__tests__/agent-process.delegate-config.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.delegate-config.e2e.test.ts
@@ -7,18 +7,20 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
+  SUBAGENT_JOB_TIMEOUT_MS,
 } from './helpers';
 
-describe('lace-agent delegate connectionId/modelId (E2E over stdio)', () => {
-  const ctx = createE2EContext({ prefix: 'lace-agent-delegate-config' });
+describe(
+  'lace-agent delegate connectionId/modelId (E2E over stdio)',
+  { timeout: E2E_TEST_TIMEOUT_MS },
+  () => {
+    const ctx = createE2EContext({ prefix: 'lace-agent-delegate-config' });
 
-  beforeEach(() => ctx.setup());
-  afterEach(() => ctx.teardown());
+    beforeEach(() => ctx.setup());
+    afterEach(() => ctx.teardown());
 
-  it(
-    'spawns a subagent with connectionId and modelId configuration',
-    { timeout: 30_000 },
-    async () => {
+    it('spawns a subagent with connectionId and modelId configuration', async () => {
       process.env.LACE_AGENT_TEST_PROVIDER_STRICT_CONFIG = '1';
       ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
@@ -87,7 +89,7 @@ describe('lace-agent delegate connectionId/modelId (E2E over stdio)', () => {
             },
           ],
         }),
-        15_000,
+        SUBAGENT_JOB_TIMEOUT_MS,
         'session/prompt (with config)'
       );
 
@@ -101,7 +103,7 @@ describe('lace-agent delegate connectionId/modelId (E2E over stdio)', () => {
             }
           }, 10);
         }),
-        10_000,
+        SUBAGENT_JOB_TIMEOUT_MS,
         'job_started update'
       );
 
@@ -120,7 +122,7 @@ describe('lace-agent delegate connectionId/modelId (E2E over stdio)', () => {
             }
           }, 10);
         }),
-        15_000,
+        SUBAGENT_JOB_TIMEOUT_MS,
         'job_finished update'
       );
 
@@ -132,83 +134,79 @@ describe('lace-agent delegate connectionId/modelId (E2E over stdio)', () => {
       )) as { status: string; output: string };
 
       expect(output.status).toBe('completed');
-    }
-  );
-
-  it('spawns a subagent with only modelId (no connectionId)', { timeout: 30_000 }, async () => {
-    process.env.LACE_AGENT_TEST_PROVIDER_STRICT_CONFIG = '1';
-    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
-
-    const updates: Array<Record<string, unknown>> = [];
-    let subagentJobId: string | undefined;
-
-    ctx.agent.peer.onRequest('session/update', async (params) => {
-      const p = params as Record<string, unknown>;
-      updates.push(p);
-      if (p.type === 'job_started' && p.jobType === 'delegate' && typeof p.jobId === 'string') {
-        subagentJobId = p.jobId;
-      }
-      return undefined;
     });
 
-    ctx.agent.peer.onRequest('session/request_permission', async () => ({ decision: 'allow' }));
+    it('spawns a subagent with only modelId (no connectionId)', async () => {
+      process.env.LACE_AGENT_TEST_PROVIDER_STRICT_CONFIG = '1';
+      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
-    await withTimeout(
-      ctx.agent.peer.request(
-        'initialize',
-        defaultInitializeParams({ config: { approvalMode: 'ask' } })
-      ),
-      AGENT_BOOT_TIMEOUT_MS,
-      'initialize'
-    );
+      const updates: Array<Record<string, unknown>> = [];
+      let subagentJobId: string | undefined;
 
-    await withTimeout(
-      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-      2_000,
-      'session/new'
-    );
+      ctx.agent.peer.onRequest('session/update', async (params) => {
+        const p = params as Record<string, unknown>;
+        updates.push(p);
+        if (p.type === 'job_started' && p.jobType === 'delegate' && typeof p.jobId === 'string') {
+          subagentJobId = p.jobId;
+        }
+        return undefined;
+      });
 
-    // Send a prompt that triggers delegate tool with just modelId
-    // The test provider syntax: "subagent config=,modelId: prompt" (empty connectionId)
-    await withTimeout(
-      ctx.agent.peer.request('session/prompt', {
-        content: [{ type: 'text', text: 'subagent config=,gpt-4o-mini: say hi' }],
-      }),
-      15_000,
-      'session/prompt'
-    );
+      ctx.agent.peer.onRequest('session/request_permission', async () => ({ decision: 'allow' }));
 
-    // Wait for job to finish
-    await withTimeout(
-      new Promise<void>((resolve) => {
-        const interval = setInterval(() => {
-          if (!subagentJobId) return;
-          const finished = updates.find(
-            (u) => u.type === 'job_finished' && u.jobId === subagentJobId
-          );
-          if (finished) {
-            clearInterval(interval);
-            resolve();
-          }
-        }, 10);
-      }),
-      15_000,
-      'job_finished update'
-    );
+      await withTimeout(
+        ctx.agent.peer.request(
+          'initialize',
+          defaultInitializeParams({ config: { approvalMode: 'ask' } })
+        ),
+        AGENT_BOOT_TIMEOUT_MS,
+        'initialize'
+      );
 
-    const output = (await withTimeout(
-      ctx.agent.peer.request('ent/job/output', { jobId: subagentJobId }),
-      2_000,
-      'ent/job/output'
-    )) as { status: string; output: string };
+      await withTimeout(
+        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+        2_000,
+        'session/new'
+      );
 
-    expect(output.status).toBe('completed');
-  });
+      // Send a prompt that triggers delegate tool with just modelId
+      // The test provider syntax: "subagent config=,modelId: prompt" (empty connectionId)
+      await withTimeout(
+        ctx.agent.peer.request('session/prompt', {
+          content: [{ type: 'text', text: 'subagent config=,gpt-4o-mini: say hi' }],
+        }),
+        SUBAGENT_JOB_TIMEOUT_MS,
+        'session/prompt'
+      );
 
-  it(
-    'inherits connectionId/modelId from effective config when delegate provides none',
-    { timeout: 30_000 },
-    async () => {
+      // Wait for job to finish
+      await withTimeout(
+        new Promise<void>((resolve) => {
+          const interval = setInterval(() => {
+            if (!subagentJobId) return;
+            const finished = updates.find(
+              (u) => u.type === 'job_finished' && u.jobId === subagentJobId
+            );
+            if (finished) {
+              clearInterval(interval);
+              resolve();
+            }
+          }, 10);
+        }),
+        SUBAGENT_JOB_TIMEOUT_MS,
+        'job_finished update'
+      );
+
+      const output = (await withTimeout(
+        ctx.agent.peer.request('ent/job/output', { jobId: subagentJobId }),
+        2_000,
+        'ent/job/output'
+      )) as { status: string; output: string };
+
+      expect(output.status).toBe('completed');
+    });
+
+    it('inherits connectionId/modelId from effective config when delegate provides none', async () => {
       process.env.LACE_AGENT_TEST_PROVIDER_STRICT_CONFIG = '1';
       ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
@@ -274,7 +272,7 @@ describe('lace-agent delegate connectionId/modelId (E2E over stdio)', () => {
         ctx.agent.peer.request('session/prompt', {
           content: [{ type: 'text', text: 'subagent: say hi' }],
         }),
-        15_000,
+        SUBAGENT_JOB_TIMEOUT_MS,
         'session/prompt'
       );
 
@@ -291,7 +289,7 @@ describe('lace-agent delegate connectionId/modelId (E2E over stdio)', () => {
             }
           }, 10);
         }),
-        15_000,
+        SUBAGENT_JOB_TIMEOUT_MS,
         'job_finished update'
       );
 
@@ -302,6 +300,6 @@ describe('lace-agent delegate connectionId/modelId (E2E over stdio)', () => {
       )) as { status: string; output: string };
 
       expect(output.status).toBe('completed');
-    }
-  );
-});
+    });
+  }
+);

--- a/packages/agent/src/__tests__/agent-process.delegate.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.delegate.e2e.test.ts
@@ -7,6 +7,8 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
+  SUBAGENT_JOB_TIMEOUT_MS,
 } from './helpers';
 import { readSessionState } from '../storage/session-store';
 
@@ -32,13 +34,13 @@ function readTranscriptEvents(laceDir: string, sessionId: string): unknown[] {
   return [];
 }
 
-describe('lace-agent delegate tool (E2E over stdio)', () => {
+describe('lace-agent delegate tool (E2E over stdio)', { timeout: E2E_TEST_TIMEOUT_MS }, () => {
   const ctx = createE2EContext({ prefix: 'lace-agent-delegate' });
 
   beforeEach(() => ctx.setup());
   afterEach(() => ctx.teardown());
 
-  it('spawns a subagent job via delegate and returns its report', { timeout: 20_000 }, async () => {
+  it('spawns a subagent job via delegate and returns its report', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     const updates: Array<Record<string, unknown>> = [];
@@ -86,7 +88,7 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
       ctx.agent.peer.request('session/prompt', {
         content: [{ type: 'text', text: 'delegate hi' }],
       }),
-      10_000,
+      SUBAGENT_JOB_TIMEOUT_MS,
       'session/prompt'
     );
 
@@ -103,7 +105,7 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
           resolve();
         }, 10);
       }),
-      10_000,
+      SUBAGENT_JOB_TIMEOUT_MS,
       'delegate job completion'
     );
 
@@ -131,92 +133,88 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
     expect(output.output).toContain('No tool result found');
   });
 
-  it(
-    'flattens nested delegate subagents with correct parentJobId',
-    { timeout: 20_000 },
-    async () => {
-      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+  it('flattens nested delegate subagents with correct parentJobId', async () => {
+    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
-      const started: Array<{ jobId: string; parentJobId?: string; jobType: string }> = [];
-      const finished = new Set<string>();
+    const started: Array<{ jobId: string; parentJobId?: string; jobType: string }> = [];
+    const finished = new Set<string>();
 
-      ctx.agent.peer.onRequest('session/update', async (params) => {
-        const p = params as Record<string, unknown>;
-        if (
-          p.type === 'job_started' &&
-          typeof p.jobId === 'string' &&
-          typeof p.jobType === 'string'
-        ) {
-          started.push({
-            jobId: p.jobId,
-            parentJobId: typeof p.parentJobId === 'string' ? p.parentJobId : undefined,
-            jobType: p.jobType,
-          });
-        }
-        if (p.type === 'job_finished' && typeof p.jobId === 'string') {
-          finished.add(p.jobId);
-        }
-        return undefined;
-      });
+    ctx.agent.peer.onRequest('session/update', async (params) => {
+      const p = params as Record<string, unknown>;
+      if (
+        p.type === 'job_started' &&
+        typeof p.jobId === 'string' &&
+        typeof p.jobType === 'string'
+      ) {
+        started.push({
+          jobId: p.jobId,
+          parentJobId: typeof p.parentJobId === 'string' ? p.parentJobId : undefined,
+          jobType: p.jobType,
+        });
+      }
+      if (p.type === 'job_finished' && typeof p.jobId === 'string') {
+        finished.add(p.jobId);
+      }
+      return undefined;
+    });
 
-      ctx.agent.peer.onRequest('session/request_permission', async () => ({ decision: 'allow' }));
+    ctx.agent.peer.onRequest('session/request_permission', async () => ({ decision: 'allow' }));
 
-      await withTimeout(
-        ctx.agent.peer.request(
-          'initialize',
-          defaultInitializeParams({ config: { approvalMode: 'ask' } })
-        ),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
-      await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        2_000,
-        'session/new'
-      );
+    await withTimeout(
+      ctx.agent.peer.request(
+        'initialize',
+        defaultInitializeParams({ config: { approvalMode: 'ask' } })
+      ),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
+    await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      2_000,
+      'session/new'
+    );
 
-      await withTimeout(
-        ctx.agent.peer.request('session/prompt', {
-          content: [{ type: 'text', text: 'delegate delegate write file nested.txt' }],
-        }),
-        10_000,
-        'session/prompt'
-      );
+    await withTimeout(
+      ctx.agent.peer.request('session/prompt', {
+        content: [{ type: 'text', text: 'delegate delegate write file nested.txt' }],
+      }),
+      SUBAGENT_JOB_TIMEOUT_MS,
+      'session/prompt'
+    );
 
-      // Under async-only delegation a subagent is single-turn: the outer
-      // subagent dispatches the inner delegate (which is flattened onto the root
-      // with the correct parentJobId), returns the started-shape, and is torn
-      // down — it has no future turn to await the inner job. So we verify the
-      // flattening from job_started events and the OUTER job's completion; the
-      // inner job's terminal delivery is not part of this contract (nested
-      // inline delegation is intentionally unsupported).
-      const { outerJobId, innerJobId } = await withTimeout(
-        new Promise<{ outerJobId: string; innerJobId: string }>((resolve) => {
-          const interval = setInterval(() => {
-            const subagents = started.filter((s) => s.jobType === 'delegate');
-            if (subagents.length < 2) return;
+    // Under async-only delegation a subagent is single-turn: the outer
+    // subagent dispatches the inner delegate (which is flattened onto the root
+    // with the correct parentJobId), returns the started-shape, and is torn
+    // down — it has no future turn to await the inner job. So we verify the
+    // flattening from job_started events and the OUTER job's completion; the
+    // inner job's terminal delivery is not part of this contract (nested
+    // inline delegation is intentionally unsupported).
+    const { outerJobId, innerJobId } = await withTimeout(
+      new Promise<{ outerJobId: string; innerJobId: string }>((resolve) => {
+        const interval = setInterval(() => {
+          const subagents = started.filter((s) => s.jobType === 'delegate');
+          if (subagents.length < 2) return;
 
-            const outerJobId = subagents[0]!.jobId;
-            const inner = subagents.find(
-              (s) => s.jobId !== outerJobId && s.parentJobId === outerJobId
-            );
-            if (!inner) return;
+          const outerJobId = subagents[0]!.jobId;
+          const inner = subagents.find(
+            (s) => s.jobId !== outerJobId && s.parentJobId === outerJobId
+          );
+          if (!inner) return;
 
-            if (!finished.has(outerJobId)) return;
+          if (!finished.has(outerJobId)) return;
 
-            clearInterval(interval);
-            resolve({ outerJobId, innerJobId: inner.jobId });
-          }, 10);
-        }),
-        10_000,
-        'nested job flattening'
-      );
+          clearInterval(interval);
+          resolve({ outerJobId, innerJobId: inner.jobId });
+        }, 10);
+      }),
+      SUBAGENT_JOB_TIMEOUT_MS,
+      'nested job flattening'
+    );
 
-      expect(outerJobId).not.toBe(innerJobId);
-    }
-  );
+    expect(outerJobId).not.toBe(innerJobId);
+  });
 
-  it('can resume a completed delegate job', { timeout: 20_000 }, async () => {
+  it('can resume a completed delegate job', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     const updates: Array<Record<string, unknown>> = [];
@@ -259,7 +257,7 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
       ctx.agent.peer.request('session/prompt', {
         content: [{ type: 'text', text: 'delegate say hello' }],
       }),
-      10_000,
+      SUBAGENT_JOB_TIMEOUT_MS,
       'first delegate'
     );
 
@@ -275,7 +273,7 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
           }
         }, 10);
       }),
-      10_000,
+      SUBAGENT_JOB_TIMEOUT_MS,
       'first job completion'
     );
 
@@ -286,7 +284,7 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
       ctx.agent.peer.request('session/prompt', {
         content: [{ type: 'text', text: `delegate resume=${firstJobId} now say goodbye` }],
       }),
-      10_000,
+      SUBAGENT_JOB_TIMEOUT_MS,
       'resume delegate'
     );
 
@@ -304,7 +302,7 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
           }
         }, 10);
       }),
-      10_000,
+      SUBAGENT_JOB_TIMEOUT_MS,
       'resume job completion'
     );
 
@@ -321,7 +319,7 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
     expect(output.status).toBe('completed');
   });
 
-  it('can chain resumes (resume a resumed job)', { timeout: 30_000 }, async () => {
+  it('can chain resumes (resume a resumed job)', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     const updates: Array<Record<string, unknown>> = [];
@@ -359,7 +357,7 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
       ctx.agent.peer.request('session/prompt', {
         content: [{ type: 'text', text: 'delegate say 1' }],
       }),
-      10_000,
+      SUBAGENT_JOB_TIMEOUT_MS,
       'first delegate'
     );
 
@@ -377,7 +375,7 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
           }
         }, 10);
       }),
-      10_000,
+      SUBAGENT_JOB_TIMEOUT_MS,
       'first job completion'
     );
 
@@ -386,7 +384,7 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
       ctx.agent.peer.request('session/prompt', {
         content: [{ type: 'text', text: `delegate resume=${delegateJobs[0]} say 2` }],
       }),
-      10_000,
+      SUBAGENT_JOB_TIMEOUT_MS,
       'first resume'
     );
 
@@ -404,7 +402,7 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
           }
         }, 10);
       }),
-      10_000,
+      SUBAGENT_JOB_TIMEOUT_MS,
       'second job completion'
     );
 
@@ -413,7 +411,7 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
       ctx.agent.peer.request('session/prompt', {
         content: [{ type: 'text', text: `delegate resume=${delegateJobs[1]} say 3` }],
       }),
-      10_000,
+      SUBAGENT_JOB_TIMEOUT_MS,
       'second resume (chained)'
     );
 
@@ -431,7 +429,7 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
           }
         }, 10);
       }),
-      10_000,
+      SUBAGENT_JOB_TIMEOUT_MS,
       'third job completion'
     );
 
@@ -448,94 +446,90 @@ describe('lace-agent delegate tool (E2E over stdio)', () => {
     expect(output.status).toBe('completed');
   });
 
-  it(
-    'persists job_session_assigned event and exposes subagentSessionId via ent/job/list',
-    { timeout: 20_000 },
-    async () => {
-      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+  it('persists job_session_assigned event and exposes subagentSessionId via ent/job/list', async () => {
+    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
-      let delegateJobId: string | undefined;
+    let delegateJobId: string | undefined;
 
-      ctx.agent.peer.onRequest('session/update', async (params) => {
-        const p = params as Record<string, unknown>;
-        if (p.type === 'job_started' && p.jobType === 'delegate' && typeof p.jobId === 'string') {
-          delegateJobId = p.jobId;
-        }
-        return undefined;
-      });
+    ctx.agent.peer.onRequest('session/update', async (params) => {
+      const p = params as Record<string, unknown>;
+      if (p.type === 'job_started' && p.jobType === 'delegate' && typeof p.jobId === 'string') {
+        delegateJobId = p.jobId;
+      }
+      return undefined;
+    });
 
-      ctx.agent.peer.onRequest('session/request_permission', async () => ({ decision: 'allow' }));
+    ctx.agent.peer.onRequest('session/request_permission', async () => ({ decision: 'allow' }));
 
-      await withTimeout(
-        ctx.agent.peer.request(
-          'initialize',
-          defaultInitializeParams({ config: { approvalMode: 'ask' } })
-        ),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
-      const sessionResult = (await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        2_000,
-        'session/new'
-      )) as { sessionId: string };
-      const sessionId = sessionResult.sessionId;
+    await withTimeout(
+      ctx.agent.peer.request(
+        'initialize',
+        defaultInitializeParams({ config: { approvalMode: 'ask' } })
+      ),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
+    const sessionResult = (await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      2_000,
+      'session/new'
+    )) as { sessionId: string };
+    const sessionId = sessionResult.sessionId;
 
-      // Run a delegate
-      await withTimeout(
-        ctx.agent.peer.request('session/prompt', {
-          content: [{ type: 'text', text: 'delegate say hi' }],
-        }),
-        10_000,
-        'delegate prompt'
-      );
+    // Run a delegate
+    await withTimeout(
+      ctx.agent.peer.request('session/prompt', {
+        content: [{ type: 'text', text: 'delegate say hi' }],
+      }),
+      SUBAGENT_JOB_TIMEOUT_MS,
+      'delegate prompt'
+    );
 
-      // Wait for job to complete
-      await withTimeout(
-        new Promise<void>((resolve) => {
-          const interval = setInterval(async () => {
-            if (!delegateJobId) return;
-            const jobs = (await ctx.agent!.peer.request('ent/job/list', {})) as {
-              jobs: Array<{ jobId: string; status: string }>;
-            };
-            const job = jobs.jobs.find((j) => j.jobId === delegateJobId);
-            if (job && job.status !== 'running') {
-              clearInterval(interval);
-              resolve();
-            }
-          }, 50);
-        }),
-        10_000,
-        'job completion'
-      );
+    // Wait for job to complete
+    await withTimeout(
+      new Promise<void>((resolve) => {
+        const interval = setInterval(async () => {
+          if (!delegateJobId) return;
+          const jobs = (await ctx.agent!.peer.request('ent/job/list', {})) as {
+            jobs: Array<{ jobId: string; status: string }>;
+          };
+          const job = jobs.jobs.find((j) => j.jobId === delegateJobId);
+          if (job && job.status !== 'running') {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 50);
+      }),
+      SUBAGENT_JOB_TIMEOUT_MS,
+      'job completion'
+    );
 
-      // Check the transcript for job_session_assigned
-      const sessionsDir = join(ctx.laceDir, 'agent-sessions');
-      const events = readTranscriptEvents(ctx.laceDir, sessionId) as Array<{
-        type?: string;
-        data?: { jobId?: string; subagentSessionId?: string };
-      }>;
+    // Check the transcript for job_session_assigned
+    const sessionsDir = join(ctx.laceDir, 'agent-sessions');
+    const events = readTranscriptEvents(ctx.laceDir, sessionId) as Array<{
+      type?: string;
+      data?: { jobId?: string; subagentSessionId?: string };
+    }>;
 
-      const sessionAssignedEvent = events.find(
-        (e) => e.type === 'job_session_assigned' && e.data?.jobId === delegateJobId
-      );
-      expect(sessionAssignedEvent).toBeDefined();
-      expect(sessionAssignedEvent!.data!.subagentSessionId).toBeDefined();
-      expect(typeof sessionAssignedEvent!.data!.subagentSessionId).toBe('string');
+    const sessionAssignedEvent = events.find(
+      (e) => e.type === 'job_session_assigned' && e.data?.jobId === delegateJobId
+    );
+    expect(sessionAssignedEvent).toBeDefined();
+    expect(sessionAssignedEvent!.data!.subagentSessionId).toBeDefined();
+    expect(typeof sessionAssignedEvent!.data!.subagentSessionId).toBe('string');
 
-      const subagentSessionDir = join(sessionsDir, sessionAssignedEvent!.data!.subagentSessionId!);
-      expect(readSessionState(subagentSessionDir).config?.runtimeBinding).toMatchObject({
-        schemaVersion: 1,
-        toolRuntime: { type: 'boundedHost', root: ctx.workDir, cwd: ctx.workDir },
-      });
+    const subagentSessionDir = join(sessionsDir, sessionAssignedEvent!.data!.subagentSessionId!);
+    expect(readSessionState(subagentSessionDir).config?.runtimeBinding).toMatchObject({
+      schemaVersion: 1,
+      toolRuntime: { type: 'boundedHost', root: ctx.workDir, cwd: ctx.workDir },
+    });
 
-      // Verify ent/job/list returns the subagentSessionId
-      const jobList = (await ctx.agent.peer.request('ent/job/list', {})) as {
-        jobs: Array<{ jobId: string; subagentSessionId?: string }>;
-      };
-      const job = jobList.jobs.find((j) => j.jobId === delegateJobId);
-      expect(job).toBeDefined();
-      expect(job!.subagentSessionId).toBe(sessionAssignedEvent!.data!.subagentSessionId);
-    }
-  );
+    // Verify ent/job/list returns the subagentSessionId
+    const jobList = (await ctx.agent.peer.request('ent/job/list', {})) as {
+      jobs: Array<{ jobId: string; subagentSessionId?: string }>;
+    };
+    const job = jobList.jobs.find((j) => j.jobId === delegateJobId);
+    expect(job).toBeDefined();
+    expect(job!.subagentSessionId).toBe(sessionAssignedEvent!.data!.subagentSessionId);
+  });
 });

--- a/packages/agent/src/__tests__/agent-process.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.e2e.test.ts
@@ -8,9 +8,10 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
 } from './helpers';
 
-describe('lace-agent process (E2E over stdio)', () => {
+describe('lace-agent process (E2E over stdio)', { timeout: E2E_TEST_TIMEOUT_MS }, () => {
   const ctx = createE2EContext({ prefix: 'lace-agent-e2e' });
 
   beforeEach(() => ctx.setup());
@@ -49,95 +50,91 @@ describe('lace-agent process (E2E over stdio)', () => {
     });
   });
 
-  it(
-    'initializes, creates a session, streams updates, and persists durable events',
-    { timeout: 15_000 },
-    async () => {
-      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+  it('initializes, creates a session, streams updates, and persists durable events', async () => {
+    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
-      const updates: unknown[] = [];
-      ctx.agent.peer.onRequest('session/update', async (params) => {
-        updates.push(params);
-        return undefined;
-      });
+    const updates: unknown[] = [];
+    ctx.agent.peer.onRequest('session/update', async (params) => {
+      updates.push(params);
+      return undefined;
+    });
 
-      await withTimeout(
-        ctx.agent.peer.request('initialize', defaultInitializeParams()),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
+    await withTimeout(
+      ctx.agent.peer.request('initialize', defaultInitializeParams()),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
 
-      const created = (await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        2_000,
-        'session/new'
-      )) as { sessionId: string };
+    const created = (await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      2_000,
+      'session/new'
+    )) as { sessionId: string };
 
-      writeFileSync(join(ctx.workDir, 'hello.txt'), 'hi from disk\n', 'utf8');
+    writeFileSync(join(ctx.workDir, 'hello.txt'), 'hi from disk\n', 'utf8');
 
-      const promptResult = (await withTimeout(
-        ctx.agent.peer.request('session/prompt', {
-          content: [{ type: 'text', text: 'read file hello.txt' }],
-        }),
-        10_000,
-        'session/prompt'
-      )) as { turnId: string };
+    const promptResult = (await withTimeout(
+      ctx.agent.peer.request('session/prompt', {
+        content: [{ type: 'text', text: 'read file hello.txt' }],
+      }),
+      10_000,
+      'session/prompt'
+    )) as { turnId: string };
 
-      await withTimeout(
-        new Promise<void>((resolve) => {
-          const interval = setInterval(() => {
-            const match = updates.find((u) => {
-              const p = u as Record<string, unknown>;
-              return (
-                p?.type === 'tool_use' &&
-                p?.name === 'file_read' &&
-                p?.status === 'completed' &&
-                p?.turnId === promptResult.turnId
-              );
-            });
-            if (match) {
-              clearInterval(interval);
-              resolve();
-            }
-          }, 10);
-        }),
-        5_000,
-        'session/update tool_use stream'
-      );
+    await withTimeout(
+      new Promise<void>((resolve) => {
+        const interval = setInterval(() => {
+          const match = updates.find((u) => {
+            const p = u as Record<string, unknown>;
+            return (
+              p?.type === 'tool_use' &&
+              p?.name === 'file_read' &&
+              p?.status === 'completed' &&
+              p?.turnId === promptResult.turnId
+            );
+          });
+          if (match) {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 10);
+      }),
+      5_000,
+      'session/update tool_use stream'
+    );
 
-      const durable = (await withTimeout(
-        ctx.agent.peer.request('ent/session/events', { afterEventSeq: 0, limit: 100 }),
-        2_000,
-        'ent/session/events'
-      )) as { events: Array<{ eventSeq: number; type: string }>; hasMore: boolean };
+    const durable = (await withTimeout(
+      ctx.agent.peer.request('ent/session/events', { afterEventSeq: 0, limit: 100 }),
+      2_000,
+      'ent/session/events'
+    )) as { events: Array<{ eventSeq: number; type: string }>; hasMore: boolean };
 
-      expect(durable.hasMore).toBe(false);
-      // system_prompt_set is written on session creation with the rendered system prompt
-      // After the tool result, the LLM returns bare text which triggers a
-      // tool_choice=required retry, producing an extra message event
-      expect(durable.events.map((e) => e.type)).toEqual([
-        'system_prompt_set',
-        'prompt',
-        'turn_start',
-        'message',
-        'tool_use',
-        'message', // LLM's response after tool result (bare text)
-        'message', // bare text retry response
-        'turn_end',
-      ]);
-      expect(durable.events.map((e) => e.eventSeq)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(durable.hasMore).toBe(false);
+    // system_prompt_set is written on session creation with the rendered system prompt
+    // After the tool result, the LLM returns bare text which triggers a
+    // tool_choice=required retry, producing an extra message event
+    expect(durable.events.map((e) => e.type)).toEqual([
+      'system_prompt_set',
+      'prompt',
+      'turn_start',
+      'message',
+      'tool_use',
+      'message', // LLM's response after tool result (bare text)
+      'message', // bare text retry response
+      'turn_end',
+    ]);
+    expect(durable.events.map((e) => e.eventSeq)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
 
-      const list = (await withTimeout(
-        ctx.agent.peer.request('session/list', { cwd: ctx.workDir }),
-        2_000,
-        'session/list'
-      )) as { sessions: Array<{ sessionId: string }> };
+    const list = (await withTimeout(
+      ctx.agent.peer.request('session/list', { cwd: ctx.workDir }),
+      2_000,
+      'session/list'
+    )) as { sessions: Array<{ sessionId: string }> };
 
-      expect(list.sessions.map((s) => s.sessionId)).toContain(created.sessionId);
-    }
-  );
+    expect(list.sessions.map((s) => s.sessionId)).toContain(created.sessionId);
+  });
 
-  it('keeps JSONL session history across agent restarts', { timeout: 15_000 }, async () => {
+  it('keeps JSONL session history across agent restarts', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
@@ -203,7 +200,7 @@ describe('lace-agent process (E2E over stdio)', () => {
     expect(durable.events.map((e) => e.eventSeq)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
   });
 
-  it('reports currentSession.messageCount in ent/agent/status', { timeout: 15_000 }, async () => {
+  it('reports currentSession.messageCount in ent/agent/status', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     await withTimeout(
@@ -234,364 +231,350 @@ describe('lace-agent process (E2E over stdio)', () => {
     expect(status.currentSession?.messageCount ?? 0).toBeGreaterThan(0);
   });
 
-  it(
-    'requests permission before running bash and records a tool_use event',
-    { timeout: 15_000 },
-    async () => {
-      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+  it('requests permission before running bash and records a tool_use event', async () => {
+    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
-      const updates: unknown[] = [];
-      ctx.agent.peer.onRequest('session/update', async (params) => {
-        updates.push(params);
-        return undefined;
+    const updates: unknown[] = [];
+    ctx.agent.peer.onRequest('session/update', async (params) => {
+      updates.push(params);
+      return undefined;
+    });
+
+    let lastPermissionParams: Record<string, unknown> | undefined;
+    ctx.agent.peer.onRequest('session/request_permission', async (params) => {
+      lastPermissionParams = params as Record<string, unknown>;
+      return { decision: 'allow' };
+    });
+
+    await withTimeout(
+      ctx.agent.peer.request(
+        'initialize',
+        defaultInitializeParams({ config: { approvalMode: 'ask' } })
+      ),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
+
+    await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      2_000,
+      'session/new'
+    );
+
+    const promptResult = (await withTimeout(
+      ctx.agent.peer.request('session/prompt', {
+        content: [{ type: 'text', text: 'run: echo hi' }],
+      }),
+      10_000,
+      'session/prompt'
+    )) as { turnId: string };
+
+    await withTimeout(
+      new Promise<void>((resolve) => {
+        const interval = setInterval(() => {
+          const toolFinished = updates.find((u) => {
+            const p = u as Record<string, unknown>;
+            const result = p?.result as Record<string, unknown> | undefined;
+            return (
+              p?.type === 'tool_use' && p?.status === 'completed' && result?.outcome === 'completed'
+            );
+          });
+          if (toolFinished) {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 10);
+      }),
+      5_000,
+      'tool_use completed update'
+    );
+
+    expect(lastPermissionParams).toMatchObject({
+      tool: 'bash',
+      resource: 'echo hi',
+      sessionId: expect.any(String),
+      turnId: promptResult.turnId,
+      toolCallId: expect.any(String),
+    });
+
+    const durable = (await withTimeout(
+      ctx.agent.peer.request('ent/session/events', { afterEventSeq: 0, limit: 100 }),
+      2_000,
+      'ent/session/events'
+    )) as { events: Array<{ eventSeq: number; type: string }>; hasMore: boolean };
+
+    // system_prompt_set is written on session creation with the rendered system prompt
+    // The LLM (test provider) emits a message before the tool call ("Running echo hi..."),
+    // so we expect an extra message event before permission_requested.
+    // After the tool result, the LLM returns bare text which triggers a
+    // tool_choice=required retry, producing an extra message event.
+    expect(durable.events.map((e) => e.type)).toEqual([
+      'system_prompt_set',
+      'prompt',
+      'turn_start',
+      'message', // LLM's initial response before tool call
+      'permission_requested',
+      'permission_decided',
+      'tool_use',
+      'message', // LLM's response after tool result (bare text)
+      'message', // bare text retry response
+      'turn_end',
+    ]);
+
+    expect(durable.events.map((e) => e.eventSeq)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+
+  it('requests permission before running file_write and exposes pending permissions via ent/agent/status', async () => {
+    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+
+    let permissionParams: Record<string, unknown> | undefined;
+    let resolvePermission:
+      | ((value: { decision: string; updatedInput?: Record<string, unknown> }) => void)
+      | undefined;
+
+    ctx.agent.peer.onRequest('session/request_permission', async (params) => {
+      permissionParams = params as Record<string, unknown>;
+      return await new Promise((resolve) => {
+        resolvePermission = resolve as any;
       });
+    });
 
-      let lastPermissionParams: Record<string, unknown> | undefined;
-      ctx.agent.peer.onRequest('session/request_permission', async (params) => {
-        lastPermissionParams = params as Record<string, unknown>;
-        return { decision: 'allow' };
-      });
+    await withTimeout(
+      ctx.agent.peer.request(
+        'initialize',
+        defaultInitializeParams({ config: { approvalMode: 'ask' } })
+      ),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
 
-      await withTimeout(
-        ctx.agent.peer.request(
-          'initialize',
-          defaultInitializeParams({ config: { approvalMode: 'ask' } })
-        ),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
+    await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      2_000,
+      'session/new'
+    );
 
-      await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        2_000,
-        'session/new'
-      );
+    const promptPromise = ctx.agent.peer.request('session/prompt', {
+      content: [{ type: 'text', text: 'write file out.txt' }],
+    });
 
-      const promptResult = (await withTimeout(
-        ctx.agent.peer.request('session/prompt', {
-          content: [{ type: 'text', text: 'run: echo hi' }],
-        }),
-        10_000,
-        'session/prompt'
-      )) as { turnId: string };
+    await withTimeout(
+      new Promise<void>((resolve) => {
+        const interval = setInterval(() => {
+          if (permissionParams) {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 10);
+      }),
+      5_000,
+      'permission request'
+    );
 
-      await withTimeout(
-        new Promise<void>((resolve) => {
-          const interval = setInterval(() => {
-            const toolFinished = updates.find((u) => {
-              const p = u as Record<string, unknown>;
-              const result = p?.result as Record<string, unknown> | undefined;
-              return (
-                p?.type === 'tool_use' &&
-                p?.status === 'completed' &&
-                result?.outcome === 'completed'
-              );
-            });
-            if (toolFinished) {
-              clearInterval(interval);
-              resolve();
-            }
-          }, 10);
-        }),
-        5_000,
-        'tool_use completed update'
-      );
+    expect(permissionParams).toMatchObject({
+      tool: 'file_write',
+      sessionId: expect.any(String),
+      turnId: expect.any(String),
+      toolCallId: expect.any(String),
+    });
 
-      expect(lastPermissionParams).toMatchObject({
-        tool: 'bash',
-        resource: 'echo hi',
-        sessionId: expect.any(String),
-        turnId: promptResult.turnId,
-        toolCallId: expect.any(String),
-      });
+    const status = (await withTimeout(
+      ctx.agent.peer.request('ent/agent/status', {}),
+      2_000,
+      'ent/agent/status'
+    )) as { pendingPermissions: Array<{ tool: string }> };
 
-      const durable = (await withTimeout(
-        ctx.agent.peer.request('ent/session/events', { afterEventSeq: 0, limit: 100 }),
-        2_000,
-        'ent/session/events'
-      )) as { events: Array<{ eventSeq: number; type: string }>; hasMore: boolean };
+    expect(status.pendingPermissions.find((p) => p.tool === 'file_write')).toBeTruthy();
 
-      // system_prompt_set is written on session creation with the rendered system prompt
-      // The LLM (test provider) emits a message before the tool call ("Running echo hi..."),
-      // so we expect an extra message event before permission_requested.
-      // After the tool result, the LLM returns bare text which triggers a
-      // tool_choice=required retry, producing an extra message event.
-      expect(durable.events.map((e) => e.type)).toEqual([
-        'system_prompt_set',
-        'prompt',
-        'turn_start',
-        'message', // LLM's initial response before tool call
-        'permission_requested',
-        'permission_decided',
-        'tool_use',
-        'message', // LLM's response after tool result (bare text)
-        'message', // bare text retry response
-        'turn_end',
-      ]);
+    resolvePermission?.({ decision: 'allow' });
 
-      expect(durable.events.map((e) => e.eventSeq)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    }
-  );
+    await withTimeout(promptPromise, 10_000, 'session/prompt (write)');
 
-  it(
-    'requests permission before running file_write and exposes pending permissions via ent/agent/status',
-    { timeout: 20_000 },
-    async () => {
-      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+    expect(existsSync(join(ctx.workDir, 'out.txt'))).toBe(true);
+    expect(readFileSync(join(ctx.workDir, 'out.txt'), 'utf8')).toContain(
+      'written by test provider'
+    );
+  });
 
-      let permissionParams: Record<string, unknown> | undefined;
-      let resolvePermission:
-        | ((value: { decision: string; updatedInput?: Record<string, unknown> }) => void)
-        | undefined;
+  it('reissues pending permission prompts after agent restart (derived from events.jsonl)', async () => {
+    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
-      ctx.agent.peer.onRequest('session/request_permission', async (params) => {
-        permissionParams = params as Record<string, unknown>;
-        return await new Promise((resolve) => {
-          resolvePermission = resolve as any;
-        });
-      });
+    let sawPermissionRequest = false;
+    ctx.agent.peer.onRequest('session/request_permission', async () => {
+      sawPermissionRequest = true;
+      return await new Promise(() => undefined);
+    });
 
-      await withTimeout(
-        ctx.agent.peer.request(
-          'initialize',
-          defaultInitializeParams({ config: { approvalMode: 'ask' } })
-        ),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
+    await withTimeout(
+      ctx.agent.peer.request(
+        'initialize',
+        defaultInitializeParams({ config: { approvalMode: 'ask' } })
+      ),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
 
-      await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        2_000,
-        'session/new'
-      );
+    const created = (await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      2_000,
+      'session/new'
+    )) as { sessionId: string };
 
-      const promptPromise = ctx.agent.peer.request('session/prompt', {
-        content: [{ type: 'text', text: 'write file out.txt' }],
-      });
+    const promptPromise = ctx.agent.peer.request('session/prompt', {
+      content: [{ type: 'text', text: 'run: echo pending' }],
+    });
 
-      await withTimeout(
-        new Promise<void>((resolve) => {
-          const interval = setInterval(() => {
-            if (permissionParams) {
-              clearInterval(interval);
-              resolve();
-            }
-          }, 10);
-        }),
-        5_000,
-        'permission request'
-      );
+    await withTimeout(
+      new Promise<void>((resolve) => {
+        const interval = setInterval(() => {
+          if (sawPermissionRequest) {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 10);
+      }),
+      5_000,
+      'permission request received'
+    );
 
-      expect(permissionParams).toMatchObject({
-        tool: 'file_write',
-        sessionId: expect.any(String),
-        turnId: expect.any(String),
-        toolCallId: expect.any(String),
-      });
+    const beforeCrash = (await withTimeout(
+      ctx.agent.peer.request('ent/agent/status'),
+      2_000,
+      'ent/agent/status (before crash)'
+    )) as { pendingPermissions: Array<{ requestId: string; toolCallId: string }> };
 
-      const status = (await withTimeout(
-        ctx.agent.peer.request('ent/agent/status', {}),
-        2_000,
-        'ent/agent/status'
-      )) as { pendingPermissions: Array<{ tool: string }> };
+    expect(beforeCrash.pendingPermissions).toHaveLength(1);
+    const [{ requestId: requestIdBefore, toolCallId }] = beforeCrash.pendingPermissions;
+    expect(requestIdBefore).toEqual(expect.any(String));
+    expect(toolCallId).toEqual(expect.any(String));
 
-      expect(status.pendingPermissions.find((p) => p.tool === 'file_write')).toBeTruthy();
+    const stateRaw = readFileSync(
+      join(ctx.laceDir, 'agent-sessions', created.sessionId, 'state.json'),
+      'utf8'
+    );
+    expect((JSON.parse(stateRaw) as any).pendingPermissions).toBeUndefined();
 
-      resolvePermission?.({ decision: 'allow' });
-
-      await withTimeout(promptPromise, 10_000, 'session/prompt (write)');
-
-      expect(existsSync(join(ctx.workDir, 'out.txt'))).toBe(true);
-      expect(readFileSync(join(ctx.workDir, 'out.txt'), 'utf8')).toContain(
-        'written by test provider'
-      );
-    }
-  );
-
-  it(
-    'reissues pending permission prompts after agent restart (derived from events.jsonl)',
-    { timeout: 25_000 },
-    async () => {
-      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
-
-      let sawPermissionRequest = false;
-      ctx.agent.peer.onRequest('session/request_permission', async () => {
-        sawPermissionRequest = true;
-        return await new Promise(() => undefined);
-      });
-
-      await withTimeout(
-        ctx.agent.peer.request(
-          'initialize',
-          defaultInitializeParams({ config: { approvalMode: 'ask' } })
-        ),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
-
-      const created = (await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        2_000,
-        'session/new'
-      )) as { sessionId: string };
-
-      const promptPromise = ctx.agent.peer.request('session/prompt', {
-        content: [{ type: 'text', text: 'run: echo pending' }],
-      });
-
-      await withTimeout(
-        new Promise<void>((resolve) => {
-          const interval = setInterval(() => {
-            if (sawPermissionRequest) {
-              clearInterval(interval);
-              resolve();
-            }
-          }, 10);
-        }),
-        5_000,
-        'permission request received'
-      );
-
-      const beforeCrash = (await withTimeout(
-        ctx.agent.peer.request('ent/agent/status'),
-        2_000,
-        'ent/agent/status (before crash)'
-      )) as { pendingPermissions: Array<{ requestId: string; toolCallId: string }> };
-
-      expect(beforeCrash.pendingPermissions).toHaveLength(1);
-      const [{ requestId: requestIdBefore, toolCallId }] = beforeCrash.pendingPermissions;
-      expect(requestIdBefore).toEqual(expect.any(String));
-      expect(toolCallId).toEqual(expect.any(String));
-
-      const stateRaw = readFileSync(
-        join(ctx.laceDir, 'agent-sessions', created.sessionId, 'state.json'),
-        'utf8'
-      );
-      expect((JSON.parse(stateRaw) as any).pendingPermissions).toBeUndefined();
-
-      // Transcript files now live under <laceDir>/transcripts/<persona>/<date>/.
-      // Read every line from the session's transcript and verify the events.
-      const transcriptsRoot = join(ctx.laceDir, 'transcripts');
-      let allTranscriptText = '';
-      if (existsSync(transcriptsRoot)) {
-        for (const persona of readdirSync(transcriptsRoot)) {
-          const personaDir = join(transcriptsRoot, persona);
-          for (const date of readdirSync(personaDir)) {
-            const candidate = join(personaDir, date, `${created.sessionId}.jsonl`);
-            if (existsSync(candidate)) {
-              allTranscriptText += readFileSync(candidate, 'utf8');
-            }
+    // Transcript files now live under <laceDir>/transcripts/<persona>/<date>/.
+    // Read every line from the session's transcript and verify the events.
+    const transcriptsRoot = join(ctx.laceDir, 'transcripts');
+    let allTranscriptText = '';
+    if (existsSync(transcriptsRoot)) {
+      for (const persona of readdirSync(transcriptsRoot)) {
+        const personaDir = join(transcriptsRoot, persona);
+        for (const date of readdirSync(personaDir)) {
+          const candidate = join(personaDir, date, `${created.sessionId}.jsonl`);
+          if (existsSync(candidate)) {
+            allTranscriptText += readFileSync(candidate, 'utf8');
           }
         }
       }
-      expect(allTranscriptText).toContain('"permission_requested"');
-      expect(allTranscriptText).not.toContain('"permission_decided"');
-
-      ctx.agent.proc.kill('SIGKILL');
-      await withTimeout(
-        new Promise<void>((resolve) => ctx.agent!.proc.once('exit', () => resolve())),
-        2_000,
-        'agent process exit'
-      );
-      ctx.agent.peer.close();
-      ctx.agent = undefined;
-
-      await expect(
-        withTimeout(promptPromise as Promise<unknown>, 2_000, 'prompt crashed')
-      ).rejects.toBeDefined();
-
-      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
-
-      const reissued: Array<Record<string, unknown>> = [];
-      let resolveReissue:
-        | ((value: { decision: string; updatedInput?: Record<string, unknown> }) => void)
-        | undefined;
-      ctx.agent.peer.onRequest('session/request_permission', async (params) => {
-        reissued.push(params as Record<string, unknown>);
-        return await new Promise((resolve) => {
-          resolveReissue = resolve as any;
-        });
-      });
-
-      await withTimeout(
-        ctx.agent.peer.request(
-          'initialize',
-          defaultInitializeParams({ config: { approvalMode: 'ask' } })
-        ),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize (restart)'
-      );
-      await withTimeout(
-        ctx.agent.peer.request('session/load', {
-          sessionId: created.sessionId,
-          cwd: ctx.workDir,
-          mcpServers: [],
-        }),
-        2_000,
-        'session/load (restart)'
-      );
-
-      await withTimeout(
-        new Promise<void>((resolve) => {
-          const interval = setInterval(() => {
-            if (reissued.length > 0) {
-              clearInterval(interval);
-              resolve();
-            }
-          }, 10);
-        }),
-        5_000,
-        'permission request reissued'
-      );
-
-      expect(reissued[0]).toMatchObject({ toolCallId });
-
-      const afterRestart = (await withTimeout(
-        ctx.agent.peer.request('ent/agent/status'),
-        2_000,
-        'ent/agent/status (after restart)'
-      )) as { pendingPermissions: Array<{ requestId: string; toolCallId: string }> };
-
-      expect(afterRestart.pendingPermissions).toHaveLength(1);
-      expect(afterRestart.pendingPermissions[0]?.toolCallId).toBe(toolCallId);
-      expect(afterRestart.pendingPermissions[0]?.requestId).toEqual(expect.any(String));
-
-      resolveReissue?.({ decision: 'deny' });
-
-      await withTimeout(
-        new Promise<void>((resolve, reject) => {
-          const interval = setInterval(() => {
-            void ctx
-              .agent!.peer.request('ent/agent/status')
-              .then((status) => {
-                const p = status as { pendingPermissions?: unknown[] };
-                if ((p.pendingPermissions ?? []).length === 0) {
-                  clearInterval(interval);
-                  resolve();
-                }
-              })
-              .catch((err) => {
-                clearInterval(interval);
-                reject(err);
-              });
-          }, 25);
-        }),
-        5_000,
-        'pending permissions cleared after decision'
-      );
-
-      const durable = (await withTimeout(
-        ctx.agent.peer.request('ent/session/events', { afterEventSeq: 0, limit: 100 }),
-        2_000,
-        'ent/session/events (after restart)'
-      )) as { events: Array<{ type: string }> };
-
-      expect(durable.events.map((e) => e.type)).toEqual(
-        expect.arrayContaining(['permission_requested', 'permission_decided'])
-      );
     }
-  );
+    expect(allTranscriptText).toContain('"permission_requested"');
+    expect(allTranscriptText).not.toContain('"permission_decided"');
+
+    ctx.agent.proc.kill('SIGKILL');
+    await withTimeout(
+      new Promise<void>((resolve) => ctx.agent!.proc.once('exit', () => resolve())),
+      2_000,
+      'agent process exit'
+    );
+    ctx.agent.peer.close();
+    ctx.agent = undefined;
+
+    await expect(
+      withTimeout(promptPromise as Promise<unknown>, 2_000, 'prompt crashed')
+    ).rejects.toBeDefined();
+
+    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+
+    const reissued: Array<Record<string, unknown>> = [];
+    let resolveReissue:
+      | ((value: { decision: string; updatedInput?: Record<string, unknown> }) => void)
+      | undefined;
+    ctx.agent.peer.onRequest('session/request_permission', async (params) => {
+      reissued.push(params as Record<string, unknown>);
+      return await new Promise((resolve) => {
+        resolveReissue = resolve as any;
+      });
+    });
+
+    await withTimeout(
+      ctx.agent.peer.request(
+        'initialize',
+        defaultInitializeParams({ config: { approvalMode: 'ask' } })
+      ),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize (restart)'
+    );
+    await withTimeout(
+      ctx.agent.peer.request('session/load', {
+        sessionId: created.sessionId,
+        cwd: ctx.workDir,
+        mcpServers: [],
+      }),
+      2_000,
+      'session/load (restart)'
+    );
+
+    await withTimeout(
+      new Promise<void>((resolve) => {
+        const interval = setInterval(() => {
+          if (reissued.length > 0) {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 10);
+      }),
+      5_000,
+      'permission request reissued'
+    );
+
+    expect(reissued[0]).toMatchObject({ toolCallId });
+
+    const afterRestart = (await withTimeout(
+      ctx.agent.peer.request('ent/agent/status'),
+      2_000,
+      'ent/agent/status (after restart)'
+    )) as { pendingPermissions: Array<{ requestId: string; toolCallId: string }> };
+
+    expect(afterRestart.pendingPermissions).toHaveLength(1);
+    expect(afterRestart.pendingPermissions[0]?.toolCallId).toBe(toolCallId);
+    expect(afterRestart.pendingPermissions[0]?.requestId).toEqual(expect.any(String));
+
+    resolveReissue?.({ decision: 'deny' });
+
+    await withTimeout(
+      new Promise<void>((resolve, reject) => {
+        const interval = setInterval(() => {
+          void ctx
+            .agent!.peer.request('ent/agent/status')
+            .then((status) => {
+              const p = status as { pendingPermissions?: unknown[] };
+              if ((p.pendingPermissions ?? []).length === 0) {
+                clearInterval(interval);
+                resolve();
+              }
+            })
+            .catch((err) => {
+              clearInterval(interval);
+              reject(err);
+            });
+        }, 25);
+      }),
+      5_000,
+      'pending permissions cleared after decision'
+    );
+
+    const durable = (await withTimeout(
+      ctx.agent.peer.request('ent/session/events', { afterEventSeq: 0, limit: 100 }),
+      2_000,
+      'ent/session/events (after restart)'
+    )) as { events: Array<{ type: string }> };
+
+    expect(durable.events.map((e) => e.type)).toEqual(
+      expect.arrayContaining(['permission_requested', 'permission_decided'])
+    );
+  });
 
   it('supports ent/session/configure and reports config via ent/agent/status', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
@@ -698,7 +681,7 @@ describe('lace-agent process (E2E over stdio)', () => {
     expect(injectEvent!.data.priority).toBe('normal');
   });
 
-  it('can cancel a turn that is awaiting permission', { timeout: 15_000 }, async () => {
+  it('can cancel a turn that is awaiting permission', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     const updates: unknown[] = [];
@@ -779,7 +762,7 @@ describe('lace-agent process (E2E over stdio)', () => {
     expect(status.currentTurn).toBeUndefined();
   });
 
-  it('creates a checkpoint and can rewind files', { timeout: 15_000 }, async () => {
+  it('creates a checkpoint and can rewind files', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     ctx.agent.peer.onRequest('session/request_permission', async () => ({ decision: 'allow' }));
@@ -833,44 +816,40 @@ describe('lace-agent process (E2E over stdio)', () => {
     expect(readFileSync(join(ctx.workDir, 'foo.txt'), 'utf8')).toBe(original);
   });
 
-  it(
-    'returns CheckpointNotFound for ent/session/rewind without a checkpoint',
-    { timeout: 15_000 },
-    async () => {
-      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+  it('returns CheckpointNotFound for ent/session/rewind without a checkpoint', async () => {
+    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
-      ctx.agent.peer.onRequest('session/request_permission', async () => ({ decision: 'allow' }));
+    ctx.agent.peer.onRequest('session/request_permission', async () => ({ decision: 'allow' }));
 
-      await withTimeout(
-        ctx.agent.peer.request(
-          'initialize',
-          defaultInitializeParams({ config: { approvalMode: 'ask' } })
-        ),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
-      await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        2_000,
-        'session/new'
-      );
+    await withTimeout(
+      ctx.agent.peer.request(
+        'initialize',
+        defaultInitializeParams({ config: { approvalMode: 'ask' } })
+      ),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
+    await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      2_000,
+      'session/new'
+    );
 
-      await withTimeout(
-        ctx.agent.peer.request('session/prompt', {
-          content: [{ type: 'text', text: 'write file foo.txt' }],
-        }),
-        10_000,
-        'session/prompt write foo.txt'
-      );
+    await withTimeout(
+      ctx.agent.peer.request('session/prompt', {
+        content: [{ type: 'text', text: 'write file foo.txt' }],
+      }),
+      10_000,
+      'session/prompt write foo.txt'
+    );
 
-      await expect(
-        ctx.agent.peer.request('ent/session/rewind', { toEventSeq: 1 })
-      ).rejects.toMatchObject({
-        code: EntErrorCodes.CheckpointNotFound,
-        message: 'CheckpointNotFound',
-      });
-    }
-  );
+    await expect(
+      ctx.agent.peer.request('ent/session/rewind', { toEventSeq: 1 })
+    ).rejects.toMatchObject({
+      code: EntErrorCodes.CheckpointNotFound,
+      message: 'CheckpointNotFound',
+    });
+  });
 });
 // Note: e2e tests for 'trim-tool-results' and 'summarize' compact strategies were deleted
 // in task 10 (Task 10: remove legacy strategies). Those strategies no longer exist —

--- a/packages/agent/src/__tests__/agent-process.error-recovery.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.error-recovery.e2e.test.ts
@@ -11,97 +11,94 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
 } from './helpers';
 
-describe('lace-agent error recovery (E2E)', () => {
+describe('lace-agent error recovery (E2E)', { timeout: E2E_TEST_TIMEOUT_MS }, () => {
   const ctx = createE2EContext({ prefix: 'lace-agent-error-recovery' });
 
   beforeEach(() => ctx.setup());
   afterEach(() => ctx.teardown());
 
-  it(
-    'continues turn after recoverable tool error (file not found), model sees error and responds',
-    { timeout: 15_000 },
-    async () => {
-      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+  it('continues turn after recoverable tool error (file not found), model sees error and responds', async () => {
+    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
-      const updates: unknown[] = [];
-      ctx.agent.peer.onRequest('session/update', async (params) => {
-        updates.push(params);
-        return undefined;
-      });
+    const updates: unknown[] = [];
+    ctx.agent.peer.onRequest('session/update', async (params) => {
+      updates.push(params);
+      return undefined;
+    });
 
-      await withTimeout(
-        ctx.agent.peer.request('initialize', defaultInitializeParams()),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
+    await withTimeout(
+      ctx.agent.peer.request('initialize', defaultInitializeParams()),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
 
-      await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        2_000,
-        'session/new'
-      );
+    await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      2_000,
+      'session/new'
+    );
 
-      // Ask to read a non-existent file - this will fail with "file not found"
-      // The key behavior: the turn should CONTINUE, allowing the model to see the error
-      // and respond (instead of stopping the turn on failure)
-      const promptResult = (await withTimeout(
-        ctx.agent.peer.request('session/prompt', {
-          content: [{ type: 'text', text: 'read file nonexistent.txt' }],
-        }),
-        10_000,
-        'session/prompt'
-      )) as { turnId: string; stopReason: string };
+    // Ask to read a non-existent file - this will fail with "file not found"
+    // The key behavior: the turn should CONTINUE, allowing the model to see the error
+    // and respond (instead of stopping the turn on failure)
+    const promptResult = (await withTimeout(
+      ctx.agent.peer.request('session/prompt', {
+        content: [{ type: 'text', text: 'read file nonexistent.txt' }],
+      }),
+      10_000,
+      'session/prompt'
+    )) as { turnId: string; stopReason: string };
 
-      // Wait for turn to complete
-      await withTimeout(
-        new Promise<void>((resolve) => {
-          const interval = setInterval(() => {
-            const turnEnd = updates.find((u) => {
-              const p = u as Record<string, unknown>;
-              return p?.type === 'turn_end' && p?.turnId === promptResult.turnId;
-            });
-            if (turnEnd) {
-              clearInterval(interval);
-              resolve();
-            }
-          }, 10);
-        }),
-        8_000,
-        'turn_end'
-      );
+    // Wait for turn to complete
+    await withTimeout(
+      new Promise<void>((resolve) => {
+        const interval = setInterval(() => {
+          const turnEnd = updates.find((u) => {
+            const p = u as Record<string, unknown>;
+            return p?.type === 'turn_end' && p?.turnId === promptResult.turnId;
+          });
+          if (turnEnd) {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 10);
+      }),
+      8_000,
+      'turn_end'
+    );
 
-      // Get events to verify the sequence
-      const durable = (await withTimeout(
-        ctx.agent.peer.request('ent/session/events', { afterEventSeq: 0, limit: 100 }),
-        2_000,
-        'ent/session/events'
-      )) as { events: Array<{ eventSeq: number; type: string; data?: unknown }>; hasMore: boolean };
+    // Get events to verify the sequence
+    const durable = (await withTimeout(
+      ctx.agent.peer.request('ent/session/events', { afterEventSeq: 0, limit: 100 }),
+      2_000,
+      'ent/session/events'
+    )) as { events: Array<{ eventSeq: number; type: string; data?: unknown }>; hasMore: boolean };
 
-      // Should see: context_injected, prompt, turn_start, message, tool_use (failed), message (model's response to error), turn_end
-      const eventTypes = durable.events.map((e) => e.type);
+    // Should see: context_injected, prompt, turn_start, message, tool_use (failed), message (model's response to error), turn_end
+    const eventTypes = durable.events.map((e) => e.type);
 
-      // The tool_use event should have failed status
-      const toolUseEvents = durable.events.filter((e) => e.type === 'tool_use');
-      expect(toolUseEvents.length).toBe(1);
+    // The tool_use event should have failed status
+    const toolUseEvents = durable.events.filter((e) => e.type === 'tool_use');
+    expect(toolUseEvents.length).toBe(1);
 
-      const toolData = toolUseEvents[0].data as Record<string, unknown>;
-      const result = toolData.result as Record<string, unknown>;
-      expect(result.outcome).toBe('failed');
+    const toolData = toolUseEvents[0].data as Record<string, unknown>;
+    const result = toolData.result as Record<string, unknown>;
+    expect(result.outcome).toBe('failed');
 
-      // CRITICAL: There should be a message AFTER the failed tool_use
-      // This proves the turn continued and the model got to respond
-      const toolUseIndex = eventTypes.indexOf('tool_use');
-      const messageAfterTool = eventTypes.slice(toolUseIndex + 1).includes('message');
-      expect(messageAfterTool).toBe(true);
+    // CRITICAL: There should be a message AFTER the failed tool_use
+    // This proves the turn continued and the model got to respond
+    const toolUseIndex = eventTypes.indexOf('tool_use');
+    const messageAfterTool = eventTypes.slice(toolUseIndex + 1).includes('message');
+    expect(messageAfterTool).toBe(true);
 
-      // Turn should complete normally (not stopped by the error)
-      expect(promptResult.stopReason).toBe('end_turn');
-    }
-  );
+    // Turn should complete normally (not stopped by the error)
+    expect(promptResult.stopReason).toBe('end_turn');
+  });
 
-  it('stops turn immediately on permission denied (fatal error)', { timeout: 15_000 }, async () => {
+  it('stops turn immediately on permission denied (fatal error)', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     const updates: unknown[] = [];
@@ -185,89 +182,85 @@ describe('lace-agent error recovery (E2E)', () => {
     expect(promptResult.stopReason).toBe('end_turn');
   });
 
-  it(
-    'model can retry with corrected parameters after seeing recoverable error',
-    { timeout: 15_000 },
-    async () => {
-      ctx.agent = spawnAgentProcess({
-        laceDir: ctx.laceDir,
-        env: {
-          // Enable retry behavior: test provider will retry with fallback.txt after seeing error
-          LACE_TEST_PROVIDER_RETRY_ON_ERROR: '1',
-        },
-      });
+  it('model can retry with corrected parameters after seeing recoverable error', async () => {
+    ctx.agent = spawnAgentProcess({
+      laceDir: ctx.laceDir,
+      env: {
+        // Enable retry behavior: test provider will retry with fallback.txt after seeing error
+        LACE_TEST_PROVIDER_RETRY_ON_ERROR: '1',
+      },
+    });
 
-      const updates: unknown[] = [];
-      ctx.agent.peer.onRequest('session/update', async (params) => {
-        updates.push(params);
-        return undefined;
-      });
+    const updates: unknown[] = [];
+    ctx.agent.peer.onRequest('session/update', async (params) => {
+      updates.push(params);
+      return undefined;
+    });
 
-      await withTimeout(
-        ctx.agent.peer.request('initialize', defaultInitializeParams()),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
+    await withTimeout(
+      ctx.agent.peer.request('initialize', defaultInitializeParams()),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
 
-      await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        2_000,
-        'session/new'
-      );
+    await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      2_000,
+      'session/new'
+    );
 
-      // Create a fallback file that the model will try after the first one fails
-      writeFileSync(join(ctx.workDir, 'fallback.txt'), 'fallback content\n', 'utf8');
+    // Create a fallback file that the model will try after the first one fails
+    writeFileSync(join(ctx.workDir, 'fallback.txt'), 'fallback content\n', 'utf8');
 
-      // First file doesn't exist - model will try it, see error, retry with fallback.txt
-      const promptResult = (await withTimeout(
-        ctx.agent.peer.request('session/prompt', {
-          content: [{ type: 'text', text: 'read file wrong.txt' }],
-        }),
-        10_000,
-        'session/prompt'
-      )) as { turnId: string; stopReason: string };
+    // First file doesn't exist - model will try it, see error, retry with fallback.txt
+    const promptResult = (await withTimeout(
+      ctx.agent.peer.request('session/prompt', {
+        content: [{ type: 'text', text: 'read file wrong.txt' }],
+      }),
+      10_000,
+      'session/prompt'
+    )) as { turnId: string; stopReason: string };
 
-      // Wait for turn to complete
-      await withTimeout(
-        new Promise<void>((resolve) => {
-          const interval = setInterval(() => {
-            const turnEnd = updates.find((u) => {
-              const p = u as Record<string, unknown>;
-              return p?.type === 'turn_end' && p?.turnId === promptResult.turnId;
-            });
-            if (turnEnd) {
-              clearInterval(interval);
-              resolve();
-            }
-          }, 10);
-        }),
-        8_000,
-        'turn_end'
-      );
+    // Wait for turn to complete
+    await withTimeout(
+      new Promise<void>((resolve) => {
+        const interval = setInterval(() => {
+          const turnEnd = updates.find((u) => {
+            const p = u as Record<string, unknown>;
+            return p?.type === 'turn_end' && p?.turnId === promptResult.turnId;
+          });
+          if (turnEnd) {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 10);
+      }),
+      8_000,
+      'turn_end'
+    );
 
-      // Get events to verify the sequence
-      const durable = (await withTimeout(
-        ctx.agent.peer.request('ent/session/events', { afterEventSeq: 0, limit: 100 }),
-        2_000,
-        'ent/session/events'
-      )) as { events: Array<{ eventSeq: number; type: string; data?: unknown }>; hasMore: boolean };
+    // Get events to verify the sequence
+    const durable = (await withTimeout(
+      ctx.agent.peer.request('ent/session/events', { afterEventSeq: 0, limit: 100 }),
+      2_000,
+      'ent/session/events'
+    )) as { events: Array<{ eventSeq: number; type: string; data?: unknown }>; hasMore: boolean };
 
-      // Should see TWO tool_use events: first fails, second succeeds
-      const toolUseEvents = durable.events.filter((e) => e.type === 'tool_use');
-      expect(toolUseEvents.length).toBe(2);
+    // Should see TWO tool_use events: first fails, second succeeds
+    const toolUseEvents = durable.events.filter((e) => e.type === 'tool_use');
+    expect(toolUseEvents.length).toBe(2);
 
-      // First tool use should have failed status (file not found)
-      const firstToolData = toolUseEvents[0].data as Record<string, unknown>;
-      const firstResult = firstToolData.result as Record<string, unknown>;
-      expect(firstResult.outcome).toBe('failed');
+    // First tool use should have failed status (file not found)
+    const firstToolData = toolUseEvents[0].data as Record<string, unknown>;
+    const firstResult = firstToolData.result as Record<string, unknown>;
+    expect(firstResult.outcome).toBe('failed');
 
-      // Second tool use should have completed status (fallback file)
-      const secondToolData = toolUseEvents[1].data as Record<string, unknown>;
-      const secondResult = secondToolData.result as Record<string, unknown>;
-      expect(secondResult.outcome).toBe('completed');
+    // Second tool use should have completed status (fallback file)
+    const secondToolData = toolUseEvents[1].data as Record<string, unknown>;
+    const secondResult = secondToolData.result as Record<string, unknown>;
+    expect(secondResult.outcome).toBe('completed');
 
-      // Turn should complete normally
-      expect(promptResult.stopReason).toBe('end_turn');
-    }
-  );
+    // Turn should complete normally
+    expect(promptResult.stopReason).toBe('end_turn');
+  });
 });

--- a/packages/agent/src/__tests__/agent-process.event-seq.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.event-seq.e2e.test.ts
@@ -5,18 +5,20 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
+  SUBAGENT_JOB_TIMEOUT_MS,
 } from './helpers';
 
-describe('lace-agent durable event sequencing (E2E over stdio)', () => {
-  const ctx = createE2EContext({ prefix: 'lace-agent-event-seq' });
+describe(
+  'lace-agent durable event sequencing (E2E over stdio)',
+  { timeout: E2E_TEST_TIMEOUT_MS },
+  () => {
+    const ctx = createE2EContext({ prefix: 'lace-agent-event-seq' });
 
-  beforeEach(() => ctx.setup());
-  afterEach(() => ctx.teardown());
+    beforeEach(() => ctx.setup());
+    afterEach(() => ctx.teardown());
 
-  it(
-    'maintains strictly increasing eventSeq across delegate job creation',
-    { timeout: 20_000 },
-    async () => {
+    it('maintains strictly increasing eventSeq across delegate job creation', async () => {
       ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
       ctx.agent.peer.onRequest('session/update', async () => undefined);
@@ -40,7 +42,7 @@ describe('lace-agent durable event sequencing (E2E over stdio)', () => {
         ctx.agent.peer.request('session/prompt', {
           content: [{ type: 'text', text: 'delegate hi' }],
         }),
-        10_000,
+        SUBAGENT_JOB_TIMEOUT_MS,
         'session/prompt delegate'
       );
 
@@ -55,6 +57,6 @@ describe('lace-agent durable event sequencing (E2E over stdio)', () => {
       for (let i = 1; i < history.events.length; i++) {
         expect(history.events[i]!.eventSeq).toBeGreaterThan(history.events[i - 1]!.eventSeq);
       }
-    }
-  );
-});
+    });
+  }
+);

--- a/packages/agent/src/__tests__/agent-process.inject-drain-prefill.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.inject-drain-prefill.e2e.test.ts
@@ -15,6 +15,7 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
 } from './helpers';
 
 /**
@@ -37,7 +38,7 @@ import {
  * contract is pinned live in anthropic-prefill-contract.live.test.ts, and it is
  * why the wedge only began biting once Ada moved to opus-4.8.
  */
-describe('inject-drain prefill wedge (E2E)', () => {
+describe('inject-drain prefill wedge (E2E)', { timeout: E2E_TEST_TIMEOUT_MS }, () => {
   const ctx = createE2EContext({ prefix: 'lace-inject-drain-prefill' });
 
   beforeEach(() => ctx.setup());
@@ -87,153 +88,145 @@ describe('inject-drain prefill wedge (E2E)', () => {
     await new Promise((r) => setTimeout(r, ms));
   }
 
-  it(
-    'drains a mid-turn inject without ever dispatching an assistant prefill',
-    { timeout: 30_000 },
-    async () => {
-      const recordPath = join(ctx.laceDir, 'provider-requests.jsonl');
+  it('drains a mid-turn inject without ever dispatching an assistant prefill', async () => {
+    const recordPath = join(ctx.laceDir, 'provider-requests.jsonl');
 
-      ctx.agent = spawnAgentProcess({
-        laceDir: ctx.laceDir,
-        env: {
-          LACE_AGENT_TEST_PROVIDER: '1',
-          // Hold the provider call open long enough to land an inject while the
-          // turn is genuinely in flight — the production race, not a simulation
-          // of it: the inject must arrive AFTER the request was dispatched.
-          LACE_TEST_PROVIDER_STREAM_DELAY_MS: '2500',
-          LACE_TEST_PROVIDER_RECORD_REQUESTS: recordPath,
-        },
-      });
+    ctx.agent = spawnAgentProcess({
+      laceDir: ctx.laceDir,
+      env: {
+        LACE_AGENT_TEST_PROVIDER: '1',
+        // Hold the provider call open long enough to land an inject while the
+        // turn is genuinely in flight — the production race, not a simulation
+        // of it: the inject must arrive AFTER the request was dispatched.
+        LACE_TEST_PROVIDER_STREAM_DELAY_MS: '2500',
+        LACE_TEST_PROVIDER_RECORD_REQUESTS: recordPath,
+      },
+    });
 
-      ctx.agent.peer.onRequest('session/update', async () => undefined);
+    ctx.agent.peer.onRequest('session/update', async () => undefined);
 
-      await withTimeout(
-        ctx.agent.peer.request('initialize', defaultInitializeParams()),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
-      await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        5_000,
-        'session/new'
-      );
+    await withTimeout(
+      ctx.agent.peer.request('initialize', defaultInitializeParams()),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
+    await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      5_000,
+      'session/new'
+    );
 
-      // Start a turn but do NOT await it: the provider call is now in flight.
-      const promptPromise = ctx.agent.peer.request('session/prompt', {
+    // Start a turn but do NOT await it: the provider call is now in flight.
+    const promptPromise = ctx.agent.peer.request('session/prompt', {
+      content: [{ type: 'text', text: 'Say hello and stop.' }],
+    });
+
+    // Land an immediate inject while that call is still open. This is exactly
+    // the production shape: the runner's inject tailer has already read for
+    // this round-trip, so the inject is genuinely undelivered at turn_end.
+    await sleep(800);
+    ctx.agent.peer.notify('ent/session/inject', {
+      content: [{ type: 'text', text: 'news?' }],
+      priority: 'immediate',
+    });
+
+    await withTimeout(promptPromise, 20_000, 'session/prompt');
+
+    // Let the scheduled drain turn run to completion.
+    await sleep(3_000);
+
+    const events = readSessionEvents(ctx.laceDir);
+    const injected = events.filter((e) => e.type === 'context_injected');
+    const emptyPrompts = events.filter(
+      (e) =>
+        e.type === 'prompt' &&
+        Array.isArray((e.data as { content?: unknown[] })?.content) &&
+        (e.data as { content: unknown[] }).content.length === 0
+    );
+
+    // Precondition: the inject landed and a drain turn ran for it.
+    expect(injected.length).toBeGreaterThanOrEqual(1);
+
+    // The drain no longer prompts with empty content in this shape — an empty
+    // prompt here is precisely what produced the invalid request.
+    expect(emptyPrompts).toHaveLength(0);
+
+    // And it took the NUDGE path specifically. Without this the test would
+    // also pass if the drain had simply stopped running, which would trade
+    // one dropped notification for another.
+    const nudgePrompts = events.filter(
+      (e) =>
+        e.type === 'prompt' &&
+        JSON.stringify((e.data as { content?: unknown })?.content ?? '').includes(
+          'arrived while you were mid-turn'
+        )
+    );
+    expect(nudgePrompts).toHaveLength(1);
+
+    // The fix. The drain still dispatches a real provider request, but it now
+    // ends on a USER message, so it is not an assistant prefill. Asserted
+    // against the request the provider was actually handed — the request is
+    // built at dispatch time, so the transcript alone cannot show its shape.
+    const requests = readRequestRoles(recordPath);
+    expect(requests.length).toBeGreaterThanOrEqual(2);
+
+    // EVERY request must be well-formed, the drain included. Checking all of
+    // them keeps this honest: asserting only the last would still pass if the
+    // drain had never run at all.
+    for (const roles of requests) {
+      expect(roles.length).toBeGreaterThan(0);
+      expect(roles[roles.length - 1]).toBe('user');
+    }
+  });
+
+  it('control: with no mid-turn inject there is no empty-prompt drain', async () => {
+    const recordPath = join(ctx.laceDir, 'provider-requests.jsonl');
+
+    ctx.agent = spawnAgentProcess({
+      laceDir: ctx.laceDir,
+      env: {
+        LACE_AGENT_TEST_PROVIDER: '1',
+        LACE_TEST_PROVIDER_STREAM_DELAY_MS: '2500',
+        LACE_TEST_PROVIDER_RECORD_REQUESTS: recordPath,
+      },
+    });
+
+    ctx.agent.peer.onRequest('session/update', async () => undefined);
+
+    await withTimeout(
+      ctx.agent.peer.request('initialize', defaultInitializeParams()),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
+    await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      5_000,
+      'session/new'
+    );
+
+    // Identical turn, identical timing — the ONLY difference is that no
+    // inject lands. This isolates the inject as the cause.
+    await withTimeout(
+      ctx.agent.peer.request('session/prompt', {
         content: [{ type: 'text', text: 'Say hello and stop.' }],
-      });
+      }),
+      20_000,
+      'session/prompt'
+    );
+    await sleep(3_000);
 
-      // Land an immediate inject while that call is still open. This is exactly
-      // the production shape: the runner's inject tailer has already read for
-      // this round-trip, so the inject is genuinely undelivered at turn_end.
-      await sleep(800);
-      ctx.agent.peer.notify('ent/session/inject', {
-        content: [{ type: 'text', text: 'news?' }],
-        priority: 'immediate',
-      });
+    const events = readSessionEvents(ctx.laceDir);
+    const emptyPrompts = events.filter(
+      (e) =>
+        e.type === 'prompt' &&
+        Array.isArray((e.data as { content?: unknown[] })?.content) &&
+        (e.data as { content: unknown[] }).content.length === 0
+    );
+    expect(emptyPrompts).toHaveLength(0);
 
-      await withTimeout(promptPromise, 20_000, 'session/prompt');
-
-      // Let the scheduled drain turn run to completion.
-      await sleep(3_000);
-
-      const events = readSessionEvents(ctx.laceDir);
-      const injected = events.filter((e) => e.type === 'context_injected');
-      const emptyPrompts = events.filter(
-        (e) =>
-          e.type === 'prompt' &&
-          Array.isArray((e.data as { content?: unknown[] })?.content) &&
-          (e.data as { content: unknown[] }).content.length === 0
-      );
-
-      // Precondition: the inject landed and a drain turn ran for it.
-      expect(injected.length).toBeGreaterThanOrEqual(1);
-
-      // The drain no longer prompts with empty content in this shape — an empty
-      // prompt here is precisely what produced the invalid request.
-      expect(emptyPrompts).toHaveLength(0);
-
-      // And it took the NUDGE path specifically. Without this the test would
-      // also pass if the drain had simply stopped running, which would trade
-      // one dropped notification for another.
-      const nudgePrompts = events.filter(
-        (e) =>
-          e.type === 'prompt' &&
-          JSON.stringify((e.data as { content?: unknown })?.content ?? '').includes(
-            'arrived while you were mid-turn'
-          )
-      );
-      expect(nudgePrompts).toHaveLength(1);
-
-      // The fix. The drain still dispatches a real provider request, but it now
-      // ends on a USER message, so it is not an assistant prefill. Asserted
-      // against the request the provider was actually handed — the request is
-      // built at dispatch time, so the transcript alone cannot show its shape.
-      const requests = readRequestRoles(recordPath);
-      expect(requests.length).toBeGreaterThanOrEqual(2);
-
-      // EVERY request must be well-formed, the drain included. Checking all of
-      // them keeps this honest: asserting only the last would still pass if the
-      // drain had never run at all.
-      for (const roles of requests) {
-        expect(roles.length).toBeGreaterThan(0);
-        expect(roles[roles.length - 1]).toBe('user');
-      }
+    // And every request the provider saw is well-formed.
+    for (const roles of readRequestRoles(recordPath)) {
+      expect(roles[roles.length - 1]).toBe('user');
     }
-  );
-
-  it(
-    'control: with no mid-turn inject there is no empty-prompt drain',
-    { timeout: 30_000 },
-    async () => {
-      const recordPath = join(ctx.laceDir, 'provider-requests.jsonl');
-
-      ctx.agent = spawnAgentProcess({
-        laceDir: ctx.laceDir,
-        env: {
-          LACE_AGENT_TEST_PROVIDER: '1',
-          LACE_TEST_PROVIDER_STREAM_DELAY_MS: '2500',
-          LACE_TEST_PROVIDER_RECORD_REQUESTS: recordPath,
-        },
-      });
-
-      ctx.agent.peer.onRequest('session/update', async () => undefined);
-
-      await withTimeout(
-        ctx.agent.peer.request('initialize', defaultInitializeParams()),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
-      await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        5_000,
-        'session/new'
-      );
-
-      // Identical turn, identical timing — the ONLY difference is that no
-      // inject lands. This isolates the inject as the cause.
-      await withTimeout(
-        ctx.agent.peer.request('session/prompt', {
-          content: [{ type: 'text', text: 'Say hello and stop.' }],
-        }),
-        20_000,
-        'session/prompt'
-      );
-      await sleep(3_000);
-
-      const events = readSessionEvents(ctx.laceDir);
-      const emptyPrompts = events.filter(
-        (e) =>
-          e.type === 'prompt' &&
-          Array.isArray((e.data as { content?: unknown[] })?.content) &&
-          (e.data as { content: unknown[] }).content.length === 0
-      );
-      expect(emptyPrompts).toHaveLength(0);
-
-      // And every request the provider saw is well-formed.
-      for (const roles of readRequestRoles(recordPath)) {
-        expect(roles[roles.length - 1]).toBe('user');
-      }
-    }
-  );
+  });
 });

--- a/packages/agent/src/__tests__/agent-process.jobs.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.jobs.e2e.test.ts
@@ -5,15 +5,17 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
+  SUBAGENT_JOB_TIMEOUT_MS,
 } from './helpers';
 
-describe('lace-agent jobs (E2E over stdio)', () => {
+describe('lace-agent jobs (E2E over stdio)', { timeout: E2E_TEST_TIMEOUT_MS }, () => {
   const ctx = createE2EContext({ prefix: 'lace-agent-jobs' });
 
   beforeEach(() => ctx.setup());
   afterEach(() => ctx.teardown());
 
-  it('spawns a shell job, streams updates, and persists output', { timeout: 20_000 }, async () => {
+  it('spawns a shell job, streams updates, and persists output', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     const updates: Array<Record<string, unknown>> = [];
@@ -130,7 +132,7 @@ describe('lace-agent jobs (E2E over stdio)', () => {
     expect(outputAfterRestart.output).toContain('hi');
   });
 
-  it('can cancel a job while it is awaiting permission', { timeout: 20_000 }, async () => {
+  it('can cancel a job while it is awaiting permission', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     let observedJobId: string | undefined;
@@ -205,7 +207,7 @@ describe('lace-agent jobs (E2E over stdio)', () => {
     expect(output.status).toBe('cancelled');
   });
 
-  it('job record includes subagentSessionId for subagent jobs', { timeout: 20_000 }, async () => {
+  it('job record includes subagentSessionId for subagent jobs', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     const updates: Array<Record<string, unknown>> = [];
@@ -241,7 +243,7 @@ describe('lace-agent jobs (E2E over stdio)', () => {
       ctx.agent.peer.request('session/prompt', {
         content: [{ type: 'text', text: 'subagent: hi' }],
       }),
-      10_000,
+      SUBAGENT_JOB_TIMEOUT_MS,
       'session/prompt'
     );
 
@@ -259,7 +261,7 @@ describe('lace-agent jobs (E2E over stdio)', () => {
           }
         }, 10);
       }),
-      10_000,
+      SUBAGENT_JOB_TIMEOUT_MS,
       'job_finished update'
     );
 

--- a/packages/agent/src/__tests__/agent-process.metrics.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.metrics.e2e.test.ts
@@ -10,59 +10,56 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
 } from './helpers';
 
-describe('lace-agent session metrics (E2E)', () => {
+describe('lace-agent session metrics (E2E)', { timeout: E2E_TEST_TIMEOUT_MS }, () => {
   const ctx = createE2EContext({ prefix: 'lace-agent-metrics' });
 
   beforeEach(() => ctx.setup());
   afterEach(() => ctx.teardown());
 
-  it(
-    'returns actual token usage in ent/agent/status after prompt',
-    { timeout: 15_000 },
-    async () => {
-      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+  it('returns actual token usage in ent/agent/status after prompt', async () => {
+    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
-      await withTimeout(
-        ctx.agent.peer.request('initialize', defaultInitializeParams()),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
+    await withTimeout(
+      ctx.agent.peer.request('initialize', defaultInitializeParams()),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
 
-      await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        2_000,
-        'session/new'
-      );
+    await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      2_000,
+      'session/new'
+    );
 
-      writeFileSync(join(ctx.workDir, 'hello.txt'), 'hello world\n', 'utf8');
+    writeFileSync(join(ctx.workDir, 'hello.txt'), 'hello world\n', 'utf8');
 
-      // Send a prompt
-      await withTimeout(
-        ctx.agent.peer.request('session/prompt', {
-          content: [{ type: 'text', text: 'read file hello.txt' }],
-        }),
-        10_000,
-        'session/prompt'
-      );
+    // Send a prompt
+    await withTimeout(
+      ctx.agent.peer.request('session/prompt', {
+        content: [{ type: 'text', text: 'read file hello.txt' }],
+      }),
+      10_000,
+      'session/prompt'
+    );
 
-      // Check status - tokensUsed should be non-zero
-      // Test provider returns 100 input + 50 output = 150 tokens per turn
-      const status = (await withTimeout(
-        ctx.agent.peer.request('ent/agent/status'),
-        2_000,
-        'ent/agent/status'
-      )) as { currentSession: { tokensUsed: number } };
+    // Check status - tokensUsed should be non-zero
+    // Test provider returns 100 input + 50 output = 150 tokens per turn
+    const status = (await withTimeout(
+      ctx.agent.peer.request('ent/agent/status'),
+      2_000,
+      'ent/agent/status'
+    )) as { currentSession: { tokensUsed: number } };
 
-      expect(status.currentSession.tokensUsed).toBeGreaterThan(0);
-      // Test provider returns 100 input + 50 output = 150 tokens per LLM call
-      // With tool use, there may be multiple calls, so just verify it's a multiple of 150
-      expect(status.currentSession.tokensUsed % 150).toBe(0);
-    }
-  );
+    expect(status.currentSession.tokensUsed).toBeGreaterThan(0);
+    // Test provider returns 100 input + 50 output = 150 tokens per LLM call
+    // With tool use, there may be multiple calls, so just verify it's a multiple of 150
+    expect(status.currentSession.tokensUsed % 150).toBe(0);
+  });
 
-  it('returns actual cost in ent/agent/status after prompt', { timeout: 15_000 }, async () => {
+  it('returns actual cost in ent/agent/status after prompt', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     await withTimeout(
@@ -100,7 +97,7 @@ describe('lace-agent session metrics (E2E)', () => {
     expect(status.currentSession.costUsd).toBe(status.limits.budgetUsedUsd);
   });
 
-  it('returns turnCount in ent/agent/status after prompts', { timeout: 20_000 }, async () => {
+  it('returns turnCount in ent/agent/status after prompts', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     await withTimeout(

--- a/packages/agent/src/__tests__/agent-process.model-gating.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.model-gating.e2e.test.ts
@@ -5,6 +5,7 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
 } from './helpers';
 import {
   createTestProviderInstance,
@@ -15,85 +16,94 @@ const PROVIDER_ID = 'openai';
 const MODEL_A = 'gpt-4o';
 const MODEL_B = 'gpt-4.1-mini';
 
-describe('ent/models enable/disable (provider-global gating)', () => {
-  const ctx = createE2EContext({ prefix: 'lace-agent-gating', enableTestProvider: false });
-  const instances: string[] = [];
+describe(
+  'ent/models enable/disable (provider-global gating)',
+  { timeout: E2E_TEST_TIMEOUT_MS },
+  () => {
+    const ctx = createE2EContext({ prefix: 'lace-agent-gating', enableTestProvider: false });
+    const instances: string[] = [];
 
-  beforeEach(async () => {
-    ctx.setup();
+    beforeEach(async () => {
+      ctx.setup();
 
-    const instanceId = await createTestProviderInstance({
-      catalogId: PROVIDER_ID,
-      models: [MODEL_A, MODEL_B],
+      const instanceId = await createTestProviderInstance({
+        catalogId: PROVIDER_ID,
+        models: [MODEL_A, MODEL_B],
+      });
+      instances.push(instanceId);
     });
-    instances.push(instanceId);
-  });
 
-  afterEach(async () => {
-    await cleanupTestProviderInstances(instances);
-    instances.length = 0;
-    await ctx.teardown();
-  });
+    afterEach(async () => {
+      await cleanupTestProviderInstances(instances);
+      instances.length = 0;
+      await ctx.teardown();
+    });
 
-  it('disables and re-enables models globally for the provider', async () => {
-    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+    it('disables and re-enables models globally for the provider', async () => {
+      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
-    await withTimeout(
-      ctx.agent.peer.request(
-        'initialize',
-        defaultInitializeParams({ config: { approvalMode: 'approve', connectionId: instances[0] } })
-      ),
-      AGENT_BOOT_TIMEOUT_MS,
-      'initialize'
-    );
+      await withTimeout(
+        ctx.agent.peer.request(
+          'initialize',
+          defaultInitializeParams({
+            config: { approvalMode: 'approve', connectionId: instances[0] },
+          })
+        ),
+        AGENT_BOOT_TIMEOUT_MS,
+        'initialize'
+      );
 
-    await withTimeout(
-      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-      2_000,
-      'session/new'
-    );
+      await withTimeout(
+        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+        2_000,
+        'session/new'
+      );
 
-    const initialList = (await withTimeout(
-      ctx.agent.peer.request('ent/models/list', { connectionId: instances[0] }),
-      2_000,
-      'ent/models/list'
-    )) as { models: Array<{ modelId: string }> };
+      const initialList = (await withTimeout(
+        ctx.agent.peer.request('ent/models/list', { connectionId: instances[0] }),
+        2_000,
+        'ent/models/list'
+      )) as { models: Array<{ modelId: string }> };
 
-    const initialIds = initialList.models.map((m) => m.modelId);
-    expect(initialIds).toEqual(expect.arrayContaining([MODEL_A, MODEL_B]));
+      const initialIds = initialList.models.map((m) => m.modelId);
+      expect(initialIds).toEqual(expect.arrayContaining([MODEL_A, MODEL_B]));
 
-    const disabled = (await withTimeout(
-      ctx.agent.peer.request('ent/models/disable', {
-        providerId: PROVIDER_ID,
-        modelIds: [MODEL_B],
-      }),
-      2_000,
-      'ent/models/disable'
-    )) as { disabled: string[] };
-    expect(disabled.disabled).toContain(MODEL_B);
+      const disabled = (await withTimeout(
+        ctx.agent.peer.request('ent/models/disable', {
+          providerId: PROVIDER_ID,
+          modelIds: [MODEL_B],
+        }),
+        2_000,
+        'ent/models/disable'
+      )) as { disabled: string[] };
+      expect(disabled.disabled).toContain(MODEL_B);
 
-    const afterDisable = (await withTimeout(
-      ctx.agent.peer.request('ent/models/list', { connectionId: instances[0] }),
-      2_000,
-      'ent/models/list after disable'
-    )) as { models: Array<{ modelId: string; disabled?: boolean }> };
-    const modelB = afterDisable.models.find((m) => m.modelId === MODEL_B);
-    expect(modelB).toBeDefined();
-    expect(modelB?.disabled).toBe(true);
+      const afterDisable = (await withTimeout(
+        ctx.agent.peer.request('ent/models/list', { connectionId: instances[0] }),
+        2_000,
+        'ent/models/list after disable'
+      )) as { models: Array<{ modelId: string; disabled?: boolean }> };
+      const modelB = afterDisable.models.find((m) => m.modelId === MODEL_B);
+      expect(modelB).toBeDefined();
+      expect(modelB?.disabled).toBe(true);
 
-    const enabled = (await withTimeout(
-      ctx.agent.peer.request('ent/models/enable', { providerId: PROVIDER_ID, modelIds: [MODEL_B] }),
-      2_000,
-      'ent/models/enable'
-    )) as { enabled: string[] };
-    expect(enabled.enabled).toContain(MODEL_B);
+      const enabled = (await withTimeout(
+        ctx.agent.peer.request('ent/models/enable', {
+          providerId: PROVIDER_ID,
+          modelIds: [MODEL_B],
+        }),
+        2_000,
+        'ent/models/enable'
+      )) as { enabled: string[] };
+      expect(enabled.enabled).toContain(MODEL_B);
 
-    const afterEnable = (await withTimeout(
-      ctx.agent.peer.request('ent/models/list', { connectionId: instances[0] }),
-      2_000,
-      'ent/models/list after enable'
-    )) as { models: Array<{ modelId: string; disabled?: boolean }> };
-    const modelBAfter = afterEnable.models.find((m) => m.modelId === MODEL_B);
-    expect(modelBAfter?.disabled).not.toBe(true);
-  });
-});
+      const afterEnable = (await withTimeout(
+        ctx.agent.peer.request('ent/models/list', { connectionId: instances[0] }),
+        2_000,
+        'ent/models/list after enable'
+      )) as { models: Array<{ modelId: string; disabled?: boolean }> };
+      const modelBAfter = afterEnable.models.find((m) => m.modelId === MODEL_B);
+      expect(modelBAfter?.disabled).not.toBe(true);
+    });
+  }
+);

--- a/packages/agent/src/__tests__/agent-process.providers.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.providers.e2e.test.ts
@@ -5,15 +5,16 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
 } from './helpers';
 
-describe('lace-agent provider config (E2E over stdio)', () => {
+describe('lace-agent provider config (E2E over stdio)', { timeout: E2E_TEST_TIMEOUT_MS }, () => {
   const ctx = createE2EContext({ prefix: 'lace-agent-provider', enableTestProvider: false });
 
   beforeEach(() => ctx.setup());
   afterEach(() => ctx.teardown());
 
-  it('can create a connection and rotate credentials', { timeout: 15_000 }, async () => {
+  it('can create a connection and rotate credentials', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),
@@ -71,7 +72,7 @@ describe('lace-agent provider config (E2E over stdio)', () => {
     expect(status.state).toBe('ready');
   });
 
-  it('rejects ent/connections/upsert with invalid config', { timeout: 15_000 }, async () => {
+  it('rejects ent/connections/upsert with invalid config', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
     await withTimeout(
       ctx.agent.peer.request('initialize', defaultInitializeParams()),

--- a/packages/agent/src/__tests__/agent-process.retry.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.retry.e2e.test.ts
@@ -8,15 +8,16 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
 } from './helpers';
 
-describe('agent retry behavior (E2E)', () => {
+describe('agent retry behavior (E2E)', { timeout: E2E_TEST_TIMEOUT_MS }, () => {
   const ctx = createE2EContext({ prefix: 'lace-agent-retry' });
 
   beforeEach(() => ctx.setup());
   afterEach(() => ctx.teardown());
 
-  it('retries on provider rate limit error (429) and succeeds', { timeout: 30_000 }, async () => {
+  it('retries on provider rate limit error (429) and succeeds', async () => {
     // Setup: Fail first 2 calls with 429, then succeed
     ctx.agent = spawnAgentProcess({
       laceDir: ctx.laceDir,
@@ -59,7 +60,7 @@ describe('agent retry behavior (E2E)', () => {
     expect(result.turnId).toBeDefined();
   });
 
-  it('retries on provider temporary error (500) and succeeds', { timeout: 30_000 }, async () => {
+  it('retries on provider temporary error (500) and succeeds', async () => {
     // Setup: Fail first call with 500, then succeed
     ctx.agent = spawnAgentProcess({
       laceDir: ctx.laceDir,
@@ -95,7 +96,7 @@ describe('agent retry behavior (E2E)', () => {
     expect(result.turnId).toBeDefined();
   });
 
-  it('fails after max retries exceeded on persistent 429', { timeout: 30_000 }, async () => {
+  it('fails after max retries exceeded on persistent 429', async () => {
     // Setup: Always fail with 429 (more failures than max retries)
     // Use very low retry delays for faster test execution
     ctx.agent = spawnAgentProcess({
@@ -135,7 +136,7 @@ describe('agent retry behavior (E2E)', () => {
     });
   });
 
-  it('does not retry on non-retryable errors (400)', { timeout: 15_000 }, async () => {
+  it('does not retry on non-retryable errors (400)', async () => {
     // Setup: Fail with 400 (client error - not retryable)
     ctx.agent = spawnAgentProcess({
       laceDir: ctx.laceDir,
@@ -172,7 +173,7 @@ describe('agent retry behavior (E2E)', () => {
     });
   });
 
-  it('preserves conversation state after successful retry', { timeout: 30_000 }, async () => {
+  it('preserves conversation state after successful retry', async () => {
     // Setup: Fail first call with 500, then succeed
     ctx.agent = spawnAgentProcess({
       laceDir: ctx.laceDir,

--- a/packages/agent/src/__tests__/agent-process.streaming-order.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.streaming-order.e2e.test.ts
@@ -5,6 +5,7 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
 } from './helpers';
 
 type SessionUpdateParams = {
@@ -28,66 +29,70 @@ async function waitFor(
   throw new Error(`Timed out waiting for ${params.label}`);
 }
 
-describe('lace-agent streaming update ordering (E2E over stdio)', () => {
-  const ctx = createE2EContext({ prefix: 'lace-agent-stream-order' });
+describe(
+  'lace-agent streaming update ordering (E2E over stdio)',
+  { timeout: E2E_TEST_TIMEOUT_MS },
+  () => {
+    const ctx = createE2EContext({ prefix: 'lace-agent-stream-order' });
 
-  beforeEach(() => ctx.setup());
-  afterEach(() => ctx.teardown());
+    beforeEach(() => ctx.setup());
+    afterEach(() => ctx.teardown());
 
-  it('does not emit text_delta after turn_end for a turn', { timeout: 20_000 }, async () => {
-    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+    it('does not emit text_delta after turn_end for a turn', async () => {
+      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
-    const updates: SessionUpdateParams[] = [];
-    ctx.agent.peer.onRequest('session/update', async (params: unknown) => {
-      if (params && typeof params === 'object') {
-        const p = params as SessionUpdateParams;
-        if (typeof p.type === 'string') updates.push(p);
-      }
-      return undefined;
+      const updates: SessionUpdateParams[] = [];
+      ctx.agent.peer.onRequest('session/update', async (params: unknown) => {
+        if (params && typeof params === 'object') {
+          const p = params as SessionUpdateParams;
+          if (typeof p.type === 'string') updates.push(p);
+        }
+        return undefined;
+      });
+
+      ctx.agent.peer.onRequest('session/request_permission', async () => ({ decision: 'allow' }));
+
+      await withTimeout(
+        ctx.agent.peer.request('initialize', defaultInitializeParams()),
+        AGENT_BOOT_TIMEOUT_MS,
+        'initialize'
+      );
+      await withTimeout(
+        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+        2_000,
+        'session/new'
+      );
+
+      const promptResult = (await withTimeout(
+        ctx.agent.peer.request('session/prompt', { content: [{ type: 'text', text: 'hi' }] }),
+        10_000,
+        'session/prompt'
+      )) as { turnId: string };
+
+      const turnId = promptResult.turnId;
+
+      await waitFor(() => updates.some((u) => u.turnId === turnId && u.type === 'turn_end'), {
+        timeoutMs: 2_000,
+        intervalMs: 10,
+        label: 'turn_end update',
+      });
+
+      await new Promise((r) => setTimeout(r, 200));
+
+      const turnUpdates = updates.filter((u) => u.turnId === turnId);
+      const turnEndIndex = turnUpdates.findIndex((u) => u.type === 'turn_end');
+      expect(turnEndIndex).toBeGreaterThanOrEqual(0);
+
+      const lastTextDeltaIndex = (() => {
+        let idx = -1;
+        for (let i = 0; i < turnUpdates.length; i++) {
+          if (turnUpdates[i]?.type === 'text_delta') idx = i;
+        }
+        return idx;
+      })();
+
+      expect(lastTextDeltaIndex).toBeGreaterThanOrEqual(0);
+      expect(lastTextDeltaIndex).toBeLessThan(turnEndIndex);
     });
-
-    ctx.agent.peer.onRequest('session/request_permission', async () => ({ decision: 'allow' }));
-
-    await withTimeout(
-      ctx.agent.peer.request('initialize', defaultInitializeParams()),
-      AGENT_BOOT_TIMEOUT_MS,
-      'initialize'
-    );
-    await withTimeout(
-      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-      2_000,
-      'session/new'
-    );
-
-    const promptResult = (await withTimeout(
-      ctx.agent.peer.request('session/prompt', { content: [{ type: 'text', text: 'hi' }] }),
-      10_000,
-      'session/prompt'
-    )) as { turnId: string };
-
-    const turnId = promptResult.turnId;
-
-    await waitFor(() => updates.some((u) => u.turnId === turnId && u.type === 'turn_end'), {
-      timeoutMs: 2_000,
-      intervalMs: 10,
-      label: 'turn_end update',
-    });
-
-    await new Promise((r) => setTimeout(r, 200));
-
-    const turnUpdates = updates.filter((u) => u.turnId === turnId);
-    const turnEndIndex = turnUpdates.findIndex((u) => u.type === 'turn_end');
-    expect(turnEndIndex).toBeGreaterThanOrEqual(0);
-
-    const lastTextDeltaIndex = (() => {
-      let idx = -1;
-      for (let i = 0; i < turnUpdates.length; i++) {
-        if (turnUpdates[i]?.type === 'text_delta') idx = i;
-      }
-      return idx;
-    })();
-
-    expect(lastTextDeltaIndex).toBeGreaterThanOrEqual(0);
-    expect(lastTextDeltaIndex).toBeLessThan(turnEndIndex);
-  });
-});
+  }
+);

--- a/packages/agent/src/__tests__/agent-process.subagent-early-stop.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.subagent-early-stop.e2e.test.ts
@@ -11,115 +11,113 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
+  SUBAGENT_JOB_TIMEOUT_MS,
 } from './helpers';
 
-describe('lace-agent subagent early-stop bug (kata #31)', () => {
+describe('lace-agent subagent early-stop bug (kata #31)', { timeout: E2E_TEST_TIMEOUT_MS }, () => {
   const ctx = createE2EContext({ prefix: 'lace-agent-subagent-early-stop' });
 
   beforeEach(() => ctx.setup());
   afterEach(() => ctx.teardown());
 
-  it(
-    'subagent with persona toolScope completes ≥2 model turns when the prompt requires a tool call',
-    { timeout: 20_000 },
-    async () => {
-      // Write a user persona whose toolScope includes file_read but has a
-      // narrow scope overall. With verbatim-allowlist semantics,
-      // tools: is the complete set — personas must explicitly list every tool
-      // they need, including builtins. The kata-#31 regression is that
-      // subagents stop after a single turn when a toolScope is present; the
-      // fix is tested by confirming the subagent completes ≥2 model turns
-      // (one to call file_read, one to summarise the result).
-      const personasDir = join(ctx.laceDir, 'agent-personas');
-      mkdirSync(personasDir, { recursive: true });
-      writeFileSync(
-        join(personasDir, 'librarian.md'),
-        '---\ntools:\n  - bash\n  - file_read\n---\nYou are a librarian.\n'
-      );
+  it('subagent with persona toolScope completes ≥2 model turns when the prompt requires a tool call', async () => {
+    // Write a user persona whose toolScope includes file_read but has a
+    // narrow scope overall. With verbatim-allowlist semantics,
+    // tools: is the complete set — personas must explicitly list every tool
+    // they need, including builtins. The kata-#31 regression is that
+    // subagents stop after a single turn when a toolScope is present; the
+    // fix is tested by confirming the subagent completes ≥2 model turns
+    // (one to call file_read, one to summarise the result).
+    const personasDir = join(ctx.laceDir, 'agent-personas');
+    mkdirSync(personasDir, { recursive: true });
+    writeFileSync(
+      join(personasDir, 'librarian.md'),
+      '---\ntools:\n  - bash\n  - file_read\n---\nYou are a librarian.\n'
+    );
 
-      // Opt the TestAgentProvider into faithful wire-tools mode so it only
-      // emits tool_use for tools actually present in the wire payload. This
-      // is required to reproduce kata #31, which arises specifically when
-      // the model has no in-scope tool to call.
-      ctx.agent = spawnAgentProcess({
-        laceDir: ctx.laceDir,
-        env: { LACE_TEST_PROVIDER_RESPECT_WIRE_TOOLS: '1' },
-      });
+    // Opt the TestAgentProvider into faithful wire-tools mode so it only
+    // emits tool_use for tools actually present in the wire payload. This
+    // is required to reproduce kata #31, which arises specifically when
+    // the model has no in-scope tool to call.
+    ctx.agent = spawnAgentProcess({
+      laceDir: ctx.laceDir,
+      env: { LACE_TEST_PROVIDER_RESPECT_WIRE_TOOLS: '1' },
+    });
 
-      const updates: Array<Record<string, unknown>> = [];
-      let subagentJobId: string | undefined;
+    const updates: Array<Record<string, unknown>> = [];
+    let subagentJobId: string | undefined;
 
-      ctx.agent.peer.onRequest('session/update', async (params) => {
-        const p = params as Record<string, unknown>;
-        updates.push(p);
-        if (p.type === 'job_started' && p.jobType === 'delegate' && typeof p.jobId === 'string') {
-          subagentJobId = p.jobId;
-        }
-        return undefined;
-      });
+    ctx.agent.peer.onRequest('session/update', async (params) => {
+      const p = params as Record<string, unknown>;
+      updates.push(p);
+      if (p.type === 'job_started' && p.jobType === 'delegate' && typeof p.jobId === 'string') {
+        subagentJobId = p.jobId;
+      }
+      return undefined;
+    });
 
-      ctx.agent.peer.onRequest('session/request_permission', async () => ({ decision: 'allow' }));
+    ctx.agent.peer.onRequest('session/request_permission', async () => ({ decision: 'allow' }));
 
-      await withTimeout(
-        ctx.agent.peer.request(
-          'initialize',
-          defaultInitializeParams({ config: { approvalMode: 'allow' } })
-        ),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
-      await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        2_000,
-        'session/new'
-      );
+    await withTimeout(
+      ctx.agent.peer.request(
+        'initialize',
+        defaultInitializeParams({ config: { approvalMode: 'allow' } })
+      ),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
+    await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      2_000,
+      'session/new'
+    );
 
-      // The parent's TestAgentProvider recognizes "subagent persona=<name>: <prompt>"
-      // and issues a delegate tool call with prompt=<prompt> and persona=<name>.
-      // The subagent then receives "read file foo.txt" as its session/prompt,
-      // which its own TestAgentProvider matches → tool_use(file_read).
-      // After tool execution, a second model call should occur, returning
-      // "Result:\n<tool output>" (success or error text). If the subagent
-      // stops early (kata #31), the output will not contain "Result:".
-      await withTimeout(
-        ctx.agent.peer.request('session/prompt', {
-          content: [{ type: 'text', text: 'subagent persona=librarian: read file foo.txt' }],
-        }),
-        10_000,
-        'session/prompt'
-      );
+    // The parent's TestAgentProvider recognizes "subagent persona=<name>: <prompt>"
+    // and issues a delegate tool call with prompt=<prompt> and persona=<name>.
+    // The subagent then receives "read file foo.txt" as its session/prompt,
+    // which its own TestAgentProvider matches → tool_use(file_read).
+    // After tool execution, a second model call should occur, returning
+    // "Result:\n<tool output>" (success or error text). If the subagent
+    // stops early (kata #31), the output will not contain "Result:".
+    await withTimeout(
+      ctx.agent.peer.request('session/prompt', {
+        content: [{ type: 'text', text: 'subagent persona=librarian: read file foo.txt' }],
+      }),
+      SUBAGENT_JOB_TIMEOUT_MS,
+      'session/prompt'
+    );
 
-      await withTimeout(
-        new Promise<void>((resolve) => {
-          const interval = setInterval(() => {
-            if (!subagentJobId) return;
-            const finished = updates.find(
-              (u) => u.type === 'job_finished' && u.jobId === subagentJobId
-            );
-            if (finished) {
-              clearInterval(interval);
-              resolve();
-            }
-          }, 10);
-        }),
-        10_000,
-        'job_finished update'
-      );
+    await withTimeout(
+      new Promise<void>((resolve) => {
+        const interval = setInterval(() => {
+          if (!subagentJobId) return;
+          const finished = updates.find(
+            (u) => u.type === 'job_finished' && u.jobId === subagentJobId
+          );
+          if (finished) {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 10);
+      }),
+      SUBAGENT_JOB_TIMEOUT_MS,
+      'job_finished update'
+    );
 
-      const output = (await withTimeout(
-        ctx.agent.peer.request('ent/job/output', { jobId: subagentJobId }),
-        2_000,
-        'ent/job/output'
-      )) as { status: string; output: string };
+    const output = (await withTimeout(
+      ctx.agent.peer.request('ent/job/output', { jobId: subagentJobId }),
+      2_000,
+      'ent/job/output'
+    )) as { status: string; output: string };
 
-      // The subagent should have completed and produced "Result:" output,
-      // proving the second provider call occurred after tool execution.
-      // Kata #31 manifests when the subagent's persona toolScope excludes
-      // tools its prompt would need: the model returns text-only intent on
-      // the first turn (no tool_use), so the runner immediately ends the
-      // turn loop and output contains only the intent string.
-      expect(output.status).toBe('completed');
-      expect(output.output).toContain('Result:');
-    }
-  );
+    // The subagent should have completed and produced "Result:" output,
+    // proving the second provider call occurred after tool execution.
+    // Kata #31 manifests when the subagent's persona toolScope excludes
+    // tools its prompt would need: the model returns text-only intent on
+    // the first turn (no tool_use), so the runner immediately ends the
+    // turn loop and output contains only the intent string.
+    expect(output.status).toBe('completed');
+    expect(output.output).toContain('Result:');
+  });
 });

--- a/packages/agent/src/__tests__/agent-process.subagent-intent-text-stop.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.subagent-intent-text-stop.e2e.test.ts
@@ -18,6 +18,8 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
+  SUBAGENT_JOB_TIMEOUT_MS,
 } from './helpers';
 
 interface JobUpdate {
@@ -28,46 +30,46 @@ interface JobUpdate {
   outcome?: string;
 }
 
-describe('lace-agent subagent intent-text-stop (kata #31 round 2)', () => {
-  const ctx = createE2EContext({ prefix: 'lace-agent-subagent-intent-text-stop' });
+describe(
+  'lace-agent subagent intent-text-stop (kata #31 round 2)',
+  { timeout: E2E_TEST_TIMEOUT_MS },
+  () => {
+    const ctx = createE2EContext({ prefix: 'lace-agent-subagent-intent-text-stop' });
 
-  beforeEach(() => ctx.setup());
-  afterEach(() => ctx.teardown());
+    beforeEach(() => ctx.setup());
+    afterEach(() => ctx.teardown());
 
-  /**
-   * Production parallel:
-   *   • Persona "therapist" has tools: [file_read, file_write].
-   *   • Subagent prompt: "read file persona/persona.md" — model emits
-   *     file_read tool_use on turn 1.
-   *   • file_read returns content (here, an empty file).
-   *   • Turn 2: the model returns text-only "I'll add a brief note at the
-   *     end in Ada's voice." with stopReason='end_turn' and NO tool_use.
-   *   • Production observed: subagent terminates as status='completed' with
-   *     that intent text as final output. The host-side persona.md is never
-   *     written; the work the model declared never happens.
-   *
-   * What this test pins:
-   *   When the subagent's turn following a tool round-trip produces intent
-   *   text with no tool call, the subagent's job must NOT report
-   *   status='completed' with that intent text as its sole output. The
-   *   parent should be able to distinguish "subagent did the work" from
-   *   "subagent declared work and didn't do it".
-   *
-   * What a fix needs to change:
-   *   Either the subagent's runner re-prompts more aggressively until a tool
-   *   actually fires (bounded by max-turns), or the subagent job surfaces a
-   *   non-'completed' status to its parent so the parent can react.
-   *
-   * Driving knob:
-   *   The TestAgentProvider env var
-   *   LACE_TEST_PROVIDER_INTENT_AFTER_TOOL_RESULT replaces the usual
-   *   "Result:\n…" turn-2 summary with the configured intent string, so the
-   *   subagent observes the production-shape Turn-2 response.
-   */
-  it(
-    'FAILING — subagent with intent-only turn-2 should NOT report status=completed with intent text as final output',
-    { timeout: 30_000 },
-    async () => {
+    /**
+     * Production parallel:
+     *   • Persona "therapist" has tools: [file_read, file_write].
+     *   • Subagent prompt: "read file persona/persona.md" — model emits
+     *     file_read tool_use on turn 1.
+     *   • file_read returns content (here, an empty file).
+     *   • Turn 2: the model returns text-only "I'll add a brief note at the
+     *     end in Ada's voice." with stopReason='end_turn' and NO tool_use.
+     *   • Production observed: subagent terminates as status='completed' with
+     *     that intent text as final output. The host-side persona.md is never
+     *     written; the work the model declared never happens.
+     *
+     * What this test pins:
+     *   When the subagent's turn following a tool round-trip produces intent
+     *   text with no tool call, the subagent's job must NOT report
+     *   status='completed' with that intent text as its sole output. The
+     *   parent should be able to distinguish "subagent did the work" from
+     *   "subagent declared work and didn't do it".
+     *
+     * What a fix needs to change:
+     *   Either the subagent's runner re-prompts more aggressively until a tool
+     *   actually fires (bounded by max-turns), or the subagent job surfaces a
+     *   non-'completed' status to its parent so the parent can react.
+     *
+     * Driving knob:
+     *   The TestAgentProvider env var
+     *   LACE_TEST_PROVIDER_INTENT_AFTER_TOOL_RESULT replaces the usual
+     *   "Result:\n…" turn-2 summary with the configured intent string, so the
+     *   subagent observes the production-shape Turn-2 response.
+     */
+    it('FAILING — subagent with intent-only turn-2 should NOT report status=completed with intent text as final output', async () => {
       // Persona declares both read and write tools so the model is *allowed*
       // to call file_write on turn 2 — it simply chooses not to (modeled by
       // the env-injected intent text). This matches the production therapist
@@ -142,7 +144,7 @@ describe('lace-agent subagent intent-text-stop (kata #31 round 2)', () => {
         ctx.agent.peer.request('session/prompt', {
           content: [{ type: 'text', text: 'subagent persona=therapist: read file persona.md' }],
         }),
-        20_000,
+        SUBAGENT_JOB_TIMEOUT_MS,
         'session/prompt'
       );
 
@@ -159,7 +161,7 @@ describe('lace-agent subagent intent-text-stop (kata #31 round 2)', () => {
             }
           }, 10);
         }),
-        20_000,
+        SUBAGENT_JOB_TIMEOUT_MS,
         'job_finished update'
       );
 
@@ -218,24 +220,20 @@ describe('lace-agent subagent intent-text-stop (kata #31 round 2)', () => {
         outputContainsUnfulfilledIntent: finalOutputContainsIntent,
         completedWithIntentOnly,
       }).toMatchObject({ completedWithIntentOnly: false });
-    }
-  );
+    });
 
-  /**
-   * Negative companion: a subagent that responds with pure text (no prior
-   * tool call) is fine — pure-text answers to non-tool-requiring prompts
-   * are legitimate. The fix for the bug above must NOT cause this to
-   * regress.
-   *
-   * This test does NOT use LACE_TEST_PROVIDER_INTENT_AFTER_TOOL_RESULT (the
-   * env switch only activates when a tool result is present in the
-   * conversation), so the parent agent's first turn goes straight to a
-   * pure-text response.
-   */
-  it(
-    'PASSING — subagent without any tool call (legit pure-text answer) completes cleanly',
-    { timeout: 20_000 },
-    async () => {
+    /**
+     * Negative companion: a subagent that responds with pure text (no prior
+     * tool call) is fine — pure-text answers to non-tool-requiring prompts
+     * are legitimate. The fix for the bug above must NOT cause this to
+     * regress.
+     *
+     * This test does NOT use LACE_TEST_PROVIDER_INTENT_AFTER_TOOL_RESULT (the
+     * env switch only activates when a tool result is present in the
+     * conversation), so the parent agent's first turn goes straight to a
+     * pure-text response.
+     */
+    it('PASSING — subagent without any tool call (legit pure-text answer) completes cleanly', async () => {
       const personasDir = join(ctx.laceDir, 'agent-personas');
       mkdirSync(personasDir, { recursive: true });
       writeFileSync(
@@ -294,7 +292,7 @@ describe('lace-agent subagent intent-text-stop (kata #31 round 2)', () => {
             },
           ],
         }),
-        10_000,
+        SUBAGENT_JOB_TIMEOUT_MS,
         'session/prompt'
       );
 
@@ -311,7 +309,7 @@ describe('lace-agent subagent intent-text-stop (kata #31 round 2)', () => {
             }
           }, 10);
         }),
-        10_000,
+        SUBAGENT_JOB_TIMEOUT_MS,
         'job_finished update'
       );
 
@@ -325,6 +323,6 @@ describe('lace-agent subagent intent-text-stop (kata #31 round 2)', () => {
       // is a clean completion. The fix for the FAILING test above must not
       // regress this path.
       expect(output.status).toBe('completed');
-    }
-  );
-});
+    });
+  }
+);

--- a/packages/agent/src/__tests__/agent-process.subagent.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.subagent.e2e.test.ts
@@ -5,85 +5,83 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
+  SUBAGENT_JOB_TIMEOUT_MS,
 } from './helpers';
 
-describe('lace-agent subagents (E2E over stdio)', () => {
+describe('lace-agent subagents (E2E over stdio)', { timeout: E2E_TEST_TIMEOUT_MS }, () => {
   const ctx = createE2EContext({ prefix: 'lace-agent-subagent' });
 
   beforeEach(() => ctx.setup());
   afterEach(() => ctx.teardown());
 
-  it(
-    'spawns a subagent job and exposes its output via ent/job/output',
-    { timeout: 20_000 },
-    async () => {
-      ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
+  it('spawns a subagent job and exposes its output via ent/job/output', async () => {
+    ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
-      const updates: Array<Record<string, unknown>> = [];
-      let subagentJobId: string | undefined;
+    const updates: Array<Record<string, unknown>> = [];
+    let subagentJobId: string | undefined;
 
-      ctx.agent.peer.onRequest('session/update', async (params) => {
-        const p = params as Record<string, unknown>;
-        updates.push(p);
-        if (p.type === 'job_started' && p.jobType === 'delegate' && typeof p.jobId === 'string') {
-          subagentJobId = p.jobId;
-        }
-        return undefined;
-      });
+    ctx.agent.peer.onRequest('session/update', async (params) => {
+      const p = params as Record<string, unknown>;
+      updates.push(p);
+      if (p.type === 'job_started' && p.jobType === 'delegate' && typeof p.jobId === 'string') {
+        subagentJobId = p.jobId;
+      }
+      return undefined;
+    });
 
-      ctx.agent.peer.onRequest('session/request_permission', async () => ({ decision: 'allow' }));
+    ctx.agent.peer.onRequest('session/request_permission', async () => ({ decision: 'allow' }));
 
-      await withTimeout(
-        ctx.agent.peer.request(
-          'initialize',
-          defaultInitializeParams({ config: { approvalMode: 'ask' } })
-        ),
-        AGENT_BOOT_TIMEOUT_MS,
-        'initialize'
-      );
-      await withTimeout(
-        ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
-        2_000,
-        'session/new'
-      );
+    await withTimeout(
+      ctx.agent.peer.request(
+        'initialize',
+        defaultInitializeParams({ config: { approvalMode: 'ask' } })
+      ),
+      AGENT_BOOT_TIMEOUT_MS,
+      'initialize'
+    );
+    await withTimeout(
+      ctx.agent.peer.request('session/new', { cwd: ctx.workDir, mcpServers: [] }),
+      2_000,
+      'session/new'
+    );
 
-      await withTimeout(
-        ctx.agent.peer.request('session/prompt', {
-          content: [{ type: 'text', text: 'subagent: hi' }],
-        }),
-        10_000,
-        'session/prompt'
-      );
+    await withTimeout(
+      ctx.agent.peer.request('session/prompt', {
+        content: [{ type: 'text', text: 'subagent: hi' }],
+      }),
+      SUBAGENT_JOB_TIMEOUT_MS,
+      'session/prompt'
+    );
 
-      await withTimeout(
-        new Promise<void>((resolve) => {
-          const interval = setInterval(() => {
-            if (!subagentJobId) return;
-            const finished = updates.find(
-              (u) => u.type === 'job_finished' && u.jobId === subagentJobId
-            );
-            if (finished) {
-              clearInterval(interval);
-              resolve();
-            }
-          }, 10);
-        }),
-        10_000,
-        'job_finished update'
-      );
+    await withTimeout(
+      new Promise<void>((resolve) => {
+        const interval = setInterval(() => {
+          if (!subagentJobId) return;
+          const finished = updates.find(
+            (u) => u.type === 'job_finished' && u.jobId === subagentJobId
+          );
+          if (finished) {
+            clearInterval(interval);
+            resolve();
+          }
+        }, 10);
+      }),
+      SUBAGENT_JOB_TIMEOUT_MS,
+      'job_finished update'
+    );
 
-      const output = (await withTimeout(
-        ctx.agent.peer.request('ent/job/output', { jobId: subagentJobId }),
-        2_000,
-        'ent/job/output'
-      )) as { status: string; output: string };
+    const output = (await withTimeout(
+      ctx.agent.peer.request('ent/job/output', { jobId: subagentJobId }),
+      2_000,
+      'ent/job/output'
+    )) as { status: string; output: string };
 
-      expect(output.status).toBe('completed');
-      expect(output.output).toContain('No tool result found');
-    }
-  );
+    expect(output.status).toBe('completed');
+    expect(output.output).toContain('No tool result found');
+  });
 
-  it('forwards subagent permission requests with jobId', { timeout: 20_000 }, async () => {
+  it('forwards subagent permission requests with jobId', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     let subagentJobId: string | undefined;
@@ -120,7 +118,7 @@ describe('lace-agent subagents (E2E over stdio)', () => {
       ctx.agent.peer.request('session/prompt', {
         content: [{ type: 'text', text: 'subagent: run: echo hi' }],
       }),
-      10_000,
+      SUBAGENT_JOB_TIMEOUT_MS,
       'session/prompt'
     );
 
@@ -133,7 +131,7 @@ describe('lace-agent subagents (E2E over stdio)', () => {
           }
         }, 10);
       }),
-      10_000,
+      SUBAGENT_JOB_TIMEOUT_MS,
       'permission request forwarded'
     );
 

--- a/packages/agent/src/__tests__/agent-process.todo.e2e.test.ts
+++ b/packages/agent/src/__tests__/agent-process.todo.e2e.test.ts
@@ -10,9 +10,10 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
 } from './helpers';
 
-describe('lace-agent todo tools (E2E over stdio)', () => {
+describe('lace-agent todo tools (E2E over stdio)', { timeout: E2E_TEST_TIMEOUT_MS }, () => {
   const ctx = createE2EContext({ prefix: 'lace-agent-todo' });
 
   beforeEach(() => ctx.setup());
@@ -26,7 +27,7 @@ describe('lace-agent todo tools (E2E over stdio)', () => {
     return join(ctx.laceDir, 'agent-sessions', sessionId);
   }
 
-  it('creates todo.md when agent uses todo_write', { timeout: 20_000 }, async () => {
+  it('creates todo.md when agent uses todo_write', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     const updates: Array<Record<string, unknown>> = [];
@@ -95,7 +96,7 @@ describe('lace-agent todo tools (E2E over stdio)', () => {
     expect(todoContent).toMatch(/`t_\w{3}`/); // Has an ID like t_abc
   });
 
-  it('reads existing todos with todo_read', { timeout: 20_000 }, async () => {
+  it('reads existing todos with todo_read', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     const updates: Array<Record<string, unknown>> = [];
@@ -168,7 +169,7 @@ describe('lace-agent todo tools (E2E over stdio)', () => {
     expect(textContent).toContain('t_xyz');
   });
 
-  it('marks tasks done with todo_write', { timeout: 20_000 }, async () => {
+  it('marks tasks done with todo_write', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     const updates: Array<Record<string, unknown>> = [];
@@ -237,7 +238,7 @@ describe('lace-agent todo tools (E2E over stdio)', () => {
     expect(todoContent).toContain('t_abc');
   });
 
-  it('does not prompt for permission when using todo tools', { timeout: 20_000 }, async () => {
+  it('does not prompt for permission when using todo tools', async () => {
     ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
     let permissionRequested = false;

--- a/packages/agent/src/__tests__/credential-broker-socket-chain.e2e.test.ts
+++ b/packages/agent/src/__tests__/credential-broker-socket-chain.e2e.test.ts
@@ -13,6 +13,7 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
 } from './helpers';
 
 // A tiny exec-tool that answers `lace-tool-schema` with a request_credential descriptor
@@ -46,24 +47,24 @@ function makeFixtureDir(): string {
   return dir;
 }
 
-describe('credentialBrokerSocket full chain (initialize → session/new → prompt → envelope)', () => {
-  const ctx = createE2EContext({ prefix: 'lace-cred-chain' });
-  let fixtureDir: string;
+describe(
+  'credentialBrokerSocket full chain (initialize → session/new → prompt → envelope)',
+  { timeout: E2E_TEST_TIMEOUT_MS },
+  () => {
+    const ctx = createE2EContext({ prefix: 'lace-cred-chain' });
+    let fixtureDir: string;
 
-  beforeEach(() => {
-    ctx.setup();
-    fixtureDir = makeFixtureDir();
-  });
+    beforeEach(() => {
+      ctx.setup();
+      fixtureDir = makeFixtureDir();
+    });
 
-  afterEach(async () => {
-    await ctx.teardown();
-    rmSync(fixtureDir, { recursive: true, force: true });
-  });
+    afterEach(async () => {
+      await ctx.teardown();
+      rmSync(fixtureDir, { recursive: true, force: true });
+    });
 
-  it(
-    'stamps the initialize-config broker socket into the credential tool envelope',
-    { timeout: 20_000 },
-    async () => {
+    it('stamps the initialize-config broker socket into the credential tool envelope', async () => {
       ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
       const updates: Array<Record<string, unknown>> = [];
@@ -134,6 +135,6 @@ describe('credentialBrokerSocket full chain (initialize → session/new → prom
       const envelopeContext = JSON.parse(text) as Record<string, unknown>;
 
       expect(envelopeContext.credentialBrokerSocket).toBe('/tmp/x.sock');
-    }
-  );
-});
+    });
+  }
+);

--- a/packages/agent/src/__tests__/credential-integration.e2e.test.ts
+++ b/packages/agent/src/__tests__/credential-integration.e2e.test.ts
@@ -22,6 +22,8 @@ import {
   spawnAgentProcess,
   withTimeout,
   defaultInitializeParams,
+  E2E_TEST_TIMEOUT_MS,
+  SUBAGENT_JOB_TIMEOUT_MS,
 } from './helpers';
 
 // A tiny exec-tool that advertises request_credential (with the credentials
@@ -66,175 +68,177 @@ function createPairedPeers(register: (peer: JsonRpcPeer) => void) {
   return { client, server };
 }
 
-describe('Part B credential integration (lace wiring + subagent path)', () => {
-  // (i)-(iii) drive an in-process agent server over paired peers; (iv) spawns a
-  // real subagent child process. Both touch the process-global tool registry, so
-  // this file runs serial (--no-file-parallelism, per the lace src/__tests__ convention).
+describe(
+  'Part B credential integration (lace wiring + subagent path)',
+  { timeout: E2E_TEST_TIMEOUT_MS },
+  () => {
+    // (i)-(iii) drive an in-process agent server over paired peers; (iv) spawns a
+    // real subagent child process. Both touch the process-global tool registry, so
+    // this file runs serial (--no-file-parallelism, per the lace src/__tests__ convention).
 
-  describe('(i) request_credential is advertised only to a persona that lists it', () => {
-    let fixtureDir: string;
+    describe('(i) request_credential is advertised only to a persona that lists it', () => {
+      let fixtureDir: string;
 
-    beforeEach(() => {
-      resetRegistriesForTest();
-      registerBuiltinTools();
-      fixtureDir = makeFixtureDir();
-      // Global, trusted registration — exactly what initialize.ts does from
-      // credentialToolsPaths (owner 'credential' carves the reserved-name throw).
-      registerExecDirInto(fixtureDir, { owner: 'credential', trustedCredentialProvenance: true });
-    });
-
-    afterEach(() => {
-      rmSync(fixtureDir, { recursive: true, force: true });
-      resetRegistriesForTest();
-    });
-
-    it('survives executor construction and is advertised when toolScope lists it', async () => {
-      expect(registries.tools.has('request_credential')).toBe(true);
-
-      // A box-worker persona's toolScope lists request_credential → advertised.
-      const { toolsForProvider } = await createToolExecutorForMode(
-        'execute',
-        undefined,
-        undefined,
-        undefined,
-        ['bash', 'request_credential']
-      );
-      expect(toolsForProvider.map((t) => t.name)).toContain('request_credential');
-    });
-
-    it('is NOT advertised to a persona whose toolScope omits it', async () => {
-      // core-like persona: lists tools but not request_credential. The broker is
-      // the real boundary, but availability gating still must not surface it here.
-      const { toolsForProvider } = await createToolExecutorForMode(
-        'execute',
-        undefined,
-        undefined,
-        undefined,
-        ['bash', 'file_read']
-      );
-      expect(toolsForProvider.map((t) => t.name)).not.toContain('request_credential');
-    });
-  });
-
-  describe('(ii) untrusted provenance does not forward the broker socket', () => {
-    let fixtureDir: string;
-
-    beforeEach(() => {
-      fixtureDir = makeFixtureDir();
-    });
-
-    afterEach(() => {
-      rmSync(fixtureDir, { recursive: true, force: true });
-      resetRegistriesForTest();
-    });
-
-    const invokeAndReadContext = async (): Promise<Record<string, unknown>> => {
-      const { executor } = await createToolExecutorForMode('execute');
-      const result = await executor.execute(
-        { id: 't1', name: 'request_credential', arguments: {} },
-        {
-          activeSessionId: 'sess-1',
-          persona: 'engineer',
-          credentialBrokerSocket: '/run/cred.sock',
-          roleEnvironment: 'prod',
-        }
-      );
-      const text = result.content.map((b) => b.text ?? '').join('');
-      return JSON.parse(text) as Record<string, unknown>;
-    };
-
-    it('forwards the socket with trusted provenance, withholds it without', async () => {
-      resetRegistriesForTest();
-      registerBuiltinTools();
-      registerExecDirInto(fixtureDir, { owner: 'credential', trustedCredentialProvenance: true });
-      const trustedCtx = await invokeAndReadContext();
-      expect(trustedCtx.credentialBrokerSocket).toBe('/run/cred.sock');
-
-      resetRegistriesForTest();
-      registerBuiltinTools();
-      // Same dir, same self-declared credentials capability — but NOT trusted.
-      registerExecDirInto(fixtureDir, { owner: 'credential' });
-      const untrustedCtx = await invokeAndReadContext();
-      expect(untrustedCtx.credentialBrokerSocket).toBeUndefined();
-    });
-  });
-
-  describe('(iii) the main-agent envelope carries credentialBrokerSocket + role', () => {
-    let originalLaceDir: string | undefined;
-    let tempDir: string;
-    let fixtureDir: string;
-
-    beforeEach(() => {
-      resetRegistriesForTest();
-      originalLaceDir = process.env.LACE_DIR;
-      tempDir = mkdtempSync(join(tmpdir(), 'lace-cred-mainagent-'));
-      process.env.LACE_DIR = tempDir;
-      fixtureDir = makeFixtureDir();
-    });
-
-    afterEach(() => {
-      if (originalLaceDir === undefined) delete process.env.LACE_DIR;
-      else process.env.LACE_DIR = originalLaceDir;
-      rmSync(tempDir, { recursive: true, force: true });
-      rmSync(fixtureDir, { recursive: true, force: true });
-      resetRegistriesForTest();
-    });
-
-    it('stamps the initialize-config socket and a role into the credential tool envelope', async () => {
-      const state = createAgentServerState();
-      const { client, server } = createPairedPeers((peer) => registerAgentRpcMethods(peer, state));
-
-      await client.request('initialize', {
-        ...defaultInitializeParams({
-          config: { credentialBrokerSocket: '/run/role.sock' },
-        }),
-        credentialToolsPaths: [fixtureDir],
+      beforeEach(() => {
+        resetRegistriesForTest();
+        registerBuiltinTools();
+        fixtureDir = makeFixtureDir();
+        // Global, trusted registration — exactly what initialize.ts does from
+        // credentialToolsPaths (owner 'credential' carves the reserved-name throw).
+        registerExecDirInto(fixtureDir, { owner: 'credential', trustedCredentialProvenance: true });
       });
 
-      // Invoke the registered credential tool with a session-stamped role +
-      // broker socket (the runner's effectiveConfig provides both). The fixture
-      // echoes the envelope context back as its tool result.
-      const { executor } = await createToolExecutorForMode('execute');
-      const result = await executor.execute(
-        { id: 't1', name: 'request_credential', arguments: {} },
-        {
-          activeSessionId: 'sess-1',
-          persona: 'persistent-box-worker',
-          credentialBrokerSocket: '/run/role.sock',
-          roleEnvironment: 'persistent-box',
-        }
-      );
-      const text = result.content.map((b) => b.text ?? '').join('');
-      const envelopeContext = JSON.parse(text) as Record<string, unknown>;
+      afterEach(() => {
+        rmSync(fixtureDir, { recursive: true, force: true });
+        resetRegistriesForTest();
+      });
 
-      expect(envelopeContext.credentialBrokerSocket).toBe('/run/role.sock');
-      // The role is stamped from session state, not model args — a prompt-injected
-      // persona cannot forge it.
-      expect(envelopeContext.role).toBe('persistent-box-worker');
+      it('survives executor construction and is advertised when toolScope lists it', async () => {
+        expect(registries.tools.has('request_credential')).toBe(true);
 
-      client.close();
-      server.close();
-    });
-  });
+        // A box-worker persona's toolScope lists request_credential → advertised.
+        const { toolsForProvider } = await createToolExecutorForMode(
+          'execute',
+          undefined,
+          undefined,
+          undefined,
+          ['bash', 'request_credential']
+        );
+        expect(toolsForProvider.map((t) => t.name)).toContain('request_credential');
+      });
 
-  describe('(iv) subagent child path — the W5c gap (spawned agent process)', () => {
-    const ctx = createE2EContext({ prefix: 'lace-cred-subagent' });
-    let fixtureDir: string;
-
-    beforeEach(() => {
-      ctx.setup();
-      fixtureDir = makeFixtureDir();
+      it('is NOT advertised to a persona whose toolScope omits it', async () => {
+        // core-like persona: lists tools but not request_credential. The broker is
+        // the real boundary, but availability gating still must not surface it here.
+        const { toolsForProvider } = await createToolExecutorForMode(
+          'execute',
+          undefined,
+          undefined,
+          undefined,
+          ['bash', 'file_read']
+        );
+        expect(toolsForProvider.map((t) => t.name)).not.toContain('request_credential');
+      });
     });
 
-    afterEach(async () => {
-      await ctx.teardown();
-      rmSync(fixtureDir, { recursive: true, force: true });
+    describe('(ii) untrusted provenance does not forward the broker socket', () => {
+      let fixtureDir: string;
+
+      beforeEach(() => {
+        fixtureDir = makeFixtureDir();
+      });
+
+      afterEach(() => {
+        rmSync(fixtureDir, { recursive: true, force: true });
+        resetRegistriesForTest();
+      });
+
+      const invokeAndReadContext = async (): Promise<Record<string, unknown>> => {
+        const { executor } = await createToolExecutorForMode('execute');
+        const result = await executor.execute(
+          { id: 't1', name: 'request_credential', arguments: {} },
+          {
+            activeSessionId: 'sess-1',
+            persona: 'engineer',
+            credentialBrokerSocket: '/run/cred.sock',
+            roleEnvironment: 'prod',
+          }
+        );
+        const text = result.content.map((b) => b.text ?? '').join('');
+        return JSON.parse(text) as Record<string, unknown>;
+      };
+
+      it('forwards the socket with trusted provenance, withholds it without', async () => {
+        resetRegistriesForTest();
+        registerBuiltinTools();
+        registerExecDirInto(fixtureDir, { owner: 'credential', trustedCredentialProvenance: true });
+        const trustedCtx = await invokeAndReadContext();
+        expect(trustedCtx.credentialBrokerSocket).toBe('/run/cred.sock');
+
+        resetRegistriesForTest();
+        registerBuiltinTools();
+        // Same dir, same self-declared credentials capability — but NOT trusted.
+        registerExecDirInto(fixtureDir, { owner: 'credential' });
+        const untrustedCtx = await invokeAndReadContext();
+        expect(untrustedCtx.credentialBrokerSocket).toBeUndefined();
+      });
     });
 
-    it(
-      'a delegated child registers request_credential and its envelope forwards the broker socket',
-      { timeout: 20_000 },
-      async () => {
+    describe('(iii) the main-agent envelope carries credentialBrokerSocket + role', () => {
+      let originalLaceDir: string | undefined;
+      let tempDir: string;
+      let fixtureDir: string;
+
+      beforeEach(() => {
+        resetRegistriesForTest();
+        originalLaceDir = process.env.LACE_DIR;
+        tempDir = mkdtempSync(join(tmpdir(), 'lace-cred-mainagent-'));
+        process.env.LACE_DIR = tempDir;
+        fixtureDir = makeFixtureDir();
+      });
+
+      afterEach(() => {
+        if (originalLaceDir === undefined) delete process.env.LACE_DIR;
+        else process.env.LACE_DIR = originalLaceDir;
+        rmSync(tempDir, { recursive: true, force: true });
+        rmSync(fixtureDir, { recursive: true, force: true });
+        resetRegistriesForTest();
+      });
+
+      it('stamps the initialize-config socket and a role into the credential tool envelope', async () => {
+        const state = createAgentServerState();
+        const { client, server } = createPairedPeers((peer) =>
+          registerAgentRpcMethods(peer, state)
+        );
+
+        await client.request('initialize', {
+          ...defaultInitializeParams({
+            config: { credentialBrokerSocket: '/run/role.sock' },
+          }),
+          credentialToolsPaths: [fixtureDir],
+        });
+
+        // Invoke the registered credential tool with a session-stamped role +
+        // broker socket (the runner's effectiveConfig provides both). The fixture
+        // echoes the envelope context back as its tool result.
+        const { executor } = await createToolExecutorForMode('execute');
+        const result = await executor.execute(
+          { id: 't1', name: 'request_credential', arguments: {} },
+          {
+            activeSessionId: 'sess-1',
+            persona: 'persistent-box-worker',
+            credentialBrokerSocket: '/run/role.sock',
+            roleEnvironment: 'persistent-box',
+          }
+        );
+        const text = result.content.map((b) => b.text ?? '').join('');
+        const envelopeContext = JSON.parse(text) as Record<string, unknown>;
+
+        expect(envelopeContext.credentialBrokerSocket).toBe('/run/role.sock');
+        // The role is stamped from session state, not model args — a prompt-injected
+        // persona cannot forge it.
+        expect(envelopeContext.role).toBe('persistent-box-worker');
+
+        client.close();
+        server.close();
+      });
+    });
+
+    describe('(iv) subagent child path — the W5c gap (spawned agent process)', () => {
+      const ctx = createE2EContext({ prefix: 'lace-cred-subagent' });
+      let fixtureDir: string;
+
+      beforeEach(() => {
+        ctx.setup();
+        fixtureDir = makeFixtureDir();
+      });
+
+      afterEach(async () => {
+        await ctx.teardown();
+        rmSync(fixtureDir, { recursive: true, force: true });
+      });
+
+      it('a delegated child registers request_credential and its envelope forwards the broker socket', async () => {
         ctx.agent = spawnAgentProcess({ laceDir: ctx.laceDir });
 
         const updates: Array<Record<string, unknown>> = [];
@@ -293,7 +297,7 @@ describe('Part B credential integration (lace wiring + subagent path)', () => {
               }
             }, 10);
           }),
-          12_000,
+          SUBAGENT_JOB_TIMEOUT_MS,
           'delegate job completion'
         );
 
@@ -309,10 +313,10 @@ describe('Part B credential integration (lace wiring + subagent path)', () => {
         // the socket value proves the child stamped it (broker socket reached the child).
         const childContext = extractCredentialEnvelopeContext(output.output);
         expect(childContext.credentialBrokerSocket).toBe('/run/child-role.sock');
-      }
-    );
-  });
-});
+      });
+    });
+  }
+);
 
 // The subagent's job output embeds the fixture's echoed envelope-context JSON in
 // a "[tool_result: request_credential → {…}]" segment. Parse that first complete

--- a/packages/agent/src/__tests__/ent-protocol.spec.ts
+++ b/packages/agent/src/__tests__/ent-protocol.spec.ts
@@ -10,6 +10,7 @@ import {
   spawnAgentProcess,
   withTimeout,
   type SpawnedAgent,
+  E2E_TEST_TIMEOUT_MS,
 } from './helpers/agent-process';
 import { defaultInitializeParams } from './helpers/initialize';
 import * as MethodSchemas from '@lace/ent-protocol';
@@ -94,7 +95,7 @@ function notifyOk(options: {
  * Contract-style coverage for key Ent protocol methods.
  * These tests exercise stdio JSON-RPC end-to-end against the built agent.
  */
-describe('Ent protocol contract (selected coverage)', () => {
+describe('Ent protocol contract (selected coverage)', { timeout: E2E_TEST_TIMEOUT_MS }, () => {
   let laceDir: string;
   let workDir: string;
   let agent: SpawnedAgent | undefined;
@@ -118,177 +119,173 @@ describe('Ent protocol contract (selected coverage)', () => {
     rmSync(workDir, { recursive: true, force: true });
   });
 
-  it(
-    'supports provider catalog, connections, models (enable/disable) and session configure',
-    { timeout: 25_000 },
-    async () => {
-      agent = spawnAgentProcess({ laceDir });
+  it('supports provider catalog, connections, models (enable/disable) and session configure', async () => {
+    agent = spawnAgentProcess({ laceDir });
 
-      await requestOk({
-        agent,
-        method: 'initialize',
-        requestSchema: MethodSchemas.InitializeRequestSchema,
-        responseSchema: MethodSchemas.InitializeResponseSchema,
-        params: defaultInitializeParams(),
-        label: 'init',
-      });
+    await requestOk({
+      agent,
+      method: 'initialize',
+      requestSchema: MethodSchemas.InitializeRequestSchema,
+      responseSchema: MethodSchemas.InitializeResponseSchema,
+      params: defaultInitializeParams(),
+      label: 'init',
+    });
 
-      const catalog = await requestOk<{ providers: Array<{ id: string; models: unknown[] }> }>({
-        agent,
-        method: 'ent/providers/catalog',
-        requestSchema: MethodSchemas.EntProvidersCatalogRequestSchema,
-        responseSchema: MethodSchemas.EntProvidersCatalogResponseSchema,
-        label: 'providers/catalog',
-      });
-      expect(catalog.providers.length).toBeGreaterThan(0);
-      expect(Array.isArray(catalog.providers[0]?.models)).toBe(true);
+    const catalog = await requestOk<{ providers: Array<{ id: string; models: unknown[] }> }>({
+      agent,
+      method: 'ent/providers/catalog',
+      requestSchema: MethodSchemas.EntProvidersCatalogRequestSchema,
+      responseSchema: MethodSchemas.EntProvidersCatalogResponseSchema,
+      label: 'providers/catalog',
+    });
+    expect(catalog.providers.length).toBeGreaterThan(0);
+    expect(Array.isArray(catalog.providers[0]?.models)).toBe(true);
 
-      // providers list
-      const { providers } = await requestOk<{
-        providers: Array<{ providerId: string; displayName?: string }>;
-      }>({
-        agent,
-        method: 'ent/providers/list',
-        requestSchema: MethodSchemas.EntProvidersListRequestSchema,
-        responseSchema: MethodSchemas.EntProvidersListResponseSchema,
-        label: 'providers/list',
-      });
-      expect(providers.length).toBeGreaterThan(0);
+    // providers list
+    const { providers } = await requestOk<{
+      providers: Array<{ providerId: string; displayName?: string }>;
+    }>({
+      agent,
+      method: 'ent/providers/list',
+      requestSchema: MethodSchemas.EntProvidersListRequestSchema,
+      responseSchema: MethodSchemas.EntProvidersListResponseSchema,
+      label: 'providers/list',
+    });
+    expect(providers.length).toBeGreaterThan(0);
 
-      const providerId =
-        providers.find((p) => p.providerId === 'openai')?.providerId ?? providers[0].providerId;
+    const providerId =
+      providers.find((p) => p.providerId === 'openai')?.providerId ?? providers[0].providerId;
 
-      // connections upsert
-      const { connectionId } = await requestOk<{ connectionId: string }>({
-        agent,
-        method: 'ent/connections/upsert',
-        requestSchema: MethodSchemas.EntConnectionsUpsertRequestSchema,
-        responseSchema: MethodSchemas.EntConnectionsUpsertResponseSchema,
-        params: { providerId, connection: { name: 'ent-spec', config: {} } },
-        label: 'connections/upsert',
-      });
-      expect(connectionId).toBeTruthy();
+    // connections upsert
+    const { connectionId } = await requestOk<{ connectionId: string }>({
+      agent,
+      method: 'ent/connections/upsert',
+      requestSchema: MethodSchemas.EntConnectionsUpsertRequestSchema,
+      responseSchema: MethodSchemas.EntConnectionsUpsertResponseSchema,
+      params: { providerId, connection: { name: 'ent-spec', config: {} } },
+      label: 'connections/upsert',
+    });
+    expect(connectionId).toBeTruthy();
 
-      // models list
-      const modelsResp = await requestOk<{
-        providerId: string;
-        models: Array<{
-          modelId: string;
-          disabled?: boolean;
-          disabledState?: 'enabled' | 'disabled';
-        }>;
-      }>({
-        agent,
-        method: 'ent/models/list',
-        requestSchema: MethodSchemas.EntModelsListRequestSchema,
-        responseSchema: MethodSchemas.EntModelsListResponseSchema,
-        params: { connectionId },
-        label: 'models/list',
-      });
-      expect(modelsResp.providerId).toBe(providerId);
-      expect(modelsResp.models.length).toBeGreaterThan(0);
-      expect(modelsResp.models[0]?.disabledState).toBeDefined();
+    // models list
+    const modelsResp = await requestOk<{
+      providerId: string;
+      models: Array<{
+        modelId: string;
+        disabled?: boolean;
+        disabledState?: 'enabled' | 'disabled';
+      }>;
+    }>({
+      agent,
+      method: 'ent/models/list',
+      requestSchema: MethodSchemas.EntModelsListRequestSchema,
+      responseSchema: MethodSchemas.EntModelsListResponseSchema,
+      params: { connectionId },
+      label: 'models/list',
+    });
+    expect(modelsResp.providerId).toBe(providerId);
+    expect(modelsResp.models.length).toBeGreaterThan(0);
+    expect(modelsResp.models[0]?.disabledState).toBeDefined();
 
-      const targetModel = modelsResp.models[0].modelId;
+    const targetModel = modelsResp.models[0].modelId;
 
-      // disable + verify disabled flag appears
-      await requestOk({
-        agent,
-        method: 'ent/models/disable',
-        requestSchema: MethodSchemas.EntModelsDisableRequestSchema,
-        responseSchema: MethodSchemas.EntModelsDisableResponseSchema,
-        params: { providerId, modelIds: [targetModel] },
-        label: 'models/disable',
-      });
-      const afterDisable = await requestOk<{
-        models: Array<{
-          modelId: string;
-          disabled?: boolean;
-          disabledState?: 'enabled' | 'disabled';
-        }>;
-      }>({
-        agent,
-        method: 'ent/models/list',
-        requestSchema: MethodSchemas.EntModelsListRequestSchema,
-        responseSchema: MethodSchemas.EntModelsListResponseSchema,
-        params: { connectionId },
-        label: 'models/list after disable',
-      });
-      const disabledEntry = afterDisable.models.find((m) => m.modelId === targetModel);
-      expect(disabledEntry?.disabled).toBe(true);
-      expect(disabledEntry?.disabledState).toBe('disabled');
+    // disable + verify disabled flag appears
+    await requestOk({
+      agent,
+      method: 'ent/models/disable',
+      requestSchema: MethodSchemas.EntModelsDisableRequestSchema,
+      responseSchema: MethodSchemas.EntModelsDisableResponseSchema,
+      params: { providerId, modelIds: [targetModel] },
+      label: 'models/disable',
+    });
+    const afterDisable = await requestOk<{
+      models: Array<{
+        modelId: string;
+        disabled?: boolean;
+        disabledState?: 'enabled' | 'disabled';
+      }>;
+    }>({
+      agent,
+      method: 'ent/models/list',
+      requestSchema: MethodSchemas.EntModelsListRequestSchema,
+      responseSchema: MethodSchemas.EntModelsListResponseSchema,
+      params: { connectionId },
+      label: 'models/list after disable',
+    });
+    const disabledEntry = afterDisable.models.find((m) => m.modelId === targetModel);
+    expect(disabledEntry?.disabled).toBe(true);
+    expect(disabledEntry?.disabledState).toBe('disabled');
 
-      // configure provider connection/env via Ent and model/permission mode via ACP config options
-      const { sessionId } = await requestOk<{ sessionId: string }>({
-        agent,
-        method: 'session/new',
-        requestSchema: MethodSchemas.SessionNewRequestSchema,
-        responseSchema: MethodSchemas.SessionNewResponseSchema,
-        params: { cwd: workDir, mcpServers: [] },
-        label: 'session/new',
-      });
-      expect(sessionId).toBeTruthy();
+    // configure provider connection/env via Ent and model/permission mode via ACP config options
+    const { sessionId } = await requestOk<{ sessionId: string }>({
+      agent,
+      method: 'session/new',
+      requestSchema: MethodSchemas.SessionNewRequestSchema,
+      responseSchema: MethodSchemas.SessionNewResponseSchema,
+      params: { cwd: workDir, mcpServers: [] },
+      label: 'session/new',
+    });
+    expect(sessionId).toBeTruthy();
 
-      const configureResult = await requestOk<{
-        applied: string[];
-        config: Record<string, unknown>;
-      }>({
-        agent,
-        method: 'ent/session/configure',
-        requestSchema: MethodSchemas.EntSessionConfigureRequestSchema,
-        responseSchema: MethodSchemas.EntSessionConfigureResponseSchema,
-        params: {
-          connectionId,
-          environment: { HELLO: 'WORLD' },
-        },
-        label: 'session/configure',
-      });
-
-      expect(configureResult.applied).toEqual(
-        expect.arrayContaining(['connectionId', 'environment'])
-      );
-      expect(configureResult.config).toMatchObject({
+    const configureResult = await requestOk<{
+      applied: string[];
+      config: Record<string, unknown>;
+    }>({
+      agent,
+      method: 'ent/session/configure',
+      requestSchema: MethodSchemas.EntSessionConfigureRequestSchema,
+      responseSchema: MethodSchemas.EntSessionConfigureResponseSchema,
+      params: {
         connectionId,
         environment: { HELLO: 'WORLD' },
-      });
+      },
+      label: 'session/configure',
+    });
 
-      const modelResult = await requestOk<{ configOptions: Array<Record<string, unknown>> }>({
-        agent,
-        method: 'session/set_config_option',
-        requestSchema: (MethodSchemas as any).SessionSetConfigOptionRequestSchema,
-        responseSchema: (MethodSchemas as any).SessionSetConfigOptionResponseSchema,
-        params: { sessionId, configId: 'model', value: targetModel },
-        label: 'session/set_config_option model',
-      });
-      expect(modelResult.configOptions).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            id: 'model',
-            category: 'model',
-            currentValue: targetModel,
-          }),
-        ])
-      );
+    expect(configureResult.applied).toEqual(
+      expect.arrayContaining(['connectionId', 'environment'])
+    );
+    expect(configureResult.config).toMatchObject({
+      connectionId,
+      environment: { HELLO: 'WORLD' },
+    });
 
-      const approvalResult = await requestOk<{ configOptions: Array<Record<string, unknown>> }>({
-        agent,
-        method: 'session/set_config_option',
-        requestSchema: (MethodSchemas as any).SessionSetConfigOptionRequestSchema,
-        responseSchema: (MethodSchemas as any).SessionSetConfigOptionResponseSchema,
-        params: { sessionId, configId: 'approvalMode', value: 'approveReads' },
-        label: 'session/set_config_option approvalMode',
-      });
-      expect(approvalResult.configOptions).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            id: 'approvalMode',
-            category: '_permission_mode',
-            currentValue: 'approveReads',
-          }),
-        ])
-      );
-    }
-  );
+    const modelResult = await requestOk<{ configOptions: Array<Record<string, unknown>> }>({
+      agent,
+      method: 'session/set_config_option',
+      requestSchema: (MethodSchemas as any).SessionSetConfigOptionRequestSchema,
+      responseSchema: (MethodSchemas as any).SessionSetConfigOptionResponseSchema,
+      params: { sessionId, configId: 'model', value: targetModel },
+      label: 'session/set_config_option model',
+    });
+    expect(modelResult.configOptions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'model',
+          category: 'model',
+          currentValue: targetModel,
+        }),
+      ])
+    );
+
+    const approvalResult = await requestOk<{ configOptions: Array<Record<string, unknown>> }>({
+      agent,
+      method: 'session/set_config_option',
+      requestSchema: (MethodSchemas as any).SessionSetConfigOptionRequestSchema,
+      responseSchema: (MethodSchemas as any).SessionSetConfigOptionResponseSchema,
+      params: { sessionId, configId: 'approvalMode', value: 'approveReads' },
+      label: 'session/set_config_option approvalMode',
+    });
+    expect(approvalResult.configOptions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'approvalMode',
+          category: '_permission_mode',
+          currentValue: 'approveReads',
+        }),
+      ])
+    );
+  });
 
   it('handles concurrent ent/providers/refresh and ent/models/list without transient Unknown providerId', async () => {
     agent = spawnAgentProcess({ laceDir });

--- a/packages/agent/src/__tests__/helpers/agent-process.ts
+++ b/packages/agent/src/__tests__/helpers/agent-process.ts
@@ -25,6 +25,44 @@ import { createNdjsonStdioTransport, JsonRpcPeer } from '@lace/ent-protocol';
  */
 export const AGENT_BOOT_TIMEOUT_MS = 30_000;
 
+/**
+ * Budget for a whole E2E test that spawns a real agent child.
+ *
+ * These tests inherited vitest's 5s default `testTimeout`, which is the same
+ * mistake AGENT_BOOT_TIMEOUT_MS documents, one layer up: the budget has to cover
+ * the child's cold boot before any of the test's own work starts. At the 48-way
+ * concurrency a fully parallel `vitest run` produces, boot alone costs p50 3.3s /
+ * max 3.6s, so most of the 5s was gone before the first RPC.
+ *
+ * The number is derived from the guards it has to contain, not from observed
+ * durations. Every request in these tests is already wrapped in a `withTimeout`
+ * whose label says what hung; the longest of those is AGENT_BOOT_TIMEOUT_MS
+ * (30s). For that guard to ever fire — and for a failure to say "initialize" and
+ * not the useless "Test timed out" — the surrounding test budget must be
+ * strictly larger than it, with room for the RPCs that follow the boot. 60s is
+ * double the largest inner guard and roughly four times the slowest E2E test
+ * observed under full parallelism (13s). Like the inner guards, it exists to
+ * catch a test that will never finish, not to police how long one takes.
+ */
+export const E2E_TEST_TIMEOUT_MS = 60_000;
+
+/**
+ * Budget for waiting on a delegate/subagent job to reach `job_finished`.
+ *
+ * A delegate job spawns a *second* lace-agent process, so this wait contains an
+ * entire additional cold boot — the same p50 3.3s / max 3.6s at 48-way
+ * concurrency — before the subagent does any work of its own. The 10-15s these
+ * call sites carried was sized as if the job were boot-free, and it blew under
+ * suite load the same way the 2s `initialize` budgets did. Sized to match
+ * AGENT_BOOT_TIMEOUT_MS: one cold boot plus real work, far above the measured
+ * worst case, and still under E2E_TEST_TIMEOUT_MS so this guard fires first and
+ * names what it was waiting for.
+ *
+ * Waits on plain *shell* jobs deliberately keep their smaller budgets — they
+ * spawn no agent, so they have no boot to absorb.
+ */
+export const SUBAGENT_JOB_TIMEOUT_MS = 30_000;
+
 export type SpawnedAgent = {
   peer: JsonRpcPeer;
   proc: ChildProcessWithoutNullStreams;

--- a/packages/agent/src/__tests__/helpers/index.ts
+++ b/packages/agent/src/__tests__/helpers/index.ts
@@ -4,6 +4,8 @@ export {
   spawnAgentProcess,
   withTimeout,
   AGENT_BOOT_TIMEOUT_MS,
+  E2E_TEST_TIMEOUT_MS,
+  SUBAGENT_JOB_TIMEOUT_MS,
   type SpawnedAgent,
 } from './agent-process';
 export { createE2EContext, type E2ETestContext, type E2EContextOptions } from './e2e-context';

--- a/packages/agent/src/__tests__/system-prompt-injection.test.ts
+++ b/packages/agent/src/__tests__/system-prompt-injection.test.ts
@@ -11,6 +11,7 @@ import {
   spawnAgentProcess,
   withTimeout,
   type SpawnedAgent,
+  E2E_TEST_TIMEOUT_MS,
 } from './helpers/agent-process';
 import { defaultInitializeParams } from './helpers/initialize';
 import { buildProviderMessagesFromDurableEvents } from '@lace/agent/server';
@@ -36,7 +37,7 @@ function readSessionEventsFromDisk(laceDir: string, sessionId: string): string[]
   return [];
 }
 
-describe('system prompt injection on session/new', () => {
+describe('system prompt injection on session/new', { timeout: E2E_TEST_TIMEOUT_MS }, () => {
   let originalLaceDir: string | undefined;
   let laceDir: string;
   let workDir: string;

--- a/packages/agent/vitest.config.ts
+++ b/packages/agent/vitest.config.ts
@@ -12,6 +12,16 @@ import { resolve } from 'path';
 // serialization is therefore done in the package.json `test` script, which runs the
 // fast unit tests in parallel first, then the subprocess-heavy tests in a second
 // `vitest run --no-file-parallelism` pass.
+//
+// Those same tests must NOT inherit vitest's 5s default `testTimeout`: at the
+// concurrency a fully parallel run produces, the child agent's cold boot alone
+// eats most of that budget, and the test dies before its own `withTimeout`
+// guards — the ones that name which call hung — can fire. They declare
+// `E2E_TEST_TIMEOUT_MS` on their describe instead (see
+// src/__tests__/helpers/agent-process.ts), which keeps the ordering
+// 5s default < AGENT_BOOT_TIMEOUT_MS < E2E_TEST_TIMEOUT_MS. The default is left
+// alone here so the ~3900 fast unit tests keep their tight guard. A new
+// agent-spawning test file has to opt in the same way.
 
 export default defineConfig({
   root: __dirname,


### PR DESCRIPTION
**Stacked on #384** — review that first. Base is `wip/flaky-test-hunt`.

**Review this with `git diff -w`.** Removing per-test timeout options let prettier collapse multiline `it(` calls back to one line, reindenting whole test bodies: 2200 lines changed raw, **275 ignoring whitespace**.

## What #384 left behind

#384 fixed the dominant flake by budgeting the `initialize` guard for agent cold boot. It left the single-parallel-pass path (`npx vitest run` — what a person or an agent naturally types) still failing.

Five passes at the parent commit, loadavg 2.2 → 22.2:

| run | failures | loadavg at start |
|---|---|---|
| 1 | 14 | 2.20 |
| 2 | 5 | 4.22 |
| 3 | 7 | 17.18 |
| 4 | 5 | 19.42 |
| 5 | 8 | 22.22 |

## Triage — four causes, not one

| cause | count | verdict |
|---|---|---|
| `Test timed out in 5000ms` (vitest default) | 30 | #384's root cause, one layer up |
| `Test timed out in 20000ms` (declared per-test) | 2 | same cause — the *declared* budget was also too small |
| `Timed out after 10000ms: <delegate job label>` | 4 | same cause one layer **down** — the wait contains a second agent cold boot |
| Docker `Conflict. The container name ... is already in use` | 3 | **not a timeout.** See below. |

The 5000ms cluster landed in exactly four files, and they are precisely the files whose tests declare no per-test timeout: `system-prompt-injection.test.ts`, `agent-process.model-gating.e2e.test.ts`, `agent-process.e2e.test.ts` (4 cases), `ent-protocol.spec.ts`.

## The ordering invariant this is really about

An inner guard only fires — and only produces its useful, labelled message — if the enclosing test budget outlives it. Otherwise vitest kills the test first and `Timed out after 30000ms: initialize` silently degrades into `Test timed out in 5000ms`, which names no call at all.

**Every pre-existing 10s–30s per-test literal in these files was at or below the guard it was supposed to outlive.** The two `20000ms` failures in the before-set are that bug firing in the wild. So this removes those literals rather than raising them piecemeal.

After this change:

```
5_000   vitest node default   — unchanged, applies to the ~3900 fast unit tests
30_000  AGENT_BOOT_TIMEOUT_MS / SUBAGENT_JOB_TIMEOUT_MS  — inner guards, fire first, name the call
60_000  E2E_TEST_TIMEOUT_MS   — per-test backstop on every agent-spawning describe
```

## The change

Two named constants in `helpers/agent-process.ts`, each with its derivation in a comment, exported through `helpers/index.ts`:

- **`E2E_TEST_TIMEOUT_MS = 60_000`**, declared once per suite as `describe(name, { timeout: … })` across all 23 agent-spawning files, replacing ~60 scattered literals. Derived from the guards it must contain, not from observed durations: double the largest inner guard, and ~4x the slowest E2E test observed under full parallelism (13s).
- **`SUBAGENT_JOB_TIMEOUT_MS = 30_000`**, 24 sites across the delegate/subagent files. Waiting for a delegate job to reach `job_finished` spans a *second* lace-agent cold boot; those waits were budgeted as if the job were boot-free. Sized to match `AGENT_BOOT_TIMEOUT_MS` and kept under the test budget so it still fires first, with its label.

Waits on plain **shell** jobs deliberately keep their 2s–5s budgets — no agent spawns, no boot to absorb, and none fired across 11 runs.

`testTimeout` is deliberately **not** set in `vitest.config.ts`: a blanket 60s would strip the 5s fast-fail from ~3900 unit tests that should keep it. The cost is that a new agent-spawning file could silently inherit 5s again, so the config's existing parallelism NOTE now states the ordering invariant and points at the constant.

Keeping `AGENT_BOOT_TIMEOUT_MS` at 30s: with a 60s enclosing budget the ordering holds with 2x margin, and 30s is ~8x the measured 3.6s worst-case boot. Lowering narrows the margin for nothing; raising crowds the backstop.

## After

Six passes, loadavg 4.3 → 17.3 — never below the quietest before-run, so the comparison isn't flattered:

| run | failures | cause | loadavg |
|---|---|---|---|
| 1 | 1 | docker name conflict | 4.35 |
| 2 | 1 | docker name conflict | 7.49 |
| 3 | **0** | — | 13.41 |
| 4 | 1 | docker name conflict | 16.74 |
| 5 | 1 | docker name conflict | 15.71 |
| 6 | 1 | docker name conflict | 17.27 |

**Zero timeout-class failures in six runs.** Test count unchanged at 3934 (3897 passed / 37 skipped) — nothing skipped, deleted, or weakened; no retries; no reduction in parallelism.

Sanctioned `npm test`: green 3/3, including a run started at loadavg 9.95 — above the ~4.5 ceiling #384's green streak actually established.

## The one remaining failure is not a timeout

`persona-container-sharing.integration.test.ts > resume after TTL spawns fresh container` fails 5 of 6 runs under full parallelism, green on the sanctioned path, with a container-name conflict.

Two parts, and they were found independently by separate investigations:

1. **The name-release race** — forced removal returns before the daemon releases the name, so an immediate re-create conflicts. Fixed in **#386**, which should remove this failure from the table above.
2. **The blast radius that makes it likely.** `runStartupReaper()` calls `reapOrphans('', new Set())` — empty prefix, empty live set — so it reaps **every** `lace-`-prefixed container on the host. Under `npx vitest run`, dozens of agent E2E children boot concurrently and each runs that reaper, so a test's container is removed out from under it. Under `npm test` the docker tests get the host largely to themselves in the serialized pass, which is exactly why this only appears on the parallel path.

That second part is deliberate — `startup-reaper.ts` says *"For v1 liveSpecNames is always empty — boot is a clean slate"* — and it holds for one agent per host. It is a design question, not a budget, so nothing here touches it.

## Worth knowing

`packages/agent/tsconfig.json` excludes `src/**/__tests__/**`, so `npm run typecheck` does not cover these files at all — a missing import would surface only at test runtime. Imports here were verified by hand and by running the files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
