### PR TITLE
fix(url_fetch): redact credentials in URLs before they reach the model

### DIFF
--- a/packages/agent/src/tools/implementations/url_fetch.ts
+++ b/packages/agent/src/tools/implementations/url_fetch.ts
@@ -488,9 +488,12 @@ Follows redirects by default. Returns detailed error context for failures.`;
    * where the request started when a redirect moved it somewhere else.
    */
   private describeSource(requestedUrl: string, finalUrl: string): string {
+    // Compare the raw URLs, present the redacted ones: redaction collapses
+    // distinct values to the same `[REDACTED]` and would otherwise hide a real
+    // redirect (or, with the userinfo rewrite, invent one).
     return isSameUrl(requestedUrl, finalUrl)
-      ? requestedUrl
-      : `${finalUrl} (redirected from ${requestedUrl})`;
+      ? this.redactSensitiveUrl(requestedUrl)
+      : `${this.redactSensitiveUrl(finalUrl)} (redirected from ${this.redactSensitiveUrl(requestedUrl)})`;
   }
 
   private handleInlineContent(
@@ -569,6 +572,138 @@ Follows redirects by default. Returns detailed error context for failures.`;
     );
   }
 
+  /**
+   * Strip credentials out of a URL before it is shown to the model. URLs carry
+   * secrets as routinely as headers do — OAuth codes and tokens, pre-signed S3
+   * and SAS signatures, API keys pasted into a query string — and the redirect
+   * destination the tool now reports is exactly where those turn up.
+   *
+   * Purely textual: scheme, host, path and every parameter name survive so the
+   * request is still diagnosable, and only values are replaced. Nothing here
+   * feeds `isSameUrl`, so redaction cannot invent a redirect.
+   */
+  private redactSensitiveUrl(url: string): string {
+    const hashIndex = url.indexOf('#');
+    const beforeFragment = hashIndex === -1 ? url : url.slice(0, hashIndex);
+    const fragment = hashIndex === -1 ? undefined : url.slice(hashIndex + 1);
+
+    const queryIndex = beforeFragment.indexOf('?');
+    const origin = queryIndex === -1 ? beforeFragment : beforeFragment.slice(0, queryIndex);
+    const query = queryIndex === -1 ? undefined : beforeFragment.slice(queryIndex + 1);
+
+    // `https://user:pass@host/` hands over a password in the clear; the
+    // username is half a credential too, so the whole userinfo goes.
+    let redacted = origin.replace(/^([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^/?#]*@/, '$1[REDACTED]@');
+
+    if (query !== undefined) {
+      redacted += `?${this.redactSensitiveParams(query)}`;
+    }
+
+    if (fragment !== undefined) {
+      // Implicit-flow tokens ride in the fragment as a query string; a plain
+      // anchor (`#install`) is worth keeping intact.
+      redacted += `#${
+        fragment.includes('=')
+          ? this.redactSensitiveParams(fragment)
+          : this.isCredentialShapedValue(fragment)
+            ? '[REDACTED]'
+            : fragment
+      }`;
+    }
+
+    return redacted;
+  }
+
+  private redactSensitiveParams(query: string): string {
+    return query
+      .split('&')
+      .map((pair) => {
+        const separator = pair.indexOf('=');
+        if (separator === -1) {
+          return this.isCredentialShapedValue(pair) ? '[REDACTED]' : pair;
+        }
+
+        const name = pair.slice(0, separator);
+        const value = pair.slice(separator + 1);
+        if (value.length === 0) return pair;
+
+        return this.isSensitiveParamName(name) || this.isCredentialShapedValue(value)
+          ? `${name}=[REDACTED]`
+          : pair;
+      })
+      .join('&');
+  }
+
+  private isSensitiveParamName(name: string): boolean {
+    const sensitiveParams = [
+      'code',
+      'token',
+      'secret',
+      'password',
+      'passwd',
+      'pwd',
+      'key',
+      'apikey',
+      'auth',
+      'authorization',
+      'credential',
+      'credentials',
+      'accesskeyid',
+      'session',
+      'sessionid',
+      'sig',
+      'signature',
+      'jwt',
+      'bearer',
+      'hmac',
+      'sas',
+    ];
+
+    // Match whole words, not substrings: `api_key` and `X-Amz-Signature` are
+    // credentials, `keywords` and `sort_order` are not.
+    const words = this.decodeUrlComponent(name)
+      .toLowerCase()
+      .split(/[^a-z0-9]+/);
+    return words.some((word) => sensitiveParams.includes(word));
+  }
+
+  /**
+   * A long opaque string is a credential whatever its parameter is called —
+   * this is what catches token parameters the denylist has never heard of.
+   * Values this long that happen not to be secrets lose nothing but noise.
+   */
+  private isCredentialShapedValue(value: string): boolean {
+    const decoded = this.decodeUrlComponent(value);
+    return (
+      decoded.length >= 32 &&
+      /^[A-Za-z0-9._~+/=-]+$/.test(decoded) &&
+      /[A-Za-z]/.test(decoded) &&
+      /[0-9]/.test(decoded)
+    );
+  }
+
+  private decodeUrlComponent(value: string): string {
+    try {
+      return decodeURIComponent(value);
+    } catch {
+      return value;
+    }
+  }
+
+  private redactSensitiveUrls(context: RichErrorContext): RichErrorContext {
+    return {
+      ...context,
+      request: {
+        ...context.request,
+        url: this.redactSensitiveUrl(context.request.url),
+        finalUrl:
+          context.request.finalUrl === undefined
+            ? undefined
+            : this.redactSensitiveUrl(context.request.finalUrl),
+      },
+    };
+  }
+
   private redactSensitiveHeaders(context: RichErrorContext): RichErrorContext {
     const sensitiveHeaders = [
       'authorization',
@@ -611,8 +746,8 @@ Follows redirects by default. Returns detailed error context for failures.`;
   }
 
   private createRichError(context: RichErrorContext): ToolResult {
-    // Redact sensitive headers before creating error details
-    const sanitizedContext = this.redactSensitiveHeaders(context);
+    // Redact sensitive headers and URL credentials before creating error details
+    const sanitizedContext = this.redactSensitiveUrls(this.redactSensitiveHeaders(context));
 
     const errorDetails = {
       ...sanitizedContext,
@@ -625,11 +760,13 @@ Follows redirects by default. Returns detailed error context for failures.`;
 
     // Request details
     errorMessage += `REQUEST:\n`;
-    errorMessage += `  URL: ${context.request.url}\n`;
+    errorMessage += `  URL: ${sanitizedContext.request.url}\n`;
     errorMessage += `  Method: ${context.request.method}\n`;
 
+    // Whether a redirect happened is decided on the raw URLs; only the printed
+    // value is redacted.
     if (context.request.finalUrl && !isSameUrl(context.request.finalUrl, context.request.url)) {
-      errorMessage += `  Final URL: ${context.request.finalUrl}\n`;
+      errorMessage += `  Final URL: ${sanitizedContext.request.finalUrl}\n`;
     }
 
     if (context.request.timing) {

--- a/packages/agent/src/tools/implementations/url_fetch.ts
+++ b/packages/agent/src/tools/implementations/url_fetch.ts
@@ -46,6 +46,29 @@ function isSameUrl(a: string, b: string): boolean {
   return normalizeUrlForComparison(a) === normalizeUrlForComparison(b);
 }
 
+// Headers whose whole value is a URL. `Location` is the redirect destination —
+// the single most credential-dense header there is, since OAuth codes and
+// signed-URL signatures live in exactly that URL — and `Referer` carries
+// whatever query string the previous page had. The sensitive-header denylist
+// does not cover them because the header itself is not a secret; the secret is
+// a parameter inside it.
+const URL_VALUED_HEADERS = ['location', 'content-location', 'referer'];
+
+/**
+ * Scrub credentials out of URLs carried in header values. A URL-valued header
+ * is redacted as a URL (so a relative `Location: /cb?code=…` is covered too);
+ * every other header gets the free-text scan as a backstop.
+ */
+function redactUrlsInHeaders(headers: Record<string, string>): Record<string, string> {
+  const redacted: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    redacted[key] = URL_VALUED_HEADERS.includes(key.toLowerCase())
+      ? redactSensitiveUrl(value)
+      : redactUrlsInText(value);
+  }
+  return redacted;
+}
+
 // URL validation schema that checks protocol and format
 const HttpUrl = z
   .string()
@@ -587,7 +610,12 @@ Follows redirects by default. Returns detailed error context for failures.`;
           context.request.finalUrl === undefined
             ? undefined
             : redactSensitiveUrl(context.request.finalUrl),
+        headers: redactUrlsInHeaders(context.request.headers),
       },
+      response:
+        context.response === undefined
+          ? undefined
+          : { ...context.response, headers: redactUrlsInHeaders(context.response.headers) },
     };
   }
 
@@ -642,13 +670,16 @@ Follows redirects by default. Returns detailed error context for failures.`;
       timestamp: new Date().toISOString(),
     };
 
-    // Format for human-readable display
-    let errorMessage = `${context.error.type.toUpperCase()} ERROR: ${sanitizedContext.error.message}\n\n`;
+    // Format for human-readable display. Everything printed below reads from
+    // `sanitizedContext`; the one deliberate exception is the redirect
+    // comparison, which has to run on the raw URLs or two different URLs that
+    // redact to the same text would look like no redirect at all.
+    let errorMessage = `${sanitizedContext.error.type.toUpperCase()} ERROR: ${sanitizedContext.error.message}\n\n`;
 
     // Request details
     errorMessage += `REQUEST:\n`;
     errorMessage += `  URL: ${sanitizedContext.request.url}\n`;
-    errorMessage += `  Method: ${context.request.method}\n`;
+    errorMessage += `  Method: ${sanitizedContext.request.method}\n`;
 
     // Whether a redirect happened is decided on the raw URLs; only the printed
     // value is redacted.
@@ -656,14 +687,14 @@ Follows redirects by default. Returns detailed error context for failures.`;
       errorMessage += `  Final URL: ${sanitizedContext.request.finalUrl}\n`;
     }
 
-    if (context.request.timing) {
-      errorMessage += `  Timing: ${context.request.timing.total}ms total\n`;
+    if (sanitizedContext.request.timing) {
+      errorMessage += `  Timing: ${sanitizedContext.request.timing.total}ms total\n`;
     }
 
     // Response details (if available)
-    if (context.response) {
+    if (sanitizedContext.response) {
       errorMessage += `\nRESPONSE:\n`;
-      errorMessage += `  Status: ${context.response.status} ${context.response.statusText}\n`;
+      errorMessage += `  Status: ${sanitizedContext.response.status} ${sanitizedContext.response.statusText}\n`;
 
       // Show relevant headers
       const relevantHeaders = [
@@ -674,13 +705,13 @@ Follows redirects by default. Returns detailed error context for failures.`;
         'x-ratelimit-remaining',
       ];
       for (const header of relevantHeaders) {
-        if (context.response.headers[header]) {
-          errorMessage += `  ${header}: ${context.response.headers[header]}\n`;
+        if (sanitizedContext.response.headers[header]) {
+          errorMessage += `  ${header}: ${sanitizedContext.response.headers[header]}\n`;
         }
       }
 
-      if (context.response.bodyPreview) {
-        errorMessage += `\nResponse preview:\n${context.response.bodyPreview}\n`;
+      if (sanitizedContext.response.bodyPreview) {
+        errorMessage += `\nResponse preview:\n${sanitizedContext.response.bodyPreview}\n`;
       }
     }
 

--- a/packages/agent/src/tools/implementations/url_fetch.ts
+++ b/packages/agent/src/tools/implementations/url_fetch.ts
@@ -12,6 +12,7 @@ import { Tool } from '../tool';
 import type { ToolResult, ToolContext, ToolAnnotations } from '../types';
 import { logger } from '@lace/agent/utils/logger';
 import { RuntimeFetchSizeLimitError } from '../runtime/types';
+import { redactSensitiveUrl, redactUrlsInText } from '../url-redaction';
 
 // Constants for configuration and validation
 const INLINE_CONTENT_LIMIT = 32 * 1024; // 32KB
@@ -492,8 +493,8 @@ Follows redirects by default. Returns detailed error context for failures.`;
     // distinct values to the same `[REDACTED]` and would otherwise hide a real
     // redirect (or, with the userinfo rewrite, invent one).
     return isSameUrl(requestedUrl, finalUrl)
-      ? this.redactSensitiveUrl(requestedUrl)
-      : `${this.redactSensitiveUrl(finalUrl)} (redirected from ${this.redactSensitiveUrl(requestedUrl)})`;
+      ? redactSensitiveUrl(requestedUrl)
+      : `${redactSensitiveUrl(finalUrl)} (redirected from ${redactSensitiveUrl(requestedUrl)})`;
   }
 
   private handleInlineContent(
@@ -572,134 +573,20 @@ Follows redirects by default. Returns detailed error context for failures.`;
     );
   }
 
-  /**
-   * Strip credentials out of a URL before it is shown to the model. URLs carry
-   * secrets as routinely as headers do — OAuth codes and tokens, pre-signed S3
-   * and SAS signatures, API keys pasted into a query string — and the redirect
-   * destination the tool now reports is exactly where those turn up.
-   *
-   * Purely textual: scheme, host, path and every parameter name survive so the
-   * request is still diagnosable, and only values are replaced. Nothing here
-   * feeds `isSameUrl`, so redaction cannot invent a redirect.
-   */
-  private redactSensitiveUrl(url: string): string {
-    const hashIndex = url.indexOf('#');
-    const beforeFragment = hashIndex === -1 ? url : url.slice(0, hashIndex);
-    const fragment = hashIndex === -1 ? undefined : url.slice(hashIndex + 1);
-
-    const queryIndex = beforeFragment.indexOf('?');
-    const origin = queryIndex === -1 ? beforeFragment : beforeFragment.slice(0, queryIndex);
-    const query = queryIndex === -1 ? undefined : beforeFragment.slice(queryIndex + 1);
-
-    // `https://user:pass@host/` hands over a password in the clear; the
-    // username is half a credential too, so the whole userinfo goes.
-    let redacted = origin.replace(/^([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^/?#]*@/, '$1[REDACTED]@');
-
-    if (query !== undefined) {
-      redacted += `?${this.redactSensitiveParams(query)}`;
-    }
-
-    if (fragment !== undefined) {
-      // Implicit-flow tokens ride in the fragment as a query string; a plain
-      // anchor (`#install`) is worth keeping intact.
-      redacted += `#${
-        fragment.includes('=')
-          ? this.redactSensitiveParams(fragment)
-          : this.isCredentialShapedValue(fragment)
-            ? '[REDACTED]'
-            : fragment
-      }`;
-    }
-
-    return redacted;
-  }
-
-  private redactSensitiveParams(query: string): string {
-    return query
-      .split('&')
-      .map((pair) => {
-        const separator = pair.indexOf('=');
-        if (separator === -1) {
-          return this.isCredentialShapedValue(pair) ? '[REDACTED]' : pair;
-        }
-
-        const name = pair.slice(0, separator);
-        const value = pair.slice(separator + 1);
-        if (value.length === 0) return pair;
-
-        return this.isSensitiveParamName(name) || this.isCredentialShapedValue(value)
-          ? `${name}=[REDACTED]`
-          : pair;
-      })
-      .join('&');
-  }
-
-  private isSensitiveParamName(name: string): boolean {
-    const sensitiveParams = [
-      'code',
-      'token',
-      'secret',
-      'password',
-      'passwd',
-      'pwd',
-      'key',
-      'apikey',
-      'auth',
-      'authorization',
-      'credential',
-      'credentials',
-      'accesskeyid',
-      'session',
-      'sessionid',
-      'sig',
-      'signature',
-      'jwt',
-      'bearer',
-      'hmac',
-      'sas',
-    ];
-
-    // Match whole words, not substrings: `api_key` and `X-Amz-Signature` are
-    // credentials, `keywords` and `sort_order` are not.
-    const words = this.decodeUrlComponent(name)
-      .toLowerCase()
-      .split(/[^a-z0-9]+/);
-    return words.some((word) => sensitiveParams.includes(word));
-  }
-
-  /**
-   * A long opaque string is a credential whatever its parameter is called —
-   * this is what catches token parameters the denylist has never heard of.
-   * Values this long that happen not to be secrets lose nothing but noise.
-   */
-  private isCredentialShapedValue(value: string): boolean {
-    const decoded = this.decodeUrlComponent(value);
-    return (
-      decoded.length >= 32 &&
-      /^[A-Za-z0-9._~+/=-]+$/.test(decoded) &&
-      /[A-Za-z]/.test(decoded) &&
-      /[0-9]/.test(decoded)
-    );
-  }
-
-  private decodeUrlComponent(value: string): string {
-    try {
-      return decodeURIComponent(value);
-    } catch {
-      return value;
-    }
-  }
-
   private redactSensitiveUrls(context: RichErrorContext): RichErrorContext {
     return {
       ...context,
+      // The message is free text from whatever failed the request; the
+      // container runtime's curl quotes the URL it was handed straight back
+      // into it, so it needs the same scrubbing as the URLs we print ourselves.
+      error: { ...context.error, message: redactUrlsInText(context.error.message) },
       request: {
         ...context.request,
-        url: this.redactSensitiveUrl(context.request.url),
+        url: redactSensitiveUrl(context.request.url),
         finalUrl:
           context.request.finalUrl === undefined
             ? undefined
-            : this.redactSensitiveUrl(context.request.finalUrl),
+            : redactSensitiveUrl(context.request.finalUrl),
       },
     };
   }
@@ -756,7 +643,7 @@ Follows redirects by default. Returns detailed error context for failures.`;
     };
 
     // Format for human-readable display
-    let errorMessage = `${context.error.type.toUpperCase()} ERROR: ${context.error.message}\n\n`;
+    let errorMessage = `${context.error.type.toUpperCase()} ERROR: ${sanitizedContext.error.message}\n\n`;
 
     // Request details
     errorMessage += `REQUEST:\n`;

--- a/packages/agent/src/tools/runtime/__tests__/container-exec-network.test.ts
+++ b/packages/agent/src/tools/runtime/__tests__/container-exec-network.test.ts
@@ -274,8 +274,10 @@ describe('ContainerExecNetworkClient', () => {
       expect(error).toBeInstanceOf(Error);
       const message = (error as Error).message;
       expect(message).not.toContain(SECRET);
-      expect(message).toContain('X-Amz-Signature=[REDACTED]');
-      expect(message).toContain('bucket.s3.amazonaws.com/report.csv');
+      expect(message).toContain(
+        'https://bucket.s3.amazonaws.com/report.csv?X-Amz-Signature=[REDACTED]'
+      );
+      expect(message).not.toContain('[REDACTED]]');
     });
 
     it('redacts a credentialed URL that curl echoed back in its own stderr', async () => {
@@ -289,7 +291,8 @@ describe('ContainerExecNetworkClient', () => {
 
       const message = (error as Error).message;
       expect(message).not.toContain(SECRET);
-      expect(message).toContain('token=[REDACTED]');
+      expect(message).toContain('https://example.com/{a?token=[REDACTED]\n');
+      expect(message).not.toContain('[REDACTED]]');
       expect(message).toContain('unmatched brace in URL position 20');
     });
 
@@ -303,7 +306,8 @@ describe('ContainerExecNetworkClient', () => {
 
       const message = (error as Error).message;
       expect(message).not.toContain(SECRET);
-      expect(message).toContain('code=[REDACTED]');
+      expect(message).toContain('http://127.0.0.1:32875/a b?code=[REDACTED]');
+      expect(message).not.toContain('[REDACTED]]');
     });
 
     it('redacts the effective URL curl reports alongside its error text', async () => {
@@ -320,7 +324,8 @@ describe('ContainerExecNetworkClient', () => {
 
       const message = (error as Error).message;
       expect(message).not.toContain(SECRET);
-      expect(message).toContain('code=[REDACTED]');
+      expect(message).toContain('https://login.example.com/cb?code=[REDACTED]');
+      expect(message).not.toContain('[REDACTED]]');
     });
 
     it('leaves a curl failure with no credentials in it untouched', async () => {

--- a/packages/agent/src/tools/runtime/__tests__/container-exec-network.test.ts
+++ b/packages/agent/src/tools/runtime/__tests__/container-exec-network.test.ts
@@ -257,4 +257,82 @@ describe('ContainerExecNetworkClient', () => {
       /__lace_curl_effective_url__/
     );
   });
+
+  describe('credential redaction in curl failures', () => {
+    const SECRET = 'SECRETVALUE0123456789abcdef0123456789';
+
+    it('does not leak the requested URL when curl fails with no stderr at all', async () => {
+      // Exit code with an empty stderr falls back to the message
+      // `nodeErrorFromExec` constructs, which interpolates the URL it was given.
+      const { runner } = fakeRunner({ exitCode: 7, stderr: '', stdoutRaw: Buffer.alloc(0) });
+      const client = new ContainerExecNetworkClient(runner);
+
+      const error = await client
+        .fetch(`https://bucket.s3.amazonaws.com/report.csv?X-Amz-Signature=${SECRET}`)
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(Error);
+      const message = (error as Error).message;
+      expect(message).not.toContain(SECRET);
+      expect(message).toContain('X-Amz-Signature=[REDACTED]');
+      expect(message).toContain('bucket.s3.amazonaws.com/report.csv');
+    });
+
+    it('redacts a credentialed URL that curl echoed back in its own stderr', async () => {
+      // Verbatim curl 8.5.0 output for a URL containing an unmatched brace.
+      const url = `https://example.com/{a?token=${SECRET}`;
+      const stderr = `curl: (3) unmatched brace in URL position 20:\n${url}\n                   ^\n`;
+      const { runner } = fakeRunner({ exitCode: 3, stderr, stdoutRaw: Buffer.alloc(0) });
+      const client = new ContainerExecNetworkClient(runner);
+
+      const error = await client.fetch(url).catch((e: unknown) => e);
+
+      const message = (error as Error).message;
+      expect(message).not.toContain(SECRET);
+      expect(message).toContain('token=[REDACTED]');
+      expect(message).toContain('unmatched brace in URL position 20');
+    });
+
+    it('redacts an echoed URL whose embedded space would stop a URL-shaped scan', async () => {
+      const url = `http://127.0.0.1:32875/a b?code=${SECRET}`;
+      const stderr = `curl: (3) unmatched brace in URL position 20:\n${url}\n`;
+      const { runner } = fakeRunner({ exitCode: 3, stderr, stdoutRaw: Buffer.alloc(0) });
+      const client = new ContainerExecNetworkClient(runner);
+
+      const error = await client.fetch(url).catch((e: unknown) => e);
+
+      const message = (error as Error).message;
+      expect(message).not.toContain(SECRET);
+      expect(message).toContain('code=[REDACTED]');
+    });
+
+    it('redacts the effective URL curl reports alongside its error text', async () => {
+      const effective = `https://login.example.com/cb?code=${SECRET}`;
+      const stderr =
+        `curl: (3) unmatched brace in URL position 20:\n${effective}\n` +
+        `__lace_curl_effective_url__:${effective}\n`;
+      const { runner } = fakeRunner({ exitCode: 3, stderr, stdoutRaw: Buffer.alloc(0) });
+      const client = new ContainerExecNetworkClient(runner);
+
+      const error = await client
+        .fetch('https://example.com/start', { redirect: 'follow' })
+        .catch((e: unknown) => e);
+
+      const message = (error as Error).message;
+      expect(message).not.toContain(SECRET);
+      expect(message).toContain('code=[REDACTED]');
+    });
+
+    it('leaves a curl failure with no credentials in it untouched', async () => {
+      const stderr = 'curl: (6) Could not resolve host: unreachable.example\n';
+      const { runner } = fakeRunner({ exitCode: 6, stderr, stdoutRaw: Buffer.alloc(0) });
+      const client = new ContainerExecNetworkClient(runner);
+
+      const error = await client
+        .fetch('http://unreachable.example/docs?page=3')
+        .catch((e: unknown) => e);
+
+      expect((error as Error).message).toBe(stderr.trim());
+    });
+  });
 });

--- a/packages/agent/src/tools/runtime/container-exec-network.ts
+++ b/packages/agent/src/tools/runtime/container-exec-network.ts
@@ -9,6 +9,7 @@ import {
   type RuntimeProcessRunner,
 } from './types';
 import { nodeErrorFromExec, streamToString, writeStreamAndClose } from './container-exec-shared';
+import { redactSensitiveUrl } from '../url-redaction';
 
 const DEFAULT_FETCH_TIMEOUT_SECS = 120;
 
@@ -63,6 +64,19 @@ function extractTrailingEffectiveUrl(body: Buffer): { url: string | undefined; b
   // Drop the newline the write-out format puts in front of the marker too.
   const end = start > 0 && body[start - 1] === 0x0a ? start - 1 : start;
   return { url: url || undefined, body: body.subarray(0, end) };
+}
+
+/** Scrub credentials out of curl's own error text, which quotes the URL it was
+ * handed back at the caller (`unmatched brace in URL position N:` prints it on
+ * its own line). Both URLs are known exactly, so replace those strings outright
+ * rather than hunting for URL-shaped spans: an exact replacement also covers a
+ * malformed URL containing a space, which no URL-shaped scan can delimit. */
+function redactUrlsInStderr(stderr: string, urls: (string | undefined)[]): string {
+  let redacted = stderr;
+  for (const url of urls) {
+    if (url) redacted = redacted.split(url).join(redactSensitiveUrl(url));
+  }
+  return redacted;
 }
 
 export class ContainerExecNetworkClient implements RuntimeNetworkClient {
@@ -123,7 +137,16 @@ export class ContainerExecNetworkClient implements RuntimeNetworkClient {
     const { url: effectiveUrl, stderr: cleanStderr } = extractEffectiveUrl(stderr);
 
     if (completion.exitCode !== 0) {
-      throw nodeErrorFromExec(completion.exitCode ?? -1, cleanStderr, 'fetch', url);
+      // The URL is a credential carrier (pre-signed signatures, OAuth codes),
+      // and this message is rendered straight into url_fetch's error report.
+      // Redact before it ever lands in an Error, so nothing downstream — a log
+      // line, another caller — has to remember to.
+      throw nodeErrorFromExec(
+        completion.exitCode ?? -1,
+        redactUrlsInStderr(cleanStderr, [url, effectiveUrl]),
+        'fetch',
+        redactSensitiveUrl(url)
+      );
     }
 
     const raw = Buffer.from(stdout, 'base64');

--- a/packages/agent/src/tools/url-fetch.test.ts
+++ b/packages/agent/src/tools/url-fetch.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from 'vitest';
 import { UrlFetchTool } from '@lace/agent/tools/implementations/url_fetch';
 import { createFakeRuntime } from './runtime/__tests__/fake-runtime';
+import type { ToolRuntime } from './runtime/types';
 
 describe('UrlFetchTool with schema validation', () => {
   let tool: UrlFetchTool;
@@ -839,6 +840,63 @@ Follows redirects by default. Returns detailed error context for failures.`
       expect(output).not.toContain('redirected from');
       expect(output).not.toContain('SECRETCODE01234');
       expect(output).toContain('Content from https://example.com/cb?code=[REDACTED]&page=3');
+    });
+  });
+
+  describe('Credential redaction in runtime error messages', () => {
+    const throwingRuntime = (message: string): ToolRuntime => ({
+      ...createFakeRuntime(),
+      network: { fetch: vi.fn().mockRejectedValue(new Error(message)) },
+    });
+
+    const runToolAgainst = async (url: string, message: string) => {
+      const result = await tool.execute(
+        { url },
+        { signal: new AbortController().signal, runtime: throwingRuntime(message) }
+      );
+      return result.content[0].text ?? '';
+    };
+
+    it('redacts a credentialed URL embedded in the runtime error message', async () => {
+      const secret = 'SECRETVALUE0123456789abcdef0123456789';
+      const output = await runToolAgainst(
+        'https://example.com/x',
+        `curl: (3) unmatched brace in URL position 20:\nhttps://example.com/{a?token=${secret}\n`
+      );
+
+      expect(output).not.toContain(secret);
+      expect(output).toContain('token=[REDACTED]');
+      expect(output).toContain('unmatched brace in URL position 20');
+    });
+
+    it('redacts userinfo credentials embedded in the runtime error message', async () => {
+      const output = await runToolAgainst(
+        'https://example.com/private',
+        'connect ECONNREFUSED for https://alice:hunter2@example.com/private'
+      );
+
+      expect(output).not.toContain('hunter2');
+      expect(output).toContain('https://[REDACTED]@example.com/private');
+    });
+
+    it('redacts a URL the error message wrapped in parentheses', async () => {
+      // The trailing `).` is punctuation, not URL: left inside the value it
+      // fails the credential-shape charset test and the token survives.
+      const secret = 'f3a91c7de204b8615c9d0af27be431905ca8d76e12b34f9087ac5de6103b2f4d';
+      const output = await runToolAgainst(
+        'https://example.com/x',
+        `request failed (https://example.com/x?blob=${secret}).`
+      );
+
+      expect(output).not.toContain(secret);
+      expect(output).toContain('blob=[REDACTED]');
+    });
+
+    it('leaves an error message with no URL in it alone', async () => {
+      const output = await runToolAgainst('https://example.com/x', 'socket hang up');
+
+      expect(output).toContain('NETWORK ERROR: socket hang up');
+      expect(output).not.toContain('[REDACTED]');
     });
   });
 });

--- a/packages/agent/src/tools/url-fetch.test.ts
+++ b/packages/agent/src/tools/url-fetch.test.ts
@@ -843,6 +843,86 @@ Follows redirects by default. Returns detailed error context for failures.`
     });
   });
 
+  describe('Credential redaction in response headers', () => {
+    const redirectingRuntime = (location: string) =>
+      createFakeRuntime({
+        fetchResult: {
+          status: 302,
+          headers: { 'content-type': 'text/html', location },
+          body: new TextEncoder().encode(''),
+        },
+      });
+
+    it('redacts the Location header of an unfollowed redirect', async () => {
+      // `followRedirects: false` turns any 3xx into an error report, and the
+      // redirect destination is exactly where an OAuth code lives.
+      const result = await tool.execute(
+        { url: 'https://example.com/start', followRedirects: false },
+        {
+          signal: new AbortController().signal,
+          runtime: redirectingRuntime('https://login.example.com/cb?code=SECRETCODE01234'),
+        }
+      );
+
+      const output = result.content[0].text ?? '';
+      expect(output).not.toContain('SECRETCODE01234');
+      expect(output).toContain('  location: https://login.example.com/cb?code=[REDACTED]\n');
+      expect(output).toContain('"location": "https://login.example.com/cb?code=[REDACTED]"');
+    });
+
+    it('redacts a relative Location header', async () => {
+      const result = await tool.execute(
+        { url: 'https://example.com/start', followRedirects: false },
+        {
+          signal: new AbortController().signal,
+          runtime: redirectingRuntime('/cb?code=SECRETCODE01234&page=3'),
+        }
+      );
+
+      const output = result.content[0].text ?? '';
+      expect(output).not.toContain('SECRETCODE01234');
+      expect(output).toContain('  location: /cb?code=[REDACTED]&page=3\n');
+    });
+
+    it('leaves a Location header carrying no credentials untouched', async () => {
+      const result = await tool.execute(
+        { url: 'https://example.com/start', followRedirects: false },
+        {
+          signal: new AbortController().signal,
+          runtime: redirectingRuntime('https://example.com/docs?page=3'),
+        }
+      );
+
+      const output = result.content[0].text ?? '';
+      expect(output).toContain('  location: https://example.com/docs?page=3\n');
+      expect(output).not.toContain('[REDACTED]');
+    });
+
+    it('redacts a credentialed URL in any other response header', async () => {
+      const runtime = createFakeRuntime({
+        fetchResult: {
+          status: 404,
+          headers: {
+            'content-type': 'text/plain',
+            'x-debug-origin': 'served from https://origin.example.com/o?token=SECRETCODE01234',
+          },
+          body: new TextEncoder().encode('nope'),
+        },
+      });
+
+      const result = await tool.execute(
+        { url: 'https://example.com/start' },
+        { signal: new AbortController().signal, runtime }
+      );
+
+      const output = result.content[0].text ?? '';
+      expect(output).not.toContain('SECRETCODE01234');
+      expect(output).toContain(
+        '"x-debug-origin": "served from https://origin.example.com/o?token=[REDACTED]"'
+      );
+    });
+  });
+
   describe('Credential redaction in runtime error messages', () => {
     const throwingRuntime = (message: string): ToolRuntime => ({
       ...createFakeRuntime(),
@@ -890,6 +970,21 @@ Follows redirects by default. Returns detailed error context for failures.`
 
       expect(output).not.toContain(secret);
       expect(output).toContain('blob=[REDACTED]');
+    });
+
+    it('does not double the sentinel when the throw site already redacted the URL', async () => {
+      // The container runtime redacts into the Error message; url_fetch then
+      // runs the free-text scan over that same message. `]` is trailing
+      // punctuation, so a naive second pass emits `code=[REDACTED]]`.
+      const output = await runToolAgainst(
+        'https://example.com/cb',
+        'fetch failed (exit 7) for https://example.com/cb?code=[REDACTED]'
+      );
+
+      expect(output).toContain(
+        'NETWORK ERROR: fetch failed (exit 7) for https://example.com/cb?code=[REDACTED]\n'
+      );
+      expect(output).not.toContain('[REDACTED]]');
     });
 
     it('leaves an error message with no URL in it alone', async () => {

--- a/packages/agent/src/tools/url-fetch.test.ts
+++ b/packages/agent/src/tools/url-fetch.test.ts
@@ -682,4 +682,163 @@ Follows redirects by default. Returns detailed error context for failures.`
       expect(output).not.toContain('redirected from');
     });
   });
+
+  describe('Credential redaction in surfaced URLs', () => {
+    const okRuntime = (finalUrl?: string) =>
+      createFakeRuntime({
+        fetchResult: {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+          body: new TextEncoder().encode('hello'),
+          ...(finalUrl === undefined ? {} : { url: finalUrl }),
+        },
+      });
+
+    const failingRuntime = (finalUrl?: string) =>
+      createFakeRuntime({
+        fetchResult: {
+          status: 404,
+          headers: { 'content-type': 'text/plain' },
+          body: new TextEncoder().encode('not found'),
+          ...(finalUrl === undefined ? {} : { url: finalUrl }),
+        },
+      });
+
+    const runTool = async (url: string, runtime: ReturnType<typeof createFakeRuntime>) => {
+      const result = await tool.execute({ url }, { signal: new AbortController().signal, runtime });
+      return result.content[0].text ?? '';
+    };
+
+    it('redacts a denylisted query parameter while keeping the key and benign params', async () => {
+      const output = await runTool(
+        'https://example.com/cb?page=3&code=4%2F0AeanS0abcdef&sort=asc',
+        failingRuntime()
+      );
+
+      expect(output).not.toContain('4%2F0AeanS0abcdef');
+      expect(output).toContain('code=[REDACTED]');
+      expect(output).toContain('page=3');
+      expect(output).toContain('sort=asc');
+      expect(output).toContain('https://example.com/cb?');
+    });
+
+    it('redacts a signed-URL signature parameter', async () => {
+      const signature = 'a'.repeat(20) + '9b2c3d4e5f60718293a4b5c6d7e8f901';
+      const output = await runTool(
+        `https://bucket.s3.amazonaws.com/report.csv?X-Amz-Credential=AKIAIOSFODNN7EXAMPLE&X-Amz-Expires=900&X-Amz-Signature=${signature}`,
+        failingRuntime()
+      );
+
+      expect(output).not.toContain(signature);
+      expect(output).not.toContain('AKIAIOSFODNN7EXAMPLE');
+      expect(output).toContain('X-Amz-Signature=[REDACTED]');
+      expect(output).toContain('X-Amz-Credential=[REDACTED]');
+      expect(output).toContain('X-Amz-Expires=900');
+    });
+
+    it('redacts a long high-entropy value under a key that is not on the denylist', async () => {
+      const opaque = 'f3a91c7de204b8615c9d0af27be431905ca8d76e12b34f9087ac5de6103b2f4d';
+      const output = await runTool(`https://example.com/x?blob=${opaque}&page=2`, failingRuntime());
+
+      expect(output).not.toContain(opaque);
+      expect(output).toContain('blob=[REDACTED]');
+      expect(output).toContain('page=2');
+    });
+
+    it('redacts userinfo credentials from the URL', async () => {
+      const output = await runTool('https://alice:hunter2@example.com/private', failingRuntime());
+
+      expect(output).not.toContain('hunter2');
+      expect(output).not.toContain('alice');
+      expect(output).toContain('https://[REDACTED]@example.com/private');
+    });
+
+    it('redacts an implicit-flow token carried in the fragment', async () => {
+      const output = await runTool(
+        'https://example.com/cb#access_token=ya29.a0AfB_byXXXXX&state=xyz789&token_type=Bearer',
+        failingRuntime()
+      );
+
+      expect(output).not.toContain('ya29.a0AfB_byXXXXX');
+      expect(output).toContain('access_token=[REDACTED]');
+      expect(output).toContain('state=xyz789');
+      // `token_type` is over-redacted: the denylist matches the word `token`.
+      // Losing `Bearer` costs nothing, and the parameter name still shows.
+      expect(output).toContain('token_type=[REDACTED]');
+    });
+
+    it('keeps a plain anchor fragment intact', async () => {
+      const output = await runTool('https://example.com/docs#installation', failingRuntime());
+
+      expect(output).toContain('URL: https://example.com/docs#installation');
+    });
+
+    it('leaves a benign URL untouched', async () => {
+      const output = await runTool(
+        'https://example.com/docs/guide?page=3&lang=en#section-2',
+        failingRuntime()
+      );
+
+      expect(output).toContain('URL: https://example.com/docs/guide?page=3&lang=en#section-2');
+      expect(output).not.toContain('[REDACTED]');
+    });
+
+    it('redacts both the requested and the effective URL of a redirect on the error path', async () => {
+      const output = await runTool(
+        'https://example.com/start?api_key=sk-live-01234567890',
+        failingRuntime('https://login.example.com/cb?code=SECRETCODE01234')
+      );
+
+      expect(output).not.toContain('sk-live-01234567890');
+      expect(output).not.toContain('SECRETCODE01234');
+      expect(output).toContain('URL: https://example.com/start?api_key=[REDACTED]');
+      expect(output).toContain('Final URL: https://login.example.com/cb?code=[REDACTED]');
+    });
+
+    it('redacts both URLs in the success-path content attribution', async () => {
+      const output = await runTool(
+        'https://example.com/start?api_key=sk-live-01234567890',
+        okRuntime('https://login.example.com/cb?code=SECRETCODE01234')
+      );
+
+      expect(output).not.toContain('sk-live-01234567890');
+      expect(output).not.toContain('SECRETCODE01234');
+      expect(output).toContain('Content from https://login.example.com/cb?code=[REDACTED]');
+      expect(output).toContain('redirected from https://example.com/start?api_key=[REDACTED]');
+    });
+
+    it('redacts the URL inside the diagnostic JSON blob', async () => {
+      const output = await runTool('https://example.com/cb?token=abc123secret', failingRuntime());
+
+      expect(output).not.toContain('abc123secret');
+      expect(output).toContain('"url": "https://example.com/cb?token=[REDACTED]"');
+    });
+
+    it('still reports a redirect when both URLs redact to the same text', async () => {
+      const output = await runTool(
+        'https://example.com/cb?code=AAAA1111',
+        failingRuntime('https://example.com/cb?code=BBBB2222')
+      );
+
+      expect(output).toContain('Final URL: https://example.com/cb?code=[REDACTED]');
+    });
+
+    it('does not report a phantom Final URL for a non-redirected request with query params', async () => {
+      const url = 'https://example.com/cb?code=SECRETCODE01234&page=3';
+      const output = await runTool(url, failingRuntime(url));
+
+      expect(output).not.toContain('Final URL:');
+      expect(output).not.toContain('SECRETCODE01234');
+      expect(output).toContain('code=[REDACTED]');
+    });
+
+    it('does not report a phantom redirect on the success path for a redacted URL', async () => {
+      const url = 'https://example.com/cb?code=SECRETCODE01234&page=3';
+      const output = await runTool(url, okRuntime(url));
+
+      expect(output).not.toContain('redirected from');
+      expect(output).not.toContain('SECRETCODE01234');
+      expect(output).toContain('Content from https://example.com/cb?code=[REDACTED]&page=3');
+    });
+  });
 });

--- a/packages/agent/src/tools/url-redaction.test.ts
+++ b/packages/agent/src/tools/url-redaction.test.ts
@@ -1,0 +1,115 @@
+// ABOUTME: Unit tests for the URL credential redactor's parameter, shape and nesting rules.
+// ABOUTME: Asserts exact output, so an over-redaction or a doubled sentinel fails the test.
+
+import { describe, it, expect } from 'vitest';
+import { redactSensitiveUrl, redactUrlsInText } from '@lace/agent/tools/url-redaction';
+
+describe('redactSensitiveUrl', () => {
+  describe('credentials nested inside a parameter value', () => {
+    it('redacts a token inside a percent-encoded redirect_uri', () => {
+      expect(
+        redactSensitiveUrl(
+          'https://example.com/authorize?redirect_uri=https%3A%2F%2Fapp.example.com%2Fcb%3Ftoken%3Dsecret123&client=web'
+        )
+      ).toBe(
+        'https://example.com/authorize?redirect_uri=https%3A%2F%2Fapp.example.com%2Fcb%3Ftoken%3D[REDACTED]&client=web'
+      );
+    });
+
+    it('redacts a token inside an unencoded nested URL', () => {
+      expect(
+        redactSensitiveUrl('https://example.com/go?next=https://app.example.com/cb?code=abc123')
+      ).toBe('https://example.com/go?next=https://app.example.com/cb?code=[REDACTED]');
+    });
+
+    it('redacts a token nested two encodings deep', () => {
+      const inner = encodeURIComponent('https://b.example.com/cb?token=secret123');
+      const middle = encodeURIComponent(`https://a.example.com/cb?next=${inner}`);
+
+      expect(redactSensitiveUrl(`https://example.com/go?next=${middle}`)).toBe(
+        'https://example.com/go?next=https%3A%2F%2Fa.example.com%2Fcb%3Fnext%3D' +
+          'https%253A%252F%252Fb.example.com%252Fcb%253Ftoken%253D[REDACTED]'
+      );
+    });
+
+    it('leaves a nested URL carrying no credentials byte-identical', () => {
+      // Only half-encoded on purpose: if the recursion re-encoded a value it
+      // did not change, this would come back fully percent-encoded.
+      const url = 'https://example.com/go?next=https://app.example.com/docs%3Fpage%3D3';
+      expect(redactSensitiveUrl(url)).toBe(url);
+    });
+  });
+
+  describe('long values that are identifiers rather than credentials', () => {
+    it('keeps a form-encoded search query, where + is a space', () => {
+      const url = 'https://example.com/search?q=how+do+i+configure+the+widget+today2';
+      expect(redactSensitiveUrl(url)).toBe(url);
+    });
+
+    it('keeps a canonical UUID', () => {
+      const url = 'https://example.com/r?id=550e8400-e29b-41d4-a716-446655440000';
+      expect(redactSensitiveUrl(url)).toBe(url);
+    });
+
+    it('keeps a long hyphenated anchor slug', () => {
+      const url = 'https://example.com/report#section-about-the-2024-annual-report-summary';
+      expect(redactSensitiveUrl(url)).toBe(url);
+    });
+
+    it('still redacts a long opaque hex value', () => {
+      expect(
+        redactSensitiveUrl(
+          'https://example.com/x?blob=f3a91c7de204b8615c9d0af27be431905ca8d76e12b34f9087ac5de6103b2f4d'
+        )
+      ).toBe('https://example.com/x?blob=[REDACTED]');
+    });
+
+    it('still redacts a base64url token that happens to contain hyphens', () => {
+      expect(
+        redactSensitiveUrl(
+          'https://example.com/x?blob=8Kd-2Qm7Xr4Tz-9Lb0Nv6Wq3Yh1Pj5Sc-Ae8Gu2Mi4Ko'
+        )
+      ).toBe('https://example.com/x?blob=[REDACTED]');
+    });
+
+    it('still redacts a UUID under a denylisted parameter name', () => {
+      expect(
+        redactSensitiveUrl('https://example.com/r?sid=550e8400-e29b-41d4-a716-446655440000')
+      ).toBe('https://example.com/r?sid=[REDACTED]');
+    });
+  });
+
+  describe('legacy `;` query separator', () => {
+    it('redacts a denylisted parameter that follows a semicolon', () => {
+      expect(
+        redactSensitiveUrl('https://example.com/cb?b=1;token=SECRETCODE0123456789abcdef')
+      ).toBe('https://example.com/cb?b=1;token=[REDACTED]');
+    });
+
+    it('keeps benign semicolon-separated parameters byte-identical', () => {
+      const url = 'https://example.com/cb?b=1;page=3';
+      expect(redactSensitiveUrl(url)).toBe(url);
+    });
+  });
+});
+
+describe('redactUrlsInText', () => {
+  it('leaves an already-redacted URL alone rather than doubling the sentinel', () => {
+    expect(redactUrlsInText('fetch failed for https://example.com/cb?code=[REDACTED]')).toBe(
+      'fetch failed for https://example.com/cb?code=[REDACTED]'
+    );
+  });
+
+  it('still strips real trailing punctuation that follows the sentinel', () => {
+    expect(redactUrlsInText('failed (https://example.com/cb?code=[REDACTED]).')).toBe(
+      'failed (https://example.com/cb?code=[REDACTED]).'
+    );
+  });
+
+  it('still redacts a raw URL wrapped in parentheses', () => {
+    const secret = 'f3a91c7de204b8615c9d0af27be431905ca8d76e12b34f9087ac5de6103b2f4d';
+    expect(redactUrlsInText(`failed (https://example.com/x?blob=${secret}).`)).toBe(
+      'failed (https://example.com/x?blob=[REDACTED]).'
+    );
+  });
+});

--- a/packages/agent/src/tools/url-redaction.ts
+++ b/packages/agent/src/tools/url-redaction.ts
@@ -1,0 +1,147 @@
+// ABOUTME: Textual redaction of credential-bearing components from URLs before they reach the model.
+// ABOUTME: Presentation-only — callers keep fetching and comparing the raw URL.
+
+const REDACTED = '[REDACTED]';
+
+const SENSITIVE_PARAMS = [
+  'code',
+  'token',
+  'secret',
+  'password',
+  'passwd',
+  'pwd',
+  'key',
+  'apikey',
+  'auth',
+  'authorization',
+  'credential',
+  'credentials',
+  'accesskeyid',
+  'session',
+  'sessionid',
+  'sig',
+  'signature',
+  'jwt',
+  'bearer',
+  'hmac',
+  'sas',
+];
+
+/**
+ * Strip credentials out of a URL before it is shown to the model. URLs carry
+ * secrets as routinely as headers do — OAuth codes and tokens, pre-signed S3
+ * and SAS signatures, API keys pasted into a query string — and the redirect
+ * destination the tool reports is exactly where those turn up.
+ *
+ * Purely textual: scheme, host, path and every parameter name survive so the
+ * request is still diagnosable, and only values are replaced. Nothing here
+ * feeds `isSameUrl`, so redaction cannot invent a redirect.
+ */
+export function redactSensitiveUrl(url: string): string {
+  const hashIndex = url.indexOf('#');
+  const beforeFragment = hashIndex === -1 ? url : url.slice(0, hashIndex);
+  const fragment = hashIndex === -1 ? undefined : url.slice(hashIndex + 1);
+
+  const queryIndex = beforeFragment.indexOf('?');
+  const origin = queryIndex === -1 ? beforeFragment : beforeFragment.slice(0, queryIndex);
+  const query = queryIndex === -1 ? undefined : beforeFragment.slice(queryIndex + 1);
+
+  // `https://user:pass@host/` hands over a password in the clear; the
+  // username is half a credential too, so the whole userinfo goes.
+  let redacted = origin.replace(/^([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^/?#]*@/, `$1${REDACTED}@`);
+
+  if (query !== undefined) {
+    redacted += `?${redactSensitiveParams(query)}`;
+  }
+
+  if (fragment !== undefined) {
+    // Implicit-flow tokens ride in the fragment as a query string; a plain
+    // anchor (`#install`) is worth keeping intact.
+    redacted += `#${
+      fragment.includes('=')
+        ? redactSensitiveParams(fragment)
+        : isCredentialShapedValue(fragment)
+          ? REDACTED
+          : fragment
+    }`;
+  }
+
+  return redacted;
+}
+
+// Anything that looks like `scheme://…` and runs to the first whitespace or
+// quoting character. Free-form error text is all we have to go on when an
+// error message came from a program that quoted the URL back at us.
+const URL_IN_TEXT_RE = /[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s<>"'`]+/g;
+// A URL at the end of a sentence takes the punctuation with it; leave the
+// trailing run outside the redacted span rather than treating it as URL.
+const TRAILING_PUNCTUATION_RE = /[.,;:!?)\]}>'"]+$/;
+
+/**
+ * Redact every URL-shaped span in free-form text — an error message from curl,
+ * from `fetch`, or from anything else that quoted the request back at us.
+ *
+ * This is a backstop, not a parser. It only finds URLs carrying an explicit
+ * scheme, and it stops at the first whitespace, so a URL the source wrapped,
+ * re-encoded, or split cannot be caught here. Callers that know the exact URL
+ * should also replace that known string outright.
+ */
+export function redactUrlsInText(text: string): string {
+  return text.replace(URL_IN_TEXT_RE, (match) => {
+    const trailing = TRAILING_PUNCTUATION_RE.exec(match)?.[0] ?? '';
+    const url = trailing.length === 0 ? match : match.slice(0, -trailing.length);
+    return `${redactSensitiveUrl(url)}${trailing}`;
+  });
+}
+
+function redactSensitiveParams(query: string): string {
+  return query
+    .split('&')
+    .map((pair) => {
+      const separator = pair.indexOf('=');
+      if (separator === -1) {
+        return isCredentialShapedValue(pair) ? REDACTED : pair;
+      }
+
+      const name = pair.slice(0, separator);
+      const value = pair.slice(separator + 1);
+      if (value.length === 0) return pair;
+
+      return isSensitiveParamName(name) || isCredentialShapedValue(value)
+        ? `${name}=${REDACTED}`
+        : pair;
+    })
+    .join('&');
+}
+
+function isSensitiveParamName(name: string): boolean {
+  // Match whole words, not substrings: `api_key` and `X-Amz-Signature` are
+  // credentials, `keywords` and `sort_order` are not.
+  const words = decodeUrlComponent(name)
+    .toLowerCase()
+    .split(/[^a-z0-9]+/);
+  return words.some((word) => SENSITIVE_PARAMS.includes(word));
+}
+
+/**
+ * A long opaque string is a credential whatever its parameter is called —
+ * this is what catches token parameters the denylist has never heard of.
+ * Values this long that happen not to be secrets lose nothing but noise.
+ */
+function isCredentialShapedValue(value: string): boolean {
+  const decoded = decodeUrlComponent(value);
+  return (
+    decoded.length >= 32 &&
+    /^[A-Za-z0-9._~+/=-]+$/.test(decoded) &&
+    /[A-Za-z]/.test(decoded) &&
+    /[0-9]/.test(decoded)
+  );
+}
+
+function decodeUrlComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}

--- a/packages/agent/src/tools/url-redaction.ts
+++ b/packages/agent/src/tools/url-redaction.ts
@@ -19,6 +19,7 @@ const SENSITIVE_PARAMS = [
   'accesskeyid',
   'session',
   'sessionid',
+  'sid',
   'sig',
   'signature',
   'jwt',
@@ -26,6 +27,11 @@ const SENSITIVE_PARAMS = [
   'hmac',
   'sas',
 ];
+
+// A parameter value that is itself a URL gets recursed into; a URL nested
+// inside a URL nested inside a URL is pathological, and the cap keeps a
+// hand-crafted chain of encodings from turning into unbounded work.
+const MAX_NESTED_URL_DEPTH = 3;
 
 /**
  * Strip credentials out of a URL before it is shown to the model. URLs carry
@@ -35,9 +41,14 @@ const SENSITIVE_PARAMS = [
  *
  * Purely textual: scheme, host, path and every parameter name survive so the
  * request is still diagnosable, and only values are replaced. Nothing here
- * feeds `isSameUrl`, so redaction cannot invent a redirect.
+ * feeds `isSameUrl`, so redaction cannot invent a redirect. Redacting an
+ * already-redacted URL is a no-op, so the layers can safely overlap.
  */
 export function redactSensitiveUrl(url: string): string {
+  return redactUrlAtDepth(url, 0);
+}
+
+function redactUrlAtDepth(url: string, depth: number): string {
   const hashIndex = url.indexOf('#');
   const beforeFragment = hashIndex === -1 ? url : url.slice(0, hashIndex);
   const fragment = hashIndex === -1 ? undefined : url.slice(hashIndex + 1);
@@ -51,7 +62,7 @@ export function redactSensitiveUrl(url: string): string {
   let redacted = origin.replace(/^([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^/?#]*@/, `$1${REDACTED}@`);
 
   if (query !== undefined) {
-    redacted += `?${redactSensitiveParams(query)}`;
+    redacted += `?${redactSensitiveParams(query, depth)}`;
   }
 
   if (fragment !== undefined) {
@@ -59,7 +70,7 @@ export function redactSensitiveUrl(url: string): string {
     // anchor (`#install`) is worth keeping intact.
     redacted += `#${
       fragment.includes('=')
-        ? redactSensitiveParams(fragment)
+        ? redactSensitiveParams(fragment, depth)
         : isCredentialShapedValue(fragment)
           ? REDACTED
           : fragment
@@ -88,30 +99,76 @@ const TRAILING_PUNCTUATION_RE = /[.,;:!?)\]}>'"]+$/;
  */
 export function redactUrlsInText(text: string): string {
   return text.replace(URL_IN_TEXT_RE, (match) => {
-    const trailing = TRAILING_PUNCTUATION_RE.exec(match)?.[0] ?? '';
+    const trailing = trailingPunctuationOf(match);
     const url = trailing.length === 0 ? match : match.slice(0, -trailing.length);
     return `${redactSensitiveUrl(url)}${trailing}`;
   });
 }
 
-function redactSensitiveParams(query: string): string {
+/**
+ * The trailing punctuation the surrounding prose contributed, not the URL.
+ *
+ * The sentinel ends in `]`, which is punctuation. A URL that has already been
+ * redacted at the throw site arrives here as `…code=[REDACTED]`; trimming that
+ * `]` off would hand the rest back for a second redaction pass and re-emit the
+ * closing bracket, printing `code=[REDACTED]]`. So only the run *after* the
+ * last sentinel is ever eligible.
+ */
+function trailingPunctuationOf(match: string): string {
+  const sentinelStart = match.lastIndexOf(REDACTED);
+  const tailStart = sentinelStart === -1 ? 0 : sentinelStart + REDACTED.length;
+  return TRAILING_PUNCTUATION_RE.exec(match.slice(tailStart))?.[0] ?? '';
+}
+
+function redactSensitiveParams(query: string, depth: number): string {
+  // `;` is a legacy query separator alongside `&`. Splitting with a capturing
+  // group keeps whichever one the URL actually used in place.
   return query
-    .split('&')
-    .map((pair) => {
-      const separator = pair.indexOf('=');
-      if (separator === -1) {
-        return isCredentialShapedValue(pair) ? REDACTED : pair;
-      }
+    .split(/([&;])/)
+    .map((part, index) => (index % 2 === 1 ? part : redactSensitiveParam(part, depth)))
+    .join('');
+}
 
-      const name = pair.slice(0, separator);
-      const value = pair.slice(separator + 1);
-      if (value.length === 0) return pair;
+function redactSensitiveParam(pair: string, depth: number): string {
+  const separator = pair.indexOf('=');
+  if (separator === -1) {
+    return isCredentialShapedValue(pair) ? REDACTED : pair;
+  }
 
-      return isSensitiveParamName(name) || isCredentialShapedValue(value)
-        ? `${name}=${REDACTED}`
-        : pair;
-    })
-    .join('&');
+  const name = pair.slice(0, separator);
+  const value = pair.slice(separator + 1);
+  if (value.length === 0) return pair;
+
+  if (isSensitiveParamName(name) || isCredentialShapedValue(value)) {
+    return `${name}=${REDACTED}`;
+  }
+
+  const nested = redactNestedUrl(value, depth);
+  return nested === undefined ? pair : `${name}=${nested}`;
+}
+
+/**
+ * A parameter value that is itself a URL carries its own query string, and
+ * OAuth routinely puts a token in there: `?redirect_uri=…%3Ftoken%3D…`,
+ * `?next=`, `?state=`. Neither the denylist (the outer name is benign) nor the
+ * shape test (a URL has `:` and `?` in it) sees the credential, so recurse.
+ *
+ * Returns undefined when nothing changed, so a value that needed no redaction
+ * comes back byte-identical rather than re-encoded.
+ */
+function redactNestedUrl(value: string, depth: number): string | undefined {
+  if (depth >= MAX_NESTED_URL_DEPTH) return undefined;
+
+  const decoded = decodeUrlComponent(value);
+  if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(decoded)) return undefined;
+
+  const redacted = redactUrlAtDepth(decoded, depth + 1);
+  if (redacted === decoded) return undefined;
+  if (decoded === value) return redacted;
+
+  // Re-encode to the level the caller used, but keep the sentinel legible
+  // rather than shipping `%5BREDACTED%5D` to the model.
+  return encodeURIComponent(redacted).split(encodeURIComponent(REDACTED)).join(REDACTED);
 }
 
 function isSensitiveParamName(name: string): boolean {
@@ -126,7 +183,12 @@ function isSensitiveParamName(name: string): boolean {
 /**
  * A long opaque string is a credential whatever its parameter is called —
  * this is what catches token parameters the denylist has never heard of.
- * Values this long that happen not to be secrets lose nothing but noise.
+ *
+ * "Opaque" is the load-bearing word. Values this long that carry a recognisable
+ * identifier structure — a canonical UUID, or a run of words joined by `+`,
+ * `-` or spaces — are the common long non-secrets of the web (record ids,
+ * search queries, anchor slugs) and are left alone. Everything else long
+ * enough, alphanumeric, and mixed letters-and-digits is redacted.
  */
 function isCredentialShapedValue(value: string): boolean {
   const decoded = decodeUrlComponent(value);
@@ -134,8 +196,34 @@ function isCredentialShapedValue(value: string): boolean {
     decoded.length >= 32 &&
     /^[A-Za-z0-9._~+/=-]+$/.test(decoded) &&
     /[A-Za-z]/.test(decoded) &&
-    /[0-9]/.test(decoded)
+    /[0-9]/.test(decoded) &&
+    !isStructuredIdentifier(decoded)
   );
+}
+
+// `550e8400-e29b-41d4-a716-446655440000` — the 8-4-4-4-12 grouping is a
+// format, not just an alphabet, and in a URL it is overwhelmingly a record id.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// A word: letters, optionally with a small number suffix (`today2`, `q3`), or
+// a bare year/number. Random base64 segments are not shaped like this.
+const WORD_SEGMENT_RE = /^(?:[A-Za-z]{1,24}[0-9]{0,4}|[0-9]{1,4})$/;
+const WORD_SEPARATOR_RE = /[-+ ]+/;
+
+function isStructuredIdentifier(value: string): boolean {
+  return UUID_RE.test(value) || isWordJoinedText(value);
+}
+
+/**
+ * Prose that arrived as one parameter value: a search query (`?q=how+do+i+…`,
+ * where `+` is a space that `decodeURIComponent` does not decode), a slug, an
+ * anchor. Demanding several genuinely alphabetic words keeps hyphenated or
+ * `+`-bearing base64 out: its segments are long and mix digits throughout.
+ */
+function isWordJoinedText(value: string): boolean {
+  const segments = value.split(WORD_SEPARATOR_RE);
+  if (segments.length < 4) return false;
+  if (!segments.every((segment) => WORD_SEGMENT_RE.test(segment))) return false;
+  return segments.filter((segment) => /^[A-Za-z]{2,}$/.test(segment)).length >= 3;
 }
 
 function decodeUrlComponent(value: string): string {


### PR DESCRIPTION
`url_fetch` deliberately redacts sensitive request headers (`authorization`, `cookie`, `x-api-key`) before error text reaches the model. It did not redact **URLs**, which routinely carry credentials: OAuth `?code=` / `?access_token=`, AWS `X-Amz-Signature`, Azure SAS `sig=`, GCS `Signature=`, API keys in query strings, and `https://user:pass@host/` userinfo.

That was always partly true of the requested URL. #394 and #395 made it materially more reachable by surfacing the **post-redirect effective URL** — and redirect targets are exactly where OAuth codes and signed-URL credentials appear. A request to a benign URL can redirect to one carrying a token, and that token was printed to the model.

## The redaction

New `packages/agent/src/tools/url-redaction.ts` exports `redactSensitiveUrl` (a known URL string) and `redactUrlsInText` (free-form text). Same denylist-then-map shape and `[REDACTED]` sentinel as the existing `redactSensitiveHeaders`, so the sibling reads like its sibling.

**It never calls `new URL()`.** The redactor is purely textual, splitting on the first `#` and first `?` by index, so scheme, host, path, parameter names, separators and percent-encoding come back byte-identical — only values change. Parsing would re-normalize the URL an operator is trying to debug, and would re-encode `[REDACTED]` as `%5BREDACTED%5D`.

What is replaced:

- **Userinfo** — `scheme://[REDACTED]@host`. The username goes too; a username is half a credential.
- **Query parameters** — value replaced, key kept, when the name is denylisted **or** the value is credential-shaped. `&` and the legacy `;` both separate parameters, and whichever the URL used is preserved.
- **Nested URLs** — a parameter value that decodes to a URL (`?redirect_uri=…%3Ftoken%3D…`, `?next=`, `?state=`) is recursed into and re-encoded, depth-capped at 3. A value nothing changed comes back byte-identical rather than re-encoded.
- **Fragments** — a fragment containing `=` goes through the same parameter pass (implicit-flow `#access_token=`); otherwise it is redacted only if credential-shaped, so `#installation` survives.
- **URL-valued headers** — `location`, `content-location` and `referer` in the error context are redacted as URLs; every other header value gets the free-text scan. `Location` is the redirect destination, and with `followRedirects: false` every 3xx prints it.

Name matching splits on non-alphanumerics and compares **whole words**, unlike the header function's substring match. Substring matching on `key` would eat `?keywords=` and `?sort_key=`; `api_key`, `client_secret` and `X-Amz-Signature` still match.

The value heuristic is length ≥ 32, charset confined to `[A-Za-z0-9._~+/=-]`, both a letter and a digit, **and no recognisable identifier structure** — covering hex signatures, JWTs and opaque bearer tokens under parameter names nobody anticipated. Shannon entropy was considered and rejected: over a 32–64 character sample it barely separates a token from a slug, so it would be false comfort rather than a filter.

"Opaque" is the load-bearing word, and the first version of this heuristic did not honour it. `decodeURIComponent` does not turn `+` into a space and `+` is in the allowed charset, so every form-encoded search query of 32+ characters containing one digit was destroyed — `?q=how+do+i+configure+the+widget+today2` → `?q=[REDACTED]`. For a URL-fetching tool a search query is a live case, so the claim that "keys always survive, so diagnostic loss is small" did not hold when the key is `q`. UUIDs and long hyphenated anchor slugs went the same way.

Two structures are now exempt, chosen because they are *formats* rather than alphabets:

- a **canonical UUID** (`8-4-4-4-12` hex grouping);
- **word-joined text**: four or more segments split on `+`, `-` or space, every segment shaped like a word (letters, optionally a short digit suffix) or a bare number, and at least three of them genuinely alphabetic.

Everything else long enough is still redacted, hex included. A 40-character lowercase hex value is a commit SHA and it is also an HMAC-SHA1; there is no signal in the bytes that separates them, so it stays redacted and the `?sha=` case loses its value. That is the deliberate direction to fail in.

## Two layers, because one is not enough

**Presentation** (`url_fetch.ts`) — every place the tool shows a URL: the `REQUEST:` block, the `Final URL:` line, the diagnostic JSON, and the success-path `Content from <url>` attribution. `redactSensitiveUrls` also runs `redactUrlsInText` over `context.error.message`.

**Throw site** (`container-exec-network.ts`) — the URL passed to `nodeErrorFromExec` is redacted, and curl's stderr is scrubbed by **exact substring replacement** of the two URLs already in hand, not by a regex.

The exact-replacement choice matters. At the throw site the secret is a *known string*, so nothing is guessed — and the existing code deliberately supports `http://host/a b`, a malformed URL containing a space, which no URL-shaped scan can delimit. It also keeps the raw URL out of the `Error` object entirely, so a future logger printing `error.message` is covered without having to remember.

Neither layer alone suffices: throw-site-only leaves every non-container error path unguarded (host runtime `fetch`, future runtimes, wrapped errors); presentation-only cannot handle a URL with a space and lets the raw URL live inside a thrown `Error` other code may log.

## Raw-context reads in `createRichError`

`createRichError`'s header line read `context.error.message` — the **raw** context — while everything below it read `sanitizedContext`. That was a pre-existing bypass. Review pointed out, correctly, that finding one instance and not sweeping for the rest was the wrong stopping point: `response.headers` and `response.bodyPreview` were still raw, and `response.headers` is where the unredacted `Location` reached the model.

The whole function has now been swept. Every read is `sanitizedContext.*` — `error.type`, `error.message`, `request.url`, `request.method`, `request.finalUrl`, `request.timing`, `response.status`, `response.statusText`, `response.headers`, `response.bodyPreview` — with exactly one deliberate exception, commented in place: the `isSameUrl` redirect comparison, which must run on raw values or two different URLs that redact to identical text would look like no redirect at all.

## The redirect comparison is untouched

`isSameUrl` / `normalizeUrlForComparison` still operate on **raw** values; redaction happens strictly at presentation. Reintroducing #394's phantom-redirect bug would be a bad trade for this, and #394/#395's tests all still pass.

Redaction is deterministic, so it cannot manufacture a phantom redirect. The real risk runs the other way — two genuinely different redirect URLs collapsing to identical redacted text and *hiding* a redirect. There is a test for exactly that, and it exists because a mutation initially killed nothing and exposed the gap.

## What still gets through

Stated plainly, because a redaction feature that oversells itself is worse than none. This list is the audit after the review fixes, not before.

**Secrets that leak:**

- **Short secrets under novel names.** `?t=abc123` — under 32 chars, key not denylisted.
- **All-alpha values** under a benign parameter name — the shape test requires both a letter and a digit.
- **A bare UUID used as a bearer token** under a parameter name the denylist has never heard of. This is new, and it is the price of not destroying every record id in a URL. `session`, `sessionid`, `sid`, `token`, `key` and `auth` are all denylisted, which covers the shapes a UUID credential actually turns up in, but `?x=<uuid>` as a capability token now survives. Judged worth it: in a URL a canonical UUID is overwhelmingly an identifier.
- **A credential that looks like four or more joined words** — `?x=alpha-bravo-charlie-delta-echo`. Also new, and the reason the word rule demands three genuinely alphabetic segments and rejects digit-interleaved ones: random base64url with hyphens does not pass. A hand-crafted passphrase-style secret does.
- **The path is never redacted.** `/v1/keys/sk-live-…` leaks. Redacting path segments by shape would mangle far too many legitimate paths; that trade was judged worse.
- **Schemeless URLs in free-form text.** `redactUrlsInText` only matches `scheme://…`.
- **Whitespace-split URLs at the presentation boundary** — the scan stops at the first space. The throw-site exact replacement covers this for the container path only.
- **Re-encoded variants** quoted back by a runtime — exact replacement misses them.
- **`response.bodyPreview` is not scanned.** A credential echoed in a response body still reaches the model. Arguably intended, since it is the fetched content, but it is a path. The read now goes through `sanitizedContext`, so turning the scan on is a one-line change rather than a second bypass.
- **Nested URLs more than three levels of encoding deep** are not recursed into.

**Non-secrets still destroyed (over-redaction):**

- **`token_type=Bearer`** — the denylist matches the word `token`. Costs nothing; there is a test recording it as deliberate.
- **Hex digests: commit SHAs, MD5/SHA-256 content hashes, ETags** under a non-denylisted key. A hex digest and a hex HMAC are the same bytes, so this one is not separable and was left redacting. `?sha=9f8c…` still becomes `?sha=[REDACTED]`; the key survives, so the error still says a `sha` was sent.
- **Any other long opaque alphanumeric run** with no word or UUID structure — base64-shaped ids, ULIDs, nanoids.

Fixed since the first review round, all with mutation evidence: the raw `Location` header, the remaining raw-context reads, credentials nested inside a parameter value, `+`-joined search queries, UUIDs, anchor slugs, the `;` separator bypass, and the doubled `[REDACTED]]` sentinel on the container path.

## Correction to the original bug report

This work was scoped partly on the claim that curl "routinely" embeds the requested URL in stderr. **That could not be reproduced.** Modern curl names the *host* in almost every failure probed — `(6) Could not resolve host: x`, `(7) Failed to connect to host port N` — including redirect-protocol denials. The URL-quoting case is real (`curl: (3) unmatched brace in URL position 20:` followed by the full URL, captured from curl 8.5.0) but not the common one.

The certain leak is route 1: the constructed message `${op} failed (exit ${exitCode}) for ${path}` when stderr is empty. The fix is unchanged; the severity picture is narrower than originally stated.

## Other `nodeErrorFromExec` callers

All five are in `container-exec-fs.ts` (`stat`, `readTextFile`, `writeTextFile`, `mkdir`, `readdir`) and pass container filesystem paths. They deliberately get no redaction: a path is not a credential carrier the way a URL is, the file tools already show these paths to the model routinely, and redacting them would break diagnosis for no gain. `nodeErrorFromExec` itself is unchanged rather than absorbing redaction, precisely because only one of its six call sites carries a credential-bearing argument.

## The two layers composed badly

`container-exec-network.ts` redacts into the `Error` message at the throw site; `url_fetch.ts` then runs the free-text scan over that same message. The sentinel ends in `]`, which the trailing-punctuation trim treated as sentence punctuation, so `code=[REDACTED]` was handed back for a second pass and re-emitted as `code=[REDACTED]]`. Cosmetic, but it was the *normal* path for every container fetch failure, and no test caught it: they asserted `toContain('code=[REDACTED]')`, which passes against `[REDACTED]]`.

Only the run *after* the last sentinel is eligible for trimming now, which makes `redactUrlsInText` idempotent. The container-path assertions are exact.

## Mutation evidence

Every new test was verified to fail against a deliberately broken implementation. Across all three commits, 36 mutations, all killed.

The review round added 15, each killing at least one test and no test killed by nothing: dropping response-header redaction, reverting the swept `sanitizedContext` reads, reverting the `;` split, removing the identifier exemption (and each of its two halves separately), inverting it so everything is exempt, disabling nested-URL recursion, lowering the depth cap, removing the re-encode guard, reverting the sentinel-aware punctuation trim, disabling the trim entirely, dropping `sid`, dropping `location` from the URL-valued headers, and a redact-everything mutation to prove "benign `Location` untouched" is a real assertion.

The instructive one: a trailing-punctuation trim initially killed nothing and looked like dead code. It isn't — `(see https://x?blob=<64 hex>)` captures the `)` into the value, the `)` fails the credential-shape charset test, and the token leaks. A test now covers it.

Two mutations exist purely to prove the negative-control tests can go red (redact-everything, and over-redact the host), so "benign URL untouched" is a real assertion rather than a vacuous one.

## Verification

- typecheck clean, lint clean.
- `url-redaction` + `url-fetch` + `src/tools/runtime` + `src/tools/__tests__`: **288 passed, 0 failed**.
- Test files are excluded from `tsconfig.json`, so they were typechecked via a temporary config. No errors in any touched file; the one hit in `url-fetch.test.ts:15` is a pre-existing `TS2558`.

**Not verified:** behaviour against a real old curl (7.29, which the code comments call out as a supported image). The stderr formats used come from curl 8.5.0. The exact-replacement layer does not depend on stderr format, so this is likely not a gap — but it was not tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

