### PR TITLE
fix: make 'npm run test:run' actually run the tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ npm run dev           # Start the CLI client
 npm run typecheck     # Type-check all active packages
 npm run lint          # Lint packages that define lint scripts
 npm test              # Run package tests once
+npx vitest run <path> # Run a single test file, from inside its package
 npm run test:coverage # Run agent coverage
 ```
 

--- a/docs/plans/2025-08-05/file-edit-implementation.md
+++ b/docs/plans/2025-08-05/file-edit-implementation.md
@@ -79,7 +79,7 @@ src/
 1. Run existing tests to ensure environment works:
 
    ```bash
-   npm run test:run -- src/tools/implementations/file-edit.test.ts
+   npx vitest run src/tools/implementations/file-edit.test.ts
    ```
 
 2. Read these files to understand the system:
@@ -154,7 +154,7 @@ describe('FileEditTool V2', () => {
 **Testing**:
 
 ```bash
-npm run test:run -- src/tools/implementations/file-edit-v2.test.ts
+npx vitest run src/tools/implementations/file-edit-v2.test.ts
 ```
 
 Should see skipped test.
@@ -233,7 +233,7 @@ import { FileEditTool } from './file-edit-v2';
 **Testing**:
 
 ```bash
-npm run test:run -- src/tools/implementations/file-edit-v2.test.ts
+npx vitest run src/tools/implementations/file-edit-v2.test.ts
 ```
 
 Test should compile but still be skipped.
@@ -255,7 +255,7 @@ git commit -m "feat: add basic structure for file-edit-v2 tool"
 **Step 1**: Remove `.skip` from first test and run it:
 
 ```bash
-npm run test:run -- src/tools/implementations/file-edit-v2.test.ts
+npx vitest run src/tools/implementations/file-edit-v2.test.ts
 ```
 
 Test should fail with "Not implemented yet"
@@ -309,7 +309,7 @@ protected async executeValidated(
 **Step 3**: Run test - should pass:
 
 ```bash
-npm run test:run -- src/tools/implementations/file-edit-v2.test.ts
+npx vitest run src/tools/implementations/file-edit-v2.test.ts
 ```
 
 **Commit**:
@@ -915,7 +915,7 @@ git commit -m "test: add integration tests for real-world scenarios"
 3. **Run existing tests**:
 
    ```bash
-   npm run test:run -- src/tools/implementations/file-edit.test.ts
+   npx vitest run src/tools/implementations/file-edit.test.ts
    ```
 
 4. **Fix any compatibility issues** - the old tests should mostly pass
@@ -1012,7 +1012,7 @@ The tool provides detailed errors with:
 Run tests:
 
 ```bash
-npm run test:run -- src/tools/implementations/file-edit.test.ts
+npx vitest run src/tools/implementations/file-edit.test.ts
 ```
 
 ````
@@ -1066,7 +1066,7 @@ git commit -m "chore: cleanup temporary files"
 
 After each task, verify:
 
-- [ ] Tests pass: `npm run test:run -- <test-file>`
+- [ ] Tests pass: `npx vitest run <test-file>`
 - [ ] No TypeScript errors: `npm run typecheck`
 - [ ] Linter passes: `npm run lint`
 - [ ] Commit is made with descriptive message

--- a/docs/plans/2025-08-27/helper-agents.md
+++ b/docs/plans/2025-08-27/helper-agents.md
@@ -326,8 +326,8 @@ msg.toolCalls.forEach((toolCall: ToolCall) => {
 5. Run tests after each file change to catch issues early:
 
 ```bash
-npm run test:run packages/core/src/providers/anthropic-provider.test.ts
-npm run test:run packages/core/src/providers/openai-provider.test.ts
+npx vitest run packages/core/src/providers/anthropic-provider.test.ts
+npx vitest run packages/core/src/providers/openai-provider.test.ts
 ```
 
 6. Commit your changes:
@@ -402,7 +402,7 @@ describe('parseProviderModel', () => {
 Run the test to verify it fails:
 
 ```bash
-npm run test:run packages/core/src/utils/provider-utils.test.ts
+npx vitest run packages/core/src/utils/provider-utils.test.ts
 ```
 
 Now implement `packages/core/src/utils/provider-utils.ts`:
@@ -451,7 +451,7 @@ export function parseProviderModel(providerModel: string): {
 Run tests to verify they pass:
 
 ```bash
-npm run test:run packages/core/src/utils/provider-utils.test.ts
+npx vitest run packages/core/src/utils/provider-utils.test.ts
 ```
 
 Update existing code to use the utility:
@@ -603,7 +603,7 @@ describe('GlobalConfigManager', () => {
 Run test to verify it fails:
 
 ```bash
-npm run test:run packages/core/src/config/global-config.test.ts
+npx vitest run packages/core/src/config/global-config.test.ts
 ```
 
 Now implement `packages/core/src/config/global-config.ts`:
@@ -695,7 +695,7 @@ export class GlobalConfigManager {
 Run tests to verify they pass:
 
 ```bash
-npm run test:run packages/core/src/config/global-config.test.ts
+npx vitest run packages/core/src/config/global-config.test.ts
 ```
 
 Commit:
@@ -991,7 +991,7 @@ describe('BaseHelper', () => {
 Run test to verify it fails:
 
 ```bash
-npm run test:run packages/core/src/helpers/base-helper.test.ts
+npx vitest run packages/core/src/helpers/base-helper.test.ts
 ```
 
 Now implement `packages/core/src/helpers/base-helper.ts`:
@@ -1163,7 +1163,7 @@ export abstract class BaseHelper {
 Run tests to verify they pass:
 
 ```bash
-npm run test:run packages/core/src/helpers/base-helper.test.ts
+npx vitest run packages/core/src/helpers/base-helper.test.ts
 ```
 
 Commit:
@@ -1475,7 +1475,7 @@ describe('InfrastructureHelper', () => {
 Run test to verify it fails:
 
 ```bash
-npm run test:run packages/core/src/helpers/infrastructure-helper.test.ts
+npx vitest run packages/core/src/helpers/infrastructure-helper.test.ts
 ```
 
 Now implement `packages/core/src/helpers/infrastructure-helper.ts`:
@@ -1670,7 +1670,7 @@ export class InfrastructureHelper extends BaseHelper {
 Run tests to verify they pass:
 
 ```bash
-npm run test:run packages/core/src/helpers/infrastructure-helper.test.ts
+npx vitest run packages/core/src/helpers/infrastructure-helper.test.ts
 ```
 
 Commit:
@@ -1950,7 +1950,7 @@ describe('SessionHelper', () => {
 Run test to verify it fails:
 
 ```bash
-npm run test:run packages/core/src/helpers/session-helper.test.ts
+npx vitest run packages/core/src/helpers/session-helper.test.ts
 ```
 
 Now implement `packages/core/src/helpers/session-helper.ts`:
@@ -2179,7 +2179,7 @@ export class SessionHelper extends BaseHelper {
 Run tests to verify they pass:
 
 ```bash
-npm run test:run packages/core/src/helpers/session-helper.test.ts
+npx vitest run packages/core/src/helpers/session-helper.test.ts
 ```
 
 Commit:
@@ -2304,7 +2304,7 @@ describe('Helper Integration Tests', () => {
 Run tests:
 
 ```bash
-npm run test:run packages/core/src/helpers/integration.test.ts
+npx vitest run packages/core/src/helpers/integration.test.ts
 ```
 
 Commit:

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "knip:ci": "npx knip --isolate-workspaces --reporter json > knip-report.json || true",
     "prepare": "husky",
     "test": "npm run test --workspace=packages/ent-protocol && npm run test --workspace=packages/agent && npm run test --workspace=packages/cli",
-    "test:run": "npm -ws --if-present run test:run",
+    "test:run": "npm run test",
     "test:watch": "npm run test:watch --workspace=packages/agent",
     "test:coverage": "npm run test:coverage --workspace=packages/agent",
     "update-catalogs": "npx tsx scripts/update-provider-catalogs.ts"


### PR DESCRIPTION
## The bug

Root `package.json` defines `test:run` as `npm -ws --if-present run test:run`, composing a `test:run` script out of each workspace. None of the three current workspaces — `packages/ent-protocol`, `packages/agent`, `packages/cli` — define a `test:run` script; they only define `test`, `test:watch`, and (for agent) `test:coverage`.

**Correction to the original description of this PR:** it claimed the script "silently exits 0 without running anything." That is npm-version-specific. On npm 12.0.2 / node 22.22 in this checkout it errors instead:

```
$ npm -ws --if-present run test:run
Exit prior to config file resolving
cause
-ws is not a valid single-hyphen cli flag. Did you mean --ws?
```

Still broken, still worth fixing, but the symptom is a hard error on current npm and a silent no-op on the older npm the original measurement came from. The "before = 0 tests / after = 3654 pass" comparison in the first version of this description came from that older npm.

## Why

Looking at history, `test:run` used to be a real per-package alias (added in dad480166 for `packages/core` and `packages/web`, "to prevent confusion for developers expecting standard script naming") and was later collapsed into the `--if-present` form as those packages were pruned during the monorepo restructuring — without anyone adding a matching `test:run` script to the packages that replaced them. It's still referenced as the way to run the suite once in several docs under `docs/plans/`.

## The fix

Point `test:run` at the existing `test` script, which already runs `vitest run` (non-watch) across all three workspaces:

```diff
-    "test:run": "npm -ws --if-present run test:run",
+    "test:run": "npm run test",
```

## Follow-up commit: the path-filtered form

Review caught that the change above makes `npm run test:run -- <path>` much worse. npm appends run-args to the end of the whole `&&` chain, not to each segment, so the path reaches only the last workspace. Reproduced on this checkout:

1. ent-protocol runs its full suite (91 tests) — no filter,
2. agent runs its full suite including the second `--no-file-parallelism` container pass (3689 tests) — no filter,
3. cli's vitest gets a `packages/agent` path filter, finds nothing, exits 1.

Before this branch that command was a ~1s no-op. After it, it burns a complete suite run and fails anyway.

Of the three fixes suggested in review, dropping the form from the docs is the only one that is both simple and correct here:

- **Restoring per-workspace `test:run` scripts** doesn't help — `--workspaces` passes the same filter to every workspace, so two of three still fail on a path they don't contain.
- **Pointing `test:run` at a single root vitest invocation** would fix the filtered case but silently change the unfiltered one, which is the dominant usage. The root vitest config excludes `packages/**`, and a projects-based root run would lose agent's `--no-file-parallelism` second pass over the container integration tests — which exists precisely to stop them running concurrently.

So `test:run` stays an alias for the full suite (what every unfiltered doc reference means by it), and the path-filtered invocations in the two plan docs that taught it become `npx vitest run <path>`, the command that actually runs one file today. `CLAUDE.md`'s command list gains that recipe as well; it previously offered no way to run a single test file.

## Testing

- `npm run test:run -- src/tools/url-fetch.test.ts` → reproduces the full-suite burn described above (the measurement, not a regression test).
- `npm run test:run` → runs the suite across all three workspaces.
- `npx vitest run src/tools/url-fetch.test.ts` from `packages/agent` → runs exactly that file (40 tests).

No automated test accompanies the docs change: the repo has no root-level suite (the root vitest config excludes `packages/**` and points at a non-existent root `src/`), and a docs-grep test parked inside the agent package would be a worse artifact than the fix.

Note: this checkout shows 7 pre-existing SQLite-backed test-file failures (`recall*`, `event-log`, `event-journal`, `backfill`, `index-db`, `index-writer`) caused by `better-sqlite3`'s native binding not being built in a fresh worktree. Unrelated to this change.
