### PR TITLE
ci: run CI on fork PRs and test all three packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ env:
 jobs:
   ci:
     name: CI
-    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -50,8 +49,14 @@ jobs:
       - name: Check Prettier formatting
         run: npm run format:check
 
-      - name: Run tests with coverage
+      - name: Run ent-protocol tests
+        run: npm run test --workspace=packages/ent-protocol
+
+      - name: Run agent tests with coverage
         run: npm run test:coverage
+
+      - name: Run CLI tests
+        run: npm run test --workspace=packages/cli
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,6 +18,9 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
+    # Fork PRs cannot see CLAUDE_CODE_OAUTH_TOKEN and are not granted `id-token: write`,
+    # so the review can only fail there. Skip cleanly instead of showing a misleading red X.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Three gates that looked present and weren't. All three were found by reviewing four fork PRs that merged yesterday with zero automated verification.

## 1. CI never ran on fork PRs

`ci.yml` carried:

```yaml
if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
```

so every fork PR showed CI as **Skipped**. Four PRs from an external fork (#392–#395) merged with no automated verification — local runs were the only gate.

That guard normally exists to keep untrusted code away from secrets. Audited, and it isn't doing that here:

- `grep -n "secrets\|token" .github/workflows/ci.yml` → no matches
- the workflow declares `permissions: contents: read`
- no local composite actions exist (`.github/` contains only `workflows/`; no `action.yml` anywhere outside `node_modules`)
- the three third-party actions are passed no secret

GitHub already withholds secrets from fork `pull_request` runs and issues a read-only token, so the guard protected nothing. Removed.

The trigger stays `pull_request`. It was **not** switched to `pull_request_target`, which would run untrusted fork code with full secrets — the usual wrong fix for this symptom.

**Codecov on forks** degrades quietly rather than failing. Confirmed from the shipped `dist/index.js` of `codecov-action@v4`:

```js
const setFailure = (message, failCi) => {
    if (failCi) { core.setFailed(message); } else { core.warning(message); }
    if (failCi) { process.exit(); }
};
```

`failCi` reads `fail_ci_if_error`, already `false` here, so an upload failure is a `::warning::` and the step still passes. The repo is public, so tokenless upload is the supported path regardless.

## 2. CI only ever tested one of three packages

The test step was `npm run test:coverage` — which is `--workspace=packages/agent`. **`packages/ent-protocol` and `packages/cli` had their tests run by no automated system at all.**

Now three steps:

```yaml
      - name: Run ent-protocol tests
        run: npm run test --workspace=packages/ent-protocol

      - name: Run agent tests with coverage
        run: npm run test:coverage

      - name: Run CLI tests
        run: npm run test --workspace=packages/cli
```

`test:coverage` is untouched, so agent keeps both phases — including the deliberate `--no-file-parallelism` pass that stops the container integration tests running concurrently — and still writes `packages/agent/coverage/lcov.info` for the Codecov step. `packages/cli`'s `pretest` rebuilds into `dist/` and never touches `coverage/`, so running it after the coverage step is safe.

Both newly-covered suites pass locally:

| step | result | time |
|---|---|---|
| ent-protocol | 11 files, 91 tests | 0.76 s |
| cli | 5 files (2 skipped), 14 tests (2 skipped) | 6.97 s |

The 2 skipped cli tests are `e2e.openai` and `e2e.lace-agent`, which self-skip without provider credentials — so they'll skip on forks too.

**Cost:** the last green run on main was 8 m 20 s, of which the agent coverage step alone is 5 m 14 s. The added steps are ~5 s plus ~25–35 s (cli, mostly its `pretest` rebuild). Roughly **+7%**. The redundant rebuild is left alone rather than worked around with `--ignore-scripts`.

## 3. `claude-review` showed a meaningless red ✗ on every PR

Two genuinely different failures were hiding behind one red X.

**Fork PRs** die before Claude starts:

```
Requesting OIDC token...
error: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
Attempt 1 failed: Could not fetch an OIDC token.
```

`id-token: write` is declared, but GitHub does not grant it to fork `pull_request` runs. This PR fixes that case with a job-level guard:

```yaml
    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
```

The workflow's only trigger is `pull_request`, so the payload is always populated and ci.yml's `github.event_name != 'pull_request' ||` disjunct isn't needed. Fork → skipped, grey, honest. A deleted head repo makes `head.repo` null, and `null.full_name` is null in GHA expressions, which `!=` a string → also skips; the failure direction is safe. `main` has no branch protection, so no required check is affected.

A check that is always red is a check nobody reads. That is the actual cost here.

**Same-repo branches are a separate problem this PR cannot fix.** They get through GitHub auth cleanly:

```
OIDC token successfully obtained
Exchanging OIDC token for app token...
App token successfully obtained
```

and then Claude Code dies on its first API call:

```json
{ "is_error": true, "num_turns": 1, "total_cost_usd": 0, "modelUsage": {} }
```

`num_turns: 1`, `$0.00`, empty `modelUsage` — rejected before any tokens were billed. That is an Anthropic-side auth rejection, i.e. an expired or revoked `CLAUDE_CODE_OAUTH_TOKEN`. The action redacts the literal message (`full output hidden for security`), so it can't be quoted.

Last green run: `32925323375`, 2026-08-26. Every run from 2026-09-04 onward has failed — including on `jesse/pri-3078-tool-result-images`, and on all six PRs merged on 09-05.

### What the repo owner needs to do (not doable in a PR)

1. On a machine logged into the Claude account that should own these reviews, run `claude setup-token` and copy the `sk-ant-oat…` value. Requires an active Pro or Max subscription.
2. `gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo obra/lace`.
3. Confirm with a re-run from a **non-fork** branch: `gh run rerun 33914185412 --failed --repo obra/lace`.
4. If it still fails with `is_error: true` / `total_cost_usd: 0`, temporarily add `show_full_output: true` to the `anthropics/claude-code-action@v1` step to surface the real message, then remove it.

`.github/workflows/claude.yml` uses the same secret and is equally dead; step 2 fixes both.

## Verification

- `actionlint` 1.7.7 clean on all three workflows — it type-checks `if:` expressions against the `pull_request` payload schema, so the `head.repo.full_name` path is confirmed valid.
- YAML parses; `prettier --check` passes, so the repo's own `format:check` gate won't trip.
- Both added test commands run locally (results above).

## Not verifiable without merging

- That a fork PR actually goes green end-to-end under the new CI. The secret audit and `if:` semantics are solid; the first real fork PR is the proof.
- That `claude-review` renders as *Skipped* rather than absent on a fork PR.
- That the tokenless Codecov upload succeeds — the source proves it cannot *fail the run*, not that it uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
