### PR TITLE
fix(url_fetch): capture curl's effective URL as the container runtime's finalUrl

### DIFF
--- a/packages/agent/src/tools/runtime/__tests__/container-exec-network.test.ts
+++ b/packages/agent/src/tools/runtime/__tests__/container-exec-network.test.ts
@@ -3,9 +3,11 @@
 
 import { Readable } from 'node:stream';
 import { describe, it, expect } from 'vitest';
+import { UrlFetchTool } from '@lace/agent/tools/implementations/url_fetch';
 import { ContainerExecNetworkClient } from '../container-exec-network';
+import { createFakeRuntime } from './fake-runtime';
 import { RuntimeFetchSizeLimitError } from '../types';
-import type { RuntimeProcessRunner, RuntimeProcessHandle } from '../types';
+import type { RuntimeProcessRunner, RuntimeProcessHandle, ToolRuntime } from '../types';
 
 interface FakeStart {
   /** Raw bytes that curl|base64 would have produced on stdout (we base64 them). */
@@ -127,7 +129,7 @@ describe('ContainerExecNetworkClient', () => {
     const raw = Buffer.from('HTTP/2 200\r\n\r\nok', 'utf8');
     const { runner, calls } = fakeRunner({ stdoutRaw: raw });
     const client = new ContainerExecNetworkClient(runner);
-    await client.fetch('https://example.com');
+    await client.fetch('https://example.com', { redirect: 'follow' });
     const argv = calls[0]!;
     const wIndex = argv.indexOf('-w');
     expect(wIndex).toBeGreaterThanOrEqual(0);
@@ -155,6 +157,91 @@ describe('ContainerExecNetworkClient', () => {
     const client = new ContainerExecNetworkClient(runner);
     const result = await client.fetch('https://example.com');
     expect(result.url).toBeUndefined();
+  });
+
+  it('recovers the effective URL from stdout and keeps it out of the body on curl older than 7.63', async () => {
+    // curl < 7.63 doesn't know `%{stderr}`: it warns on stderr and writes the
+    // REST of the write-out format to stdout, which here is the base64-framed
+    // response pipe. Without handling, the marker line lands inside the body.
+    const raw = Buffer.concat([
+      Buffer.from('HTTP/2 200\r\ncontent-type: text/plain\r\n\r\nhello body', 'utf8'),
+      Buffer.from('\n__lace_curl_effective_url__:http://127.0.0.1:8791/final\n', 'utf8'),
+    ]);
+    const { runner } = fakeRunner({
+      stdoutRaw: raw,
+      stderr: "curl: unknown --write-out variable: 'stderr'\n",
+    });
+    const client = new ContainerExecNetworkClient(runner);
+    const result = await client.fetch('http://127.0.0.1:8791/start', { redirect: 'follow' });
+    expect(Buffer.from(result.body).toString()).toBe('hello body');
+    expect(result.url).toBe('http://127.0.0.1:8791/final');
+  });
+
+  it('does not count the stdout write-out trailer against maxBytes', async () => {
+    const raw = Buffer.concat([
+      Buffer.from('HTTP/2 200\r\n\r\n0123456789', 'utf8'),
+      Buffer.from('\n__lace_curl_effective_url__:http://example.com/final\n', 'utf8'),
+    ]);
+    const { runner } = fakeRunner({ stdoutRaw: raw });
+    const client = new ContainerExecNetworkClient(runner);
+    const result = await client.fetch('http://example.com/start', {
+      redirect: 'follow',
+      maxBytes: 10,
+    });
+    expect(Buffer.from(result.body).toString()).toBe('0123456789');
+  });
+
+  it('leaves a body that merely resembles the marker mid-stream alone', async () => {
+    const body = 'before\n__lace_curl_effective_url__:http://example.com/x\nafter';
+    const raw = Buffer.from(`HTTP/2 200\r\n\r\n${body}`, 'utf8');
+    const { runner } = fakeRunner({ stdoutRaw: raw });
+    const client = new ContainerExecNetworkClient(runner);
+    const result = await client.fetch('http://example.com/start', { redirect: 'follow' });
+    expect(Buffer.from(result.body).toString()).toBe(body);
+    expect(result.url).toBeUndefined();
+  });
+
+  it('captures an effective URL containing a space without truncating it or leaking the remainder', async () => {
+    // curl echoes %{url_effective} verbatim when it rejects a malformed URL.
+    const stderr =
+      'curl: (3) URL rejected: Malformed input to a URL function\n' +
+      '__lace_curl_effective_url__:http://127.0.0.1:32875/a b\n';
+    const { runner } = fakeRunner({ exitCode: 3, stderr, stdoutRaw: Buffer.alloc(0) });
+    const client = new ContainerExecNetworkClient(runner);
+    const error = await client.fetch('http://127.0.0.1:32875/a b').catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+    expect(message).toContain('URL rejected');
+    expect(message).not.toContain('__lace_curl_effective_url__');
+    expect(message).not.toMatch(/\bb\b/);
+  });
+
+  it('only asks curl for the effective URL when it is actually following redirects', async () => {
+    const raw = Buffer.from('HTTP/2 200\r\n\r\nok', 'utf8');
+    const { runner, calls } = fakeRunner({ stdoutRaw: raw });
+    const client = new ContainerExecNetworkClient(runner);
+    await client.fetch('https://example.com');
+    expect(calls[0]).not.toContain('-w');
+  });
+
+  it('does not make url_fetch report a redirect when curl only normalized the URL', async () => {
+    // curl normalizes `%{url_effective}` the same way `Response.url` does, so a
+    // host-only request comes back with its path filled in. That is not a redirect.
+    const raw = Buffer.from('HTTP/2 404\r\ncontent-type: text/plain\r\n\r\nnot found', 'utf8');
+    const stderr = '__lace_curl_effective_url__:https://example.com/\n';
+    const { runner } = fakeRunner({ stdoutRaw: raw, stderr });
+    const runtime: ToolRuntime = {
+      ...createFakeRuntime(),
+      network: new ContainerExecNetworkClient(runner),
+    };
+
+    const result = await new UrlFetchTool().execute(
+      { url: 'https://example.com' },
+      { signal: new AbortController().signal, runtime }
+    );
+
+    expect(result.status).toBe('failed');
+    expect(result.content[0].text ?? '').not.toContain('Final URL:');
   });
 
   it('strips the effective-URL marker out of the error message on curl failure', async () => {

--- a/packages/agent/src/tools/runtime/__tests__/container-exec-network.test.ts
+++ b/packages/agent/src/tools/runtime/__tests__/container-exec-network.test.ts
@@ -122,4 +122,52 @@ describe('ContainerExecNetworkClient', () => {
     const client = new ContainerExecNetworkClient(runner);
     await expect(client.fetch('https://unreachable.example')).rejects.toThrow(/Failed to connect/);
   });
+
+  it('passes -w with a %{stderr}-prefixed format so curl reports url_effective on stderr, not stdout', async () => {
+    const raw = Buffer.from('HTTP/2 200\r\n\r\nok', 'utf8');
+    const { runner, calls } = fakeRunner({ stdoutRaw: raw });
+    const client = new ContainerExecNetworkClient(runner);
+    await client.fetch('https://example.com');
+    const argv = calls[0]!;
+    const wIndex = argv.indexOf('-w');
+    expect(wIndex).toBeGreaterThanOrEqual(0);
+    const format = argv[wIndex + 1]!;
+    expect(format.startsWith('%{stderr}')).toBe(true);
+    expect(format).toContain('%{url_effective}');
+  });
+
+  it("reports the redirect-following runtime's effective URL as result.url (the curl-client half of the #394 fix)", async () => {
+    const raw = Buffer.from(
+      'HTTP/2 301\r\nlocation: https://example.com/final\r\n\r\n' +
+        'HTTP/2 200\r\ncontent-type: text/plain\r\n\r\nfinal body',
+      'utf8'
+    );
+    const stderr = '__lace_curl_effective_url__:https://example.com/final\n';
+    const { runner } = fakeRunner({ stdoutRaw: raw, stderr });
+    const client = new ContainerExecNetworkClient(runner);
+    const result = await client.fetch('https://example.com', { redirect: 'follow' });
+    expect(result.url).toBe('https://example.com/final');
+  });
+
+  it('leaves result.url undefined when curl never reports an effective URL (no fabrication)', async () => {
+    const raw = Buffer.from('HTTP/2 200\r\n\r\nok', 'utf8');
+    const { runner } = fakeRunner({ stdoutRaw: raw, stderr: '' });
+    const client = new ContainerExecNetworkClient(runner);
+    const result = await client.fetch('https://example.com');
+    expect(result.url).toBeUndefined();
+  });
+
+  it('strips the effective-URL marker out of the error message on curl failure', async () => {
+    const stderr =
+      'curl: (6) Could not resolve host: unreachable.example\n' +
+      '__lace_curl_effective_url__:http://unreachable.example/\n';
+    const { runner } = fakeRunner({ exitCode: 6, stderr, stdoutRaw: Buffer.alloc(0) });
+    const client = new ContainerExecNetworkClient(runner);
+    await expect(client.fetch('http://unreachable.example')).rejects.toThrow(
+      /Could not resolve host/
+    );
+    await expect(client.fetch('http://unreachable.example')).rejects.not.toThrow(
+      /__lace_curl_effective_url__/
+    );
+  });
 });

--- a/packages/agent/src/tools/runtime/container-exec-network.ts
+++ b/packages/agent/src/tools/runtime/container-exec-network.ts
@@ -12,6 +12,26 @@ import { nodeErrorFromExec, streamToString, writeStreamAndClose } from './contai
 
 const DEFAULT_FETCH_TIMEOUT_SECS = 120;
 
+// curl's `--write-out` runs after the transfer and can report the effective
+// (post-redirect) URL via `%{url_effective}` — the same information
+// `Response.url` gives the host runtime's native `fetch`. `%{stderr}` at the
+// front of the format redirects that single write-out to stderr so it never
+// touches the base64-framed stdout pipe the response is parsed from. The
+// marker line lets us pull the URL back out of stderr (which may also carry
+// curl's own `-S` error text) without guessing at curl's error formatting.
+const EFFECTIVE_URL_MARKER = '__lace_curl_effective_url__';
+const EFFECTIVE_URL_WRITE_OUT = `%{stderr}\n${EFFECTIVE_URL_MARKER}:%{url_effective}\n`;
+const EFFECTIVE_URL_LINE_RE = new RegExp(`\n?${EFFECTIVE_URL_MARKER}:(\\S*)\n?`);
+
+/** Pull the marked effective-URL line back out of curl's stderr, returning the
+ * URL (if the marker was found) and the stderr text with the marker line
+ * removed, so it never leaks into an error message. */
+function extractEffectiveUrl(stderr: string): { url: string | undefined; stderr: string } {
+  const match = EFFECTIVE_URL_LINE_RE.exec(stderr);
+  if (!match) return { url: undefined, stderr };
+  return { url: match[1] || undefined, stderr: stderr.replace(EFFECTIVE_URL_LINE_RE, '') };
+}
+
 export class ContainerExecNetworkClient implements RuntimeNetworkClient {
   constructor(private readonly process: RuntimeProcessRunner) {}
 
@@ -43,6 +63,8 @@ export class ContainerExecNetworkClient implements RuntimeNetworkClient {
       ...(redirect === 'follow' ? ['-L'] : []),
       ...headerArgs,
       ...(hasBody ? ['--data-binary', '@-'] : []),
+      '-w',
+      EFFECTIVE_URL_WRITE_OUT,
       url,
     ];
 
@@ -64,8 +86,10 @@ export class ContainerExecNetworkClient implements RuntimeNetworkClient {
       handle.completion,
     ]);
 
+    const { url: effectiveUrl, stderr: cleanStderr } = extractEffectiveUrl(stderr);
+
     if (completion.exitCode !== 0) {
-      throw nodeErrorFromExec(completion.exitCode ?? -1, stderr, 'fetch', url);
+      throw nodeErrorFromExec(completion.exitCode ?? -1, cleanStderr, 'fetch', url);
     }
 
     const raw = Buffer.from(stdout, 'base64');
@@ -76,7 +100,7 @@ export class ContainerExecNetworkClient implements RuntimeNetworkClient {
       throw new RuntimeFetchSizeLimitError(opts.maxBytes, body.byteLength);
     }
 
-    return { status, headers, body: new Uint8Array(body) };
+    return { status, headers, body: new Uint8Array(body), url: effectiveUrl };
   }
 }
 

--- a/packages/agent/src/tools/runtime/container-exec-network.ts
+++ b/packages/agent/src/tools/runtime/container-exec-network.ts
@@ -21,7 +21,11 @@ const DEFAULT_FETCH_TIMEOUT_SECS = 120;
 // curl's own `-S` error text) without guessing at curl's error formatting.
 const EFFECTIVE_URL_MARKER = '__lace_curl_effective_url__';
 const EFFECTIVE_URL_WRITE_OUT = `%{stderr}\n${EFFECTIVE_URL_MARKER}:%{url_effective}\n`;
-const EFFECTIVE_URL_LINE_RE = new RegExp(`\n?${EFFECTIVE_URL_MARKER}:(\\S*)\n?`);
+// The URL runs to the end of the line, not to the first space: curl echoes
+// `%{url_effective}` verbatim when it rejects a malformed URL, so
+// `http://host/a b` must be captured whole rather than truncated at the space
+// (which would also leave the remainder behind in the error text).
+const EFFECTIVE_URL_LINE_RE = new RegExp(`\n?${EFFECTIVE_URL_MARKER}:([^\n]*)\n?`);
 
 /** Pull the marked effective-URL line back out of curl's stderr, returning the
  * URL (if the marker was found) and the stderr text with the marker line
@@ -30,6 +34,35 @@ function extractEffectiveUrl(stderr: string): { url: string | undefined; stderr:
   const match = EFFECTIVE_URL_LINE_RE.exec(stderr);
   if (!match) return { url: undefined, stderr };
   return { url: match[1] || undefined, stderr: stderr.replace(EFFECTIVE_URL_LINE_RE, '') };
+}
+
+/**
+ * `%{stderr}` landed in curl 7.63.0 (Dec 2018), and the image is
+ * caller-supplied — CentOS 7 ships 7.29, Debian 9 ships 7.52. An older curl
+ * doesn't recognise the variable: it warns on stderr and writes the REST of
+ * the write-out format to *stdout*, which here is the base64-framed response
+ * pipe. Left alone, the marker line would be glued onto every response body
+ * and inflate the maxBytes accounting, silently and with a zero exit code.
+ * Recovering the URL from a trailing marker line instead degrades that path
+ * into the modern one.
+ *
+ * The write-out is the last thing curl emits, so the marker only counts when
+ * it runs to the very end of the stream — a body that merely contains the
+ * marker text mid-stream is left untouched.
+ */
+function extractTrailingEffectiveUrl(body: Buffer): { url: string | undefined; body: Buffer } {
+  const marker = Buffer.from(`${EFFECTIVE_URL_MARKER}:`, 'utf8');
+  const start = body.lastIndexOf(marker);
+  if (start === -1) return { url: undefined, body };
+
+  const tail = body.subarray(start + marker.length).toString('utf8');
+  const newline = tail.indexOf('\n');
+  if (newline !== -1 && newline !== tail.length - 1) return { url: undefined, body };
+
+  const url = newline === -1 ? tail : tail.slice(0, newline);
+  // Drop the newline the write-out format puts in front of the marker too.
+  const end = start > 0 && body[start - 1] === 0x0a ? start - 1 : start;
+  return { url: url || undefined, body: body.subarray(0, end) };
 }
 
 export class ContainerExecNetworkClient implements RuntimeNetworkClient {
@@ -63,8 +96,9 @@ export class ContainerExecNetworkClient implements RuntimeNetworkClient {
       ...(redirect === 'follow' ? ['-L'] : []),
       ...headerArgs,
       ...(hasBody ? ['--data-binary', '@-'] : []),
-      '-w',
-      EFFECTIVE_URL_WRITE_OUT,
+      // Only worth asking for when curl can actually end up somewhere else:
+      // without `-L` the effective URL is the requested one.
+      ...(redirect === 'follow' ? ['-w', EFFECTIVE_URL_WRITE_OUT] : []),
       url,
     ];
 
@@ -93,14 +127,15 @@ export class ContainerExecNetworkClient implements RuntimeNetworkClient {
     }
 
     const raw = Buffer.from(stdout, 'base64');
-    const { headerText, body } = splitHeadersAndBody(raw);
+    const { headerText, body: framedBody } = splitHeadersAndBody(raw);
     const { status, headers } = parseHeaderBlock(headerText);
+    const { url: stdoutUrl, body } = extractTrailingEffectiveUrl(framedBody);
 
     if (opts?.maxBytes !== undefined && body.byteLength > opts.maxBytes) {
       throw new RuntimeFetchSizeLimitError(opts.maxBytes, body.byteLength);
     }
 
-    return { status, headers, body: new Uint8Array(body), url: effectiveUrl };
+    return { status, headers, body: new Uint8Array(body), url: effectiveUrl ?? stdoutUrl };
   }
 }
 


### PR DESCRIPTION
Follow-up to #394 — same redirect-URL gap in the curl-based runtime client.

## The gap

#394 fixed `url_fetch`'s `Final URL:` diagnostic by adding an optional `url`
field to `RuntimeFetchResult` and populating it from `Response.url` in the
host runtime's native `fetch`. It explicitly left the curl-based
`ContainerExecNetworkClient` untouched, flagging the same gap there as a
real follow-up:

> The curl-based `ContainerExecNetworkClient` is left without the field.
> Extracting an effective URL from curl's output (e.g. via `--write-out`)
> is a real follow-up, but doing it safely inside the existing base64-framed
> raw-response pipe is a separate, riskier change; this PR doesn't touch it.

Confirmed: `ContainerExecNetworkClient.fetch()` never set `url` on the
result it returns, so on the container/curl runtime, `url_fetch`'s
`finalUrl` always fell back to the requested URL — even when `redirect:
'follow'` (`-L`) actually followed a redirect. Same misdirection #394 fixed
for the host runtime, unfixed here.

## The change

curl's `--write-out` runs after the transfer and can report the effective
(post-redirect) URL via `%{url_effective}` — the same information
`Response.url` gives native `fetch`. The risk #394 called out is real: the
existing pipeline is `curl "$@" | base64 -w0`, so anything curl writes to
stdout gets base64-encoded and mixed into the response bytes the client
parses.

curl's `%{stderr}` write-out variable sidesteps that: placed at the front of
the `-w` format, it redirects the *rest* of that one write-out to stderr
instead of stdout, so it never touches the base64 stream. A marker line
(`__lace_curl_effective_url__:<url>`) lets the client pick the URL back out
of stderr — which may also carry curl's own `-S` error text — without
guessing at curl's error-message formatting. The marker is stripped before
stderr is used to build a thrown error, so it never leaks into user-facing
error text.

`ContainerExecNetworkClient.fetch()` now populates `RuntimeFetchResult.url`
from the captured value — the same field #394 added. No changes needed in
`url_fetch.ts`: it already falls back to the requested URL when a runtime
can't supply one, so this just gives the curl runtime something honest to
report instead of nothing.

## Tests

`container-exec-network.test.ts`:
- `-w` is passed with a `%{stderr}`-prefixed format containing
  `%{url_effective}`.
- A redirect-following fetch (`redirect: 'follow'`) reports the captured
  effective URL as `result.url`.
- When curl never reports an effective URL, `result.url` stays `undefined`
  (no fabrication, matching #394's fallback contract).
- The effective-URL marker is stripped out of the error message on curl
  failure.

Reverting the source changes while keeping the four new tests reproduces
the gap: the three redirect/write-out-related assertions fail against the
pre-fix code (confirmed locally), and the "no fabrication" control passes
either way, as expected.

## Verification

Full `npm test` (ent-protocol + agent + cli):

| | Result |
|---|---|
| ent-protocol | 91 passed |
| agent (unit+integration split) | 3661 + 268 passed / 35 + 20 skipped |
| cli | 14 passed / 2 skipped |
| **Total** | **4034 passed / 57 skipped** |

That's #394's post-fix total (4030/57) plus exactly the 4 new tests here.
`npm run typecheck` and `npm run lint` both clean.

Branched on top of #394's commit (`fix-url-fetch-final-url`) since this
needs the `RuntimeFetchResult.url` field that PR adds and #394 hasn't
landed yet — happy to rebase onto `main` once #394 merges.
