### PR TITLE
fix(containers): reap only the booting agent's own orphan containers

### DIFF
--- a/docs/architecture/persona-containers.md
+++ b/docs/architecture/persona-containers.md
@@ -31,6 +31,15 @@ lace runs the startup reaper, where the `lace-` prefix marks per_invocation
 containers as reap candidates and the `sen-` prefix keeps persistent containers
 outside its scope.
 
+The prefix alone does not identify WHICH agent's containers those are, so every
+container lace creates in the `lace-` namespace carries a `lace.owner` label
+holding the creating agent's `LACE_DIR`. The startup reaper destroys only
+candidates whose label matches its own owner id: an agent cleans up the
+containers it leaked before a crash and leaves a sibling agent's containers on
+the same host untouched. A `lace-` container with no `lace.owner` label (created
+before the label existed) is never reaped by anyone — the reaper logs it at WARN
+so an operator can remove it by hand.
+
 ## Workspace convention (the workspace IS the result)
 
 For `per_invocation` containers the sen-docker shim provisions a bind-mounted

--- a/docs/architecture/persona-containers.md
+++ b/docs/architecture/persona-containers.md
@@ -33,12 +33,38 @@ outside its scope.
 
 The prefix alone does not identify WHICH agent's containers those are, so every
 container lace creates in the `lace-` namespace carries a `lace.owner` label
-holding the creating agent's `LACE_DIR`. The startup reaper destroys only
-candidates whose label matches its own owner id: an agent cleans up the
-containers it leaked before a crash and leaves a sibling agent's containers on
-the same host untouched. A `lace-` container with no `lace.owner` label (created
-before the label existed) is never reaped by anyone — the reaper logs it at WARN
-so an operator can remove it by hand.
+holding the creating agent's identity, and the startup reaper destroys only
+candidates whose label matches its own. An agent cleans up the containers it
+leaked before a crash and leaves a sibling agent's containers on the same host
+untouched.
+
+**The identity is an explicitly configured `LACE_DIR`** (`containerOwnerId()` in
+`manager-factory.ts`), `path.resolve`d — not `realpath`d, so retargeting a
+`current -> releases/N` symlink does not silently change the agent's identity
+and strand everything it created before the swap. Two properties are needed at
+once: durable across a restart of one agent, and distinct between agents. An
+explicit `LACE_DIR` has both.
+
+**With `LACE_DIR` unset there is no identity, and reaping is off.** The
+`getLaceDir()` default (`~/.lace`) is shared by every agent one OS user runs, so
+an id derived from it is durable but not distinct — two concurrent agents would
+match each other's containers and reap them, which is the bug the label exists
+to fix. Nothing else available at boot repairs that: anything durable under a
+shared `LACE_DIR` is shared too, and anything distinct (pid, boot time, a fresh
+random) is lost on restart. So `containerOwnerId()` returns null, the manager
+stamps no owner label, and the reaper destroys nothing and says so at WARN.
+Orphans then accumulate until an operator removes them. **Set `LACE_DIR` to turn
+reaping on.**
+
+A `lace-` container with no `lace.owner` label — created before the label
+existed, or by an agent with no identity — is never reaped by anyone; the reaper
+logs it at WARN so an operator can remove it by hand.
+
+Residual sharing: the granularity is the `LACE_DIR`, not the process. Lace
+processes that share one `LACE_DIR` — a root agent and its delegate children —
+share an owner id and will reap each other's orphan containers. So will two
+agents an operator deliberately points at the same `LACE_DIR`. One `LACE_DIR`
+per agent instance is what the reaper's guarantee is built on.
 
 ## Workspace convention (the workspace IS the result)
 

--- a/packages/agent/src/containers/__tests__/container-manager.test.ts
+++ b/packages/agent/src/containers/__tests__/container-manager.test.ts
@@ -12,7 +12,8 @@ import {
   type ExecStreamHandle,
   type ExecStreamOptions,
 } from '../types';
-import { ContainerManager } from '../container-manager';
+import { CONTAINER_OWNER_LABEL, ContainerManager } from '../container-manager';
+import { logger } from '@lace/agent/utils/logger';
 import { PlaneRuntime } from '../plane-runtime';
 import type { ContainerSpec } from '../spec';
 
@@ -27,6 +28,9 @@ class MockContainerRuntime extends BaseContainerRuntime {
     this.callLog.push(`create:${containerId}`);
     const info: ContainerInfo = { id: containerId, state: 'created' };
     info.mounts = config.mounts;
+    // A real daemon remembers create-time labels and reports them back from
+    // inspect; the reaper's ownership check depends on that.
+    if (config.labels) info.labels = config.labels;
     this.containers.set(containerId, info);
     this.registerMounts(containerId, config);
     return containerId;
@@ -70,6 +74,14 @@ class MockContainerRuntime extends BaseContainerRuntime {
     throw new Error('execStreamImpl not set');
   }
 
+  /**
+   * Mirror DockerContainerRuntime.list, which shells out to `docker ps` and so
+   * reports no labels — ownership has to come from an inspect.
+   */
+  async list(): Promise<ContainerInfo[]> {
+    return Array.from(this.containers.values()).map(({ labels: _labels, ...rest }) => rest);
+  }
+
   /** test helper: directly create-then-stop to simulate a leftover stopped container */
   async seedStopped(containerId: string): Promise<void> {
     this.create({
@@ -93,13 +105,28 @@ const baseSpec: ContainerSpec = {
   env: { FOO: 'bar' },
 };
 
+// This agent's identity (its LACE_DIR in production) and a sibling agent's.
+const OWNER = '/lace-dirs/agent-a';
+const OTHER_OWNER = '/lace-dirs/agent-b';
+
 describe('ContainerManager', () => {
   let runtime: MockContainerRuntime;
   let manager: ContainerManager;
 
+  /** Seed a daemon-side container as if created by `owner` (undefined = no owner label). */
+  function seedContainer(id: string, owner?: string): void {
+    runtime.create({
+      id,
+      image: 'test:latest',
+      workingDirectory: '/x',
+      mounts: [],
+      ...(owner === undefined ? {} : { labels: { [CONTAINER_OWNER_LABEL]: owner } }),
+    });
+  }
+
   beforeEach(() => {
     runtime = new MockContainerRuntime();
-    manager = new ContainerManager(runtime);
+    manager = new ContainerManager(runtime, OWNER);
   });
 
   describe('materialize', () => {
@@ -123,6 +150,7 @@ describe('ContainerManager', () => {
         workingDirectory: '/lace',
         mounts: baseSpec.mounts,
         environment: { FOO: 'bar' },
+        labels: { [CONTAINER_OWNER_LABEL]: OWNER },
       });
     });
 
@@ -167,14 +195,30 @@ describe('ContainerManager', () => {
       expect(config.labels).toEqual({
         'sen.broker.persona': 'persistent-box',
         'sen.broker.jobId': 'job_1',
+        [CONTAINER_OWNER_LABEL]: OWNER,
       });
     });
 
-    it('omits labels when spec has none', async () => {
+    it('stamps the owner label even when the spec carries none', async () => {
       const createSpy = vi.spyOn(runtime, 'create');
       await manager.materialize(baseSpec);
       const [config] = createSpy.mock.calls[0] as [ContainerConfig];
-      expect(config.labels).toBeUndefined();
+      expect(config.labels).toEqual({ [CONTAINER_OWNER_LABEL]: OWNER });
+    });
+
+    it('leaves labels alone for a verbatim-id spec (a persistent box)', async () => {
+      // Boxes live outside the `lace-` namespace, are never reaping candidates,
+      // and their identity labels belong to the shim — do not add ours.
+      const createSpy = vi.spyOn(runtime, 'create');
+      await manager.materialize({
+        ...baseSpec,
+        name: 'box-shell',
+        containerId: 'sen-box-shell',
+        labels: { 'sen.broker.persona': 'box' },
+      });
+
+      const [config] = createSpy.mock.calls[0] as [ContainerConfig];
+      expect(config.labels).toEqual({ 'sen.broker.persona': 'box' });
     });
 
     it('propagates spec.image into ContainerConfig (kata #53)', async () => {
@@ -605,38 +649,13 @@ describe('ContainerManager', () => {
   describe('reapOrphans', () => {
     it('destroys containers matching prefix that are not in liveSpecNames', async () => {
       // three lace-sess1-* containers, two live + one orphan
-      runtime.create({
-        id: 'lace-sess1-alpha',
-        image: 'test:latest',
-        workingDirectory: '/x',
-        mounts: [],
-      });
-      runtime.create({
-        id: 'lace-sess1-beta',
-        image: 'test:latest',
-        workingDirectory: '/x',
-        mounts: [],
-      });
-      runtime.create({
-        id: 'lace-sess1-zombie',
-        image: 'test:latest',
-        workingDirectory: '/x',
-        mounts: [],
-      });
+      seedContainer('lace-sess1-alpha', OWNER);
+      seedContainer('lace-sess1-beta', OWNER);
+      seedContainer('lace-sess1-zombie', OWNER);
       // unrelated prefix — must be left alone
-      runtime.create({
-        id: 'lace-other-x',
-        image: 'test:latest',
-        workingDirectory: '/x',
-        mounts: [],
-      });
+      seedContainer('lace-other-x', OWNER);
       // non-lace id — must be ignored entirely
-      runtime.create({
-        id: 'docker-default',
-        image: 'test:latest',
-        workingDirectory: '/x',
-        mounts: [],
-      });
+      seedContainer('docker-default', OWNER);
       runtime.callLog.length = 0;
 
       const result = await manager.reapOrphans('sess1-', new Set(['sess1-alpha', 'sess1-beta']));
@@ -650,17 +669,87 @@ describe('ContainerManager', () => {
     });
 
     it('empty prefix reaps any lace- container not in liveSpecNames', async () => {
-      runtime.create({ id: 'lace-keep', image: 'test:latest', workingDirectory: '/x', mounts: [] });
-      runtime.create({ id: 'lace-drop', image: 'test:latest', workingDirectory: '/x', mounts: [] });
+      seedContainer('lace-keep', OWNER);
+      seedContainer('lace-drop', OWNER);
 
       const result = await manager.reapOrphans('', new Set(['keep']));
 
       expect(result.reaped).toEqual(['drop']);
     });
 
+    it('spares a live container that belongs to us', async () => {
+      // The live-set exclusion must still bite for our OWN containers — owning a
+      // container is not a licence to destroy one that is currently in use.
+      seedContainer('lace-live', OWNER);
+      runtime.callLog.length = 0;
+
+      const result = await manager.reapOrphans('', new Set(['live']));
+
+      expect(result.reaped).toEqual([]);
+      expect(runtime.callLog).not.toContain('remove:lace-live');
+    });
+
+    it('reaps an orphan it created itself before restarting', async () => {
+      // Materialize through a first manager, then hand the same daemon to a
+      // fresh manager with the same owner id — the crash-and-restart shape.
+      const crashed = new ContainerManager(runtime, OWNER);
+      await crashed.materialize({ ...baseSpec, name: 'sess1-leaked' });
+      runtime.callLog.length = 0;
+
+      const restarted = new ContainerManager(runtime, OWNER);
+      const result = await restarted.reapOrphans('', new Set());
+
+      expect(result.reaped).toEqual(['sess1-leaked']);
+      expect(runtime.callLog).toContain('remove:lace-sess1-leaked');
+    });
+
+    it("leaves another agent's container alone", async () => {
+      // The blast-radius bug: a second agent booting on a shared host used to
+      // destroy every lace- container, including live ones owned by a sibling.
+      seedContainer('lace-mine', OWNER);
+      seedContainer('lace-theirs', OTHER_OWNER);
+      runtime.callLog.length = 0;
+
+      const result = await manager.reapOrphans('', new Set());
+
+      expect(result.reaped).toEqual(['mine']);
+      expect(runtime.callLog).not.toContain('stop:lace-theirs');
+      expect(runtime.callLog).not.toContain('remove:lace-theirs');
+    });
+
+    it('leaves an unlabelled container alone and warns about it', async () => {
+      // Containers created before the owner label existed are unattributable.
+      // Leaking one is recoverable by hand; reaping a stranger's is not.
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      seedContainer('lace-legacy');
+      runtime.callLog.length = 0;
+
+      const result = await manager.reapOrphans('', new Set());
+
+      expect(result.reaped).toEqual([]);
+      expect(runtime.callLog).not.toContain('remove:lace-legacy');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no owner label'), {
+        containers: ['lace-legacy'],
+      });
+      warnSpy.mockRestore();
+    });
+
+    it('leaves a container alone when its ownership cannot be inspected', async () => {
+      // Fail closed: an inspect error must not read as "unowned, therefore mine".
+      seedContainer('lace-opaque', OWNER);
+      vi.spyOn(runtime, 'daemonInspect').mockRejectedValue(new Error('daemon unreachable'));
+      vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      runtime.callLog.length = 0;
+
+      const result = await manager.reapOrphans('', new Set());
+
+      expect(result.reaped).toEqual([]);
+      expect(runtime.callLog).not.toContain('remove:lace-opaque');
+    });
+
     it('continues past individual failures and reports successes', async () => {
-      runtime.create({ id: 'lace-a', image: 'test:latest', workingDirectory: '/x', mounts: [] });
-      runtime.create({ id: 'lace-b', image: 'test:latest', workingDirectory: '/x', mounts: [] });
+      seedContainer('lace-a', OWNER);
+      seedContainer('lace-b', OWNER);
       const originalStop = runtime.stop.bind(runtime);
       vi.spyOn(runtime, 'stop').mockImplementation(async (id: string) => {
         if (id === 'lace-a') throw new Error('boom');
@@ -680,7 +769,7 @@ describe('ContainerManager', () => {
     });
 
     it('returns true when backed by a PlaneRuntime', () => {
-      const planeManager = new ContainerManager(new PlaneRuntime('/fake/sen-docker'));
+      const planeManager = new ContainerManager(new PlaneRuntime('/fake/sen-docker'), OWNER);
       expect(planeManager.isPlaneRuntime).toBe(true);
     });
   });

--- a/packages/agent/src/containers/__tests__/container-manager.test.ts
+++ b/packages/agent/src/containers/__tests__/container-manager.test.ts
@@ -13,6 +13,7 @@ import {
   type ExecStreamOptions,
 } from '../types';
 import { CONTAINER_OWNER_LABEL, ContainerManager } from '../container-manager';
+import { containerOwnerId } from '../manager-factory';
 import { logger } from '@lace/agent/utils/logger';
 import { PlaneRuntime } from '../plane-runtime';
 import type { ContainerSpec } from '../spec';
@@ -219,6 +220,19 @@ describe('ContainerManager', () => {
 
       const [config] = createSpy.mock.calls[0] as [ContainerConfig];
       expect(config.labels).toEqual({ 'sen.broker.persona': 'box' });
+    });
+
+    it('stamps no owner label when the agent has no distinct identity', async () => {
+      // A null owner id means LACE_DIR was never set, so this agent cannot be
+      // told apart from its siblings. Stamping the shared value would let the
+      // next agent claim these containers as its own and destroy them.
+      const anonymous = new ContainerManager(runtime, null);
+      const createSpy = vi.spyOn(runtime, 'create');
+
+      await anonymous.materialize({ ...baseSpec, labels: { 'sen.broker.persona': 'shell' } });
+
+      const [config] = createSpy.mock.calls[0] as [ContainerConfig];
+      expect(config.labels).toEqual({ 'sen.broker.persona': 'shell' });
     });
 
     it('propagates spec.image into ContainerConfig (kata #53)', async () => {
@@ -745,6 +759,54 @@ describe('ContainerManager', () => {
 
       expect(result.reaped).toEqual([]);
       expect(runtime.callLog).not.toContain('remove:lace-opaque');
+    });
+
+    it('reaps nothing when the agent has no distinct identity', async () => {
+      // Fail closed, the same way an unlabelled container does: without a
+      // distinct identity we cannot prove a container is ours, and a wrongly
+      // reaped container is not recoverable.
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      seedContainer('lace-someones', OWNER);
+      seedContainer('lace-anons');
+      runtime.callLog.length = 0;
+
+      const anonymous = new ContainerManager(runtime, null);
+      const result = await anonymous.reapOrphans('', new Set());
+
+      expect(result.reaped).toEqual([]);
+      expect(runtime.callLog).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('LACE_DIR'));
+      warnSpy.mockRestore();
+    });
+
+    it('does not let two agents in the default configuration reap each other', async () => {
+      // The headline guarantee, exercised through the real identity derivation:
+      // two agents booted with no LACE_DIR — the shared-dev-box shape this fix
+      // is for — must not destroy each other's containers.
+      const originalLaceDir = process.env.LACE_DIR;
+      delete process.env.LACE_DIR;
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      try {
+        const agentA = new ContainerManager(runtime, containerOwnerId());
+        const agentB = new ContainerManager(runtime, containerOwnerId());
+        await agentA.materialize({ ...baseSpec, name: 'agent-a-work' });
+        await agentB.materialize({ ...baseSpec, name: 'agent-b-work' });
+        runtime.callLog.length = 0;
+
+        // Both boot their startup reaper against the one daemon.
+        expect((await agentA.reapOrphans('', new Set())).reaped).toEqual([]);
+        expect((await agentB.reapOrphans('', new Set())).reaped).toEqual([]);
+
+        expect(runtime.callLog).toEqual([]);
+        expect(await runtime.list()).toHaveLength(2);
+      } finally {
+        warnSpy.mockRestore();
+        if (originalLaceDir === undefined) {
+          delete process.env.LACE_DIR;
+        } else {
+          process.env.LACE_DIR = originalLaceDir;
+        }
+      }
     });
 
     it('continues past individual failures and reports successes', async () => {

--- a/packages/agent/src/containers/__tests__/spawn-broker-selector-roundtrip.test.ts
+++ b/packages/agent/src/containers/__tests__/spawn-broker-selector-roundtrip.test.ts
@@ -79,7 +79,7 @@ describe('PRI-2012 B7.1 SELECTOR round-trip to create() config', () => {
 
   beforeEach(() => {
     runtime = new RecordingRuntime();
-    manager = new ContainerManager(runtime);
+    manager = new ContainerManager(runtime, '/lace-dir/selector-roundtrip');
   });
 
   afterEach(() => {});

--- a/packages/agent/src/containers/container-manager.ts
+++ b/packages/agent/src/containers/container-manager.ts
@@ -20,6 +20,15 @@ import { PlaneRuntime } from './plane-runtime';
 // cross-process orphan reaping can scope its scan.
 const CONTAINER_ID_PREFIX = 'lace-';
 
+/**
+ * Docker object label naming the agent that created a container. Its value is
+ * the creating agent's LACE_DIR (see manager-factory), which is stable across
+ * restarts of one agent and distinct between agents sharing a host. The startup
+ * reaper destroys only containers carrying its own value, so one agent's boot
+ * never touches a sibling agent's containers.
+ */
+export const CONTAINER_OWNER_LABEL = 'lace.owner';
+
 export function resolveContainerId(spec: Pick<ContainerSpec, 'name' | 'containerId'>): string {
   // Persistent container runtime opts out of the `lace-` namespace by supplying a verbatim
   // containerId. Using a non-`lace-` id is intentional: it makes boxes invisible
@@ -119,7 +128,16 @@ export class ContainerManager {
   private readonly containerIdsBySpecName = new Map<string, string>();
   private readonly materializations = new Map<string, Promise<ContainerHandle>>();
 
-  constructor(private readonly runtime: ContainerRuntime) {}
+  /**
+   * @param ownerId Identity stamped as `lace.owner` on every container this
+   *   manager creates in the `lace-` namespace, and the only value
+   *   `reapOrphans` will destroy. Must be stable across restarts of the same
+   *   agent (see `containerOwnerId` in manager-factory).
+   */
+  constructor(
+    private readonly runtime: ContainerRuntime,
+    private readonly ownerId: string
+  ) {}
 
   /**
    * True when the underlying runtime is a PlaneRuntime (the sen-docker shim).
@@ -188,7 +206,7 @@ export class ContainerManager {
       capAdd: spec.capAdd,
       network: spec.network,
       gatewayRoute: spec.gatewayRoute,
-      labels: spec.labels,
+      labels: this.labelsWithOwner(spec),
       persona: spec.persona,
       role: spec.role,
       parentSessionId: spec.parentSessionId,
@@ -275,6 +293,19 @@ export class ContainerManager {
     };
   }
 
+  /**
+   * Stamp our owner label onto the spec's labels so the reaper can tell our
+   * containers from a sibling agent's.
+   *
+   * Specs carrying a verbatim `containerId` (persistent boxes) live outside the
+   * `lace-` namespace and are never reaping candidates, so their labels are
+   * passed through untouched — the shim owns box identity labels.
+   */
+  private labelsWithOwner(spec: ContainerSpec): Record<string, string> | undefined {
+    if (spec.containerId && spec.containerId.length > 0) return spec.labels;
+    return { ...spec.labels, [CONTAINER_OWNER_LABEL]: this.ownerId };
+  }
+
   async inspect(specName: string): Promise<ContainerHandle | null> {
     const spec = this.specs.get(specName);
     const containerId = this.resolveBySpecName(specName);
@@ -357,7 +388,15 @@ export class ContainerManager {
   }
 
   /**
-   * Reap containers under our `lace-` id-prefix that are not in `liveSpecNames`.
+   * Reap containers under our `lace-` id-prefix that WE created and that are
+   * not in `liveSpecNames`.
+   *
+   * Ownership is authoritative: a candidate is destroyed only when its
+   * `lace.owner` label equals this manager's `ownerId`. Containers owned by
+   * another agent on the same host, and containers with no owner label at all
+   * (created before the label existed, or by a runtime that drops labels), are
+   * left alone — an unreaped container leaks, a wrongly-reaped one destroys
+   * someone's live work.
    *
    * @param specNamePrefix A SPEC-name prefix (NOT a container-id prefix). It is
    *   prepended internally with `CONTAINER_ID_PREFIX` (`lace-`) to form the
@@ -383,11 +422,19 @@ export class ContainerManager {
     }
 
     const reaped: string[] = [];
+    const unowned: string[] = [];
 
     for (const info of containers) {
       if (!info.id.startsWith(scanPrefix)) continue;
       const specName = specNameFromContainerId(info.id);
       if (liveSpecNames.has(specName)) continue;
+
+      const owner = await this.ownerOf(info);
+      if (owner === null) {
+        unowned.push(info.id);
+        continue;
+      }
+      if (owner !== this.ownerId) continue;
 
       try {
         await this.destroy(specName);
@@ -400,7 +447,34 @@ export class ContainerManager {
       }
     }
 
+    if (unowned.length > 0) {
+      logger.warn(
+        'Container reaper: skipping containers with no owner label; remove them by hand if stale',
+        { containers: unowned }
+      );
+    }
+
     return { reaped };
+  }
+
+  /**
+   * Read a candidate's owner label. Returns null when the container carries no
+   * owner label, has vanished, or cannot be inspected — every one of which
+   * means "not provably ours", so the caller must leave it alone.
+   */
+  private async ownerOf(info: ContainerInfo): Promise<string | null> {
+    // Ask the daemon rather than trusting `list()`: DockerContainerRuntime.list
+    // shells out to `docker ps`, which reports no labels at all.
+    try {
+      const inspected = await this.runtime.daemonInspect(info.id);
+      return inspected?.labels?.[CONTAINER_OWNER_LABEL] ?? null;
+    } catch (error) {
+      logger.warn('Container reaper: ownership inspect failed; leaving container alone', {
+        containerId: info.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
   }
 
   private async tryInspect(containerId: string): Promise<ContainerInfo | null> {

--- a/packages/agent/src/containers/container-manager.ts
+++ b/packages/agent/src/containers/container-manager.ts
@@ -22,10 +22,10 @@ const CONTAINER_ID_PREFIX = 'lace-';
 
 /**
  * Docker object label naming the agent that created a container. Its value is
- * the creating agent's LACE_DIR (see manager-factory), which is stable across
- * restarts of one agent and distinct between agents sharing a host. The startup
- * reaper destroys only containers carrying its own value, so one agent's boot
- * never touches a sibling agent's containers.
+ * the creating agent's explicitly configured LACE_DIR (see manager-factory),
+ * which is stable across restarts of one agent and distinct between agents
+ * sharing a host. The startup reaper destroys only containers carrying its own
+ * value, so one agent's boot never touches a sibling agent's containers.
  */
 export const CONTAINER_OWNER_LABEL = 'lace.owner';
 
@@ -132,11 +132,13 @@ export class ContainerManager {
    * @param ownerId Identity stamped as `lace.owner` on every container this
    *   manager creates in the `lace-` namespace, and the only value
    *   `reapOrphans` will destroy. Must be stable across restarts of the same
-   *   agent (see `containerOwnerId` in manager-factory).
+   *   agent and distinct from every other agent on the host (see
+   *   `containerOwnerId` in manager-factory). `null` when no such identity is
+   *   available: this manager then stamps no owner and reaps nothing.
    */
   constructor(
     private readonly runtime: ContainerRuntime,
-    private readonly ownerId: string
+    private readonly ownerId: string | null
   ) {}
 
   /**
@@ -300,8 +302,13 @@ export class ContainerManager {
    * Specs carrying a verbatim `containerId` (persistent boxes) live outside the
    * `lace-` namespace and are never reaping candidates, so their labels are
    * passed through untouched — the shim owns box identity labels.
+   *
+   * With no owner id we stamp nothing. A label whose value every agent on the
+   * host would also compute is worse than no label: it invites the next agent
+   * to claim these containers and destroy them.
    */
   private labelsWithOwner(spec: ContainerSpec): Record<string, string> | undefined {
+    if (this.ownerId === null) return spec.labels;
     if (spec.containerId && spec.containerId.length > 0) return spec.labels;
     return { ...spec.labels, [CONTAINER_OWNER_LABEL]: this.ownerId };
   }
@@ -396,7 +403,8 @@ export class ContainerManager {
    * another agent on the same host, and containers with no owner label at all
    * (created before the label existed, or by a runtime that drops labels), are
    * left alone — an unreaped container leaks, a wrongly-reaped one destroys
-   * someone's live work.
+   * someone's live work. For the same reason a manager with no owner id of its
+   * own reaps nothing at all.
    *
    * @param specNamePrefix A SPEC-name prefix (NOT a container-id prefix). It is
    *   prepended internally with `CONTAINER_ID_PREFIX` (`lace-`) to form the
@@ -410,6 +418,15 @@ export class ContainerManager {
     specNamePrefix: string,
     liveSpecNames: Set<string>
   ): Promise<{ reaped: string[] }> {
+    if (this.ownerId === null) {
+      logger.warn(
+        'Container reaper: this agent has no distinct identity (LACE_DIR is unset), ' +
+          "so it cannot tell its own containers from another agent's; reaping nothing. " +
+          'Set LACE_DIR to enable orphan reaping.'
+      );
+      return { reaped: [] };
+    }
+
     const scanPrefix = `${CONTAINER_ID_PREFIX}${specNamePrefix}`;
     let containers: ContainerInfo[];
     try {

--- a/packages/agent/src/containers/manager-factory.test.ts
+++ b/packages/agent/src/containers/manager-factory.test.ts
@@ -18,6 +18,10 @@ function getRuntime(manager: ContainerManager | null): ContainerRuntime | null {
   return manager === null ? null : (manager as unknown as { runtime: ContainerRuntime }).runtime;
 }
 
+function getOwnerId(manager: ContainerManager | null): string | null | undefined {
+  return manager === null ? null : (manager as unknown as { ownerId: string | null }).ownerId;
+}
+
 describe('createDefaultContainerManager', () => {
   const originalRuntimeOverride = process.env[ENV_KEY];
 
@@ -59,12 +63,18 @@ describe('createDefaultContainerManager', () => {
 
 describe('containerOwnerId', () => {
   const originalLaceDir = process.env.LACE_DIR;
+  const originalRuntimeOverride = process.env[ENV_KEY];
 
   afterEach(() => {
     if (originalLaceDir === undefined) {
       delete process.env.LACE_DIR;
     } else {
       process.env.LACE_DIR = originalLaceDir;
+    }
+    if (originalRuntimeOverride === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = originalRuntimeOverride;
     }
   });
 
@@ -74,7 +84,7 @@ describe('containerOwnerId', () => {
 
     // Two calls model two boots of one agent: same directory, same identity.
     expect(containerOwnerId()).toBe(containerOwnerId());
-    expect(containerOwnerId()).toBe(fs.realpathSync(dir));
+    expect(containerOwnerId()).toBe(path.resolve(dir));
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
@@ -99,5 +109,55 @@ describe('containerOwnerId', () => {
     process.env.LACE_DIR = missing;
 
     expect(containerOwnerId()).toBe(path.resolve(missing));
+  });
+
+  it('is null when LACE_DIR is unset', () => {
+    // The default ~/.lace is shared by every agent this OS user runs, so it
+    // cannot tell two of them apart. No id at all is the honest answer; the
+    // manager then stamps no owner and reaps nothing.
+    delete process.env.LACE_DIR;
+
+    expect(containerOwnerId()).toBeNull();
+  });
+
+  it('treats an empty LACE_DIR as unset', () => {
+    process.env.LACE_DIR = '   ';
+
+    expect(containerOwnerId()).toBeNull();
+  });
+
+  it('survives a deploy retargeting the LACE_DIR symlink', () => {
+    // The `current -> releases/N` deploy shape. Resolving the symlink would
+    // change this agent's identity on every release, permanently stranding the
+    // containers it created before the swap: unownable, so unreapable by anyone.
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'lace-owner-deploy-'));
+    const current = path.join(base, 'current');
+    fs.mkdirSync(path.join(base, 'releases', '1'), { recursive: true });
+    fs.mkdirSync(path.join(base, 'releases', '2'), { recursive: true });
+    fs.symlinkSync(path.join(base, 'releases', '1'), current);
+    process.env.LACE_DIR = current;
+
+    const beforeDeploy = containerOwnerId();
+    fs.unlinkSync(current);
+    fs.symlinkSync(path.join(base, 'releases', '2'), current);
+
+    expect(containerOwnerId()).toBe(beforeDeploy);
+
+    fs.rmSync(base, { recursive: true, force: true });
+  });
+
+  it('is the owner id the constructed manager stamps and reaps by', () => {
+    // Wiring: the factory must hand the derived identity to the manager, not a
+    // constant of its own.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lace-owner-wiring-'));
+    process.env.LACE_DIR = dir;
+    process.env[ENV_KEY] = 'docker';
+
+    const manager = createDefaultContainerManager('linux');
+
+    expect(getOwnerId(manager)).toBe(containerOwnerId());
+    expect(getOwnerId(manager)).toBe(path.resolve(dir));
+
+    fs.rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/packages/agent/src/containers/manager-factory.test.ts
+++ b/packages/agent/src/containers/manager-factory.test.ts
@@ -1,7 +1,10 @@
 // ABOUTME: Unit tests for platform/env based ContainerManager construction
 
 import { afterEach, describe, expect, it } from 'vitest';
-import { createDefaultContainerManager } from './manager-factory';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { containerOwnerId, createDefaultContainerManager } from './manager-factory';
 import type { ContainerManager } from './container-manager';
 import type { ContainerRuntime } from './types';
 
@@ -51,5 +54,50 @@ describe('createDefaultContainerManager', () => {
     expect(() => createDefaultContainerManager('darwin')).toThrow(
       /LACE_CONTAINER_RUNTIME="podman" but no runtime registered under that name/
     );
+  });
+});
+
+describe('containerOwnerId', () => {
+  const originalLaceDir = process.env.LACE_DIR;
+
+  afterEach(() => {
+    if (originalLaceDir === undefined) {
+      delete process.env.LACE_DIR;
+    } else {
+      process.env.LACE_DIR = originalLaceDir;
+    }
+  });
+
+  it('is the agent LACE_DIR, so it survives a restart of the same agent', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lace-owner-'));
+    process.env.LACE_DIR = dir;
+
+    // Two calls model two boots of one agent: same directory, same identity.
+    expect(containerOwnerId()).toBe(containerOwnerId());
+    expect(containerOwnerId()).toBe(fs.realpathSync(dir));
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('differs between two agents on one host', () => {
+    const a = fs.mkdtempSync(path.join(os.tmpdir(), 'lace-owner-a-'));
+    const b = fs.mkdtempSync(path.join(os.tmpdir(), 'lace-owner-b-'));
+
+    process.env.LACE_DIR = a;
+    const ownerA = containerOwnerId();
+    process.env.LACE_DIR = b;
+    const ownerB = containerOwnerId();
+
+    expect(ownerA).not.toBe(ownerB);
+
+    fs.rmSync(a, { recursive: true, force: true });
+    fs.rmSync(b, { recursive: true, force: true });
+  });
+
+  it('still yields an id when LACE_DIR does not exist yet', () => {
+    const missing = path.join(os.tmpdir(), 'lace-owner-missing-does-not-exist');
+    process.env.LACE_DIR = missing;
+
+    expect(containerOwnerId()).toBe(path.resolve(missing));
   });
 });

--- a/packages/agent/src/containers/manager-factory.ts
+++ b/packages/agent/src/containers/manager-factory.ts
@@ -7,8 +7,7 @@ import { DockerContainerRuntime } from './docker-container';
 import { PlaneRuntime } from './plane-runtime';
 import { AppleContainerRuntime } from './apple-container';
 import { registries } from '@lace/agent/plugins';
-import { getLaceDir } from '@lace/agent/config/lace-dir';
-import * as fs from 'fs';
+import { getEnvVar } from '@lace/agent/config/env-loader';
 import * as path from 'path';
 import type { ContainerRuntime } from './types';
 
@@ -71,24 +70,33 @@ export function registerBuiltinRuntimes(): void {
 }
 
 /**
- * Identity for the containers this agent creates: its LACE_DIR.
+ * Identity for the containers this agent creates: an explicitly configured
+ * LACE_DIR, or null when there is none.
  *
- * The requirements are that it survives an agent restart (so a crashed agent
- * still recognizes and reaps its own leaked containers) and that two agents on
- * one host never share it (so neither reaps the other's containers). LACE_DIR
- * is exactly that — it is the agent's state directory, one per agent instance.
+ * The identity has to satisfy two properties at once: survive a restart of this
+ * agent (so a crashed agent still recognizes and reaps its own leaked
+ * containers) and differ from every other agent on the host (so neither reaps
+ * the other's). An explicit LACE_DIR satisfies both — it is durable, and giving
+ * a second agent its own LACE_DIR is how you run two agents in the first place.
  *
- * Realpath'd so a symlinked and an unsymlinked spelling of the same directory
- * do not read as two different agents; falls back to the resolved path when the
- * directory does not exist yet.
+ * `getLaceDir()`'s ~/.lace default does NOT: every agent this OS user runs
+ * lands on the same path, so an id derived from it is stable but not distinct,
+ * and two concurrent agents would reap each other exactly as before this label
+ * existed. Nothing else available at boot fixes that — anything durable under a
+ * shared LACE_DIR is shared too, and anything distinct (pid, boot time, a fresh
+ * random) is lost on restart. So we return null and the caller fails closed:
+ * no owner stamped, nothing reaped. Set LACE_DIR to turn reaping back on.
+ *
+ * `path.resolve`, not `fs.realpathSync`: under the usual `current ->
+ * releases/N` deploy shape, resolving the symlink would change this agent's
+ * identity at every release and strand every container created before the swap
+ * as unowned, hence unreapable by anyone. Two different spellings of one
+ * directory read as two agents, which costs a leak rather than a wrong destroy.
  */
-export function containerOwnerId(): string {
-  const laceDir = getLaceDir();
-  try {
-    return fs.realpathSync(laceDir);
-  } catch {
-    return path.resolve(laceDir);
-  }
+export function containerOwnerId(): string | null {
+  const laceDir = getEnvVar('LACE_DIR')?.trim();
+  if (!laceDir) return null;
+  return path.resolve(laceDir);
 }
 
 export function createDefaultContainerManager(

--- a/packages/agent/src/containers/manager-factory.ts
+++ b/packages/agent/src/containers/manager-factory.ts
@@ -7,6 +7,9 @@ import { DockerContainerRuntime } from './docker-container';
 import { PlaneRuntime } from './plane-runtime';
 import { AppleContainerRuntime } from './apple-container';
 import { registries } from '@lace/agent/plugins';
+import { getLaceDir } from '@lace/agent/config/lace-dir';
+import * as fs from 'fs';
+import * as path from 'path';
 import type { ContainerRuntime } from './types';
 
 export const CONTAINER_RUNTIME_ENV = 'LACE_CONTAINER_RUNTIME';
@@ -67,6 +70,27 @@ export function registerBuiltinRuntimes(): void {
   }
 }
 
+/**
+ * Identity for the containers this agent creates: its LACE_DIR.
+ *
+ * The requirements are that it survives an agent restart (so a crashed agent
+ * still recognizes and reaps its own leaked containers) and that two agents on
+ * one host never share it (so neither reaps the other's containers). LACE_DIR
+ * is exactly that — it is the agent's state directory, one per agent instance.
+ *
+ * Realpath'd so a symlinked and an unsymlinked spelling of the same directory
+ * do not read as two different agents; falls back to the resolved path when the
+ * directory does not exist yet.
+ */
+export function containerOwnerId(): string {
+  const laceDir = getLaceDir();
+  try {
+    return fs.realpathSync(laceDir);
+  } catch {
+    return path.resolve(laceDir);
+  }
+}
+
 export function createDefaultContainerManager(
   platform: NodeJS.Platform = process.platform,
   runtimeSelection: string | undefined = process.env[CONTAINER_RUNTIME_ENV]
@@ -94,5 +118,5 @@ export function createDefaultContainerManager(
     throw new Error(`${CONTAINER_RUNTIME_ENV}="${name}" but no runtime registered under that name`);
   }
 
-  return new ContainerManager(registries.runtimes.resolve(name));
+  return new ContainerManager(registries.runtimes.resolve(name), containerOwnerId());
 }

--- a/packages/agent/src/containers/startup-reaper.ts
+++ b/packages/agent/src/containers/startup-reaper.ts
@@ -1,12 +1,14 @@
 // ABOUTME: Best-effort orphan-container reaper invoked once at agent startup
-// ABOUTME: Destroys lace-prefixed containers not in the live spec set; failures never block boot
+// ABOUTME: Destroys this agent's own leaked lace- containers; failures never block boot
 
 import { logger } from '@lace/agent/utils/logger';
 import { ContainerManager } from './container-manager';
 
 /**
- * Reap every lace-prefixed container on the host that is not in liveSpecNames.
- * For v1 liveSpecNames is always empty — boot is a clean slate.
+ * Reap the lace-prefixed containers THIS agent leaked behind a previous run.
+ * The live set is empty because a booting agent owns no containers yet; the
+ * blast radius is bounded by ContainerManager's `lace.owner` label check, which
+ * spares containers belonging to other agents on the same host.
  *
  * Best-effort: a null manager (unsupported platform) or any thrown error logs
  * and returns. Reaper failure must never block agent startup.

--- a/packages/agent/src/containers/startup-reaper.ts
+++ b/packages/agent/src/containers/startup-reaper.ts
@@ -8,7 +8,9 @@ import { ContainerManager } from './container-manager';
  * Reap the lace-prefixed containers THIS agent leaked behind a previous run.
  * The live set is empty because a booting agent owns no containers yet; the
  * blast radius is bounded by ContainerManager's `lace.owner` label check, which
- * spares containers belonging to other agents on the same host.
+ * spares containers belonging to other agents on the same host. An agent with
+ * no distinct identity of its own (LACE_DIR unset) reaps nothing at all — see
+ * `containerOwnerId` in manager-factory.
  *
  * Best-effort: a null manager (unsupported platform) or any thrown error logs
  * and returns. Reaper failure must never block agent startup.

--- a/packages/agent/src/jobs/__tests__/persona-container-sharing.integration.test.ts
+++ b/packages/agent/src/jobs/__tests__/persona-container-sharing.integration.test.ts
@@ -170,7 +170,7 @@ describe.skipIf(!DOCKER_AVAILABLE)('persona container sharing integration', () =
 
   beforeAll(async () => {
     runtime = new DockerContainerRuntime();
-    containerManager = new ContainerManager(runtime);
+    containerManager = new ContainerManager(runtime, `/lace-dir/persona-sharing-${process.pid}`);
 
     // Pull images if missing. Timeout generous for first-time pull.
     await pullImageIfMissing(TEST_PER_INVOCATION_IMAGE);

--- a/packages/agent/src/main.ts
+++ b/packages/agent/src/main.ts
@@ -160,7 +160,8 @@ async function boot(): Promise<void> {
   // The workspace reaper routes per_invocation teardown to the shim via the
   // container manager, so it needs the live container manager now that it exists.
   state.workspaceReaper.bindRuntime(manager);
-  // Orphan-container reap: destroys orphan lace-* containers via the runtime. The
+  // Orphan-container reap: destroys the lace-* containers THIS agent leaked in a
+  // previous run (matched by the `lace.owner` label), never a sibling agent's. The
   // shim owns workspace reaping on the plane, so lace does not run a workspace
   // sweep here (the removed owner marker defeats its liveness gates). On the
   // plane runtime runtime.list() returns only the empty in-process cache, so


### PR DESCRIPTION
`startup-reaper.ts` calls `manager.reapOrphans('', new Set<string>())` — empty prefix, empty live set — so a booting agent destroys **every** `lace-`-prefixed container on the host, including containers belonging to other agents.

This is deliberate and documented: *"For v1 liveSpecNames is always empty — boot is a clean slate."* That assumption holds for one agent per host and silently fails otherwise.

## First: the severity is lower than it looks

This was investigated on the premise that it might destroy live production work. **It does not**, for two independent reasons:

1. **The plane runtime skips the reaper entirely.** `main.ts:168` is `runStartupReaper(manager?.isPlaneRuntime ? null : manager)`, and production sets `LACE_CONTAINER_RUNTIME=plane` (`sen-core-v2/docker-compose.yml:145`), so the shim owns reaping and lace's reaper never runs. The blast radius exists only on the direct-docker path — dev boxes and CI.
2. **One host runs one coworker instance**, enforced by single-tenant assumptions well outside lace: the shim names persistent boxes `sen-<environment>` with no instance key; the upgrade path removes `sen-persistent-box` / `sen-coworker-box` unqualified; the egress watcher reconciles *all* `sen-egress-*` nets on the daemon; `/etc/sen/coworker.env`, the tailnet hostname and the EBS mount are host-global. (The compose comment claiming multiple coworker stacks can coexist on one host is aspirational and contradicted by all of the above.)

So what this actually broke was **test runs on shared dev boxes**, which is real and was observed twice this week:

- An agent measuring a Docker teardown race watched a sibling's test run destroy its probe containers mid-measurement.
- `persona-container-sharing.integration.test.ts > resume after TTL spawns fresh container` failed 5-of-6 under full parallelism and passed serialized — concurrent agent boots reaping each other's containers.

Worth keeping straight: a single instance legitimately runs **several lace processes** (root agent, the credential-arbiter's own lace with a separate `LACE_DIR`, per-delegate subagents). Those belong to one instance. Accidental second agents on a box are a known bug class, not a supported shape.

The fix is still worth making: the dev-box corruption is real, and the "one agent per host" invariant is currently owned by no code in lace.

## Why not a name prefix

Nothing distinguished one agent's containers from another's. Names are `lace-<parent8>-<env>-<child8>`, derived from session ids — and a booting agent knows no session ids yet, so there is no prefix available at reap time.

Labels were already plumbed end-to-end (`spec.labels` → `--label` → `docker inspect` → `ContainerInfo.labels`, already used by the spawn broker), so this uses those.

## The change

- `ContainerManager` takes an **`ownerId`** and stamps `lace.owner=<ownerId>` on every container it creates **in the `lace-` namespace**. Specs with a verbatim `containerId` (persistent boxes, `sen-<env>`) are outside that namespace, were never reap candidates, and their labels are left untouched.
- `reapOrphans` destroys a candidate only when its `lace.owner` matches. Ownership is read via `runtime.daemonInspect`, because `DockerContainerRuntime.list()` shells to `docker ps`, which reports no labels.
- **`ownerId` is the agent's explicitly configured `LACE_DIR`**, `path.resolve`d (`containerOwnerId()` in `manager-factory.ts`). Stable across a crash and restart of one agent, distinct between agents — which is exactly what lets a crashed agent still reap its own leaks while sparing a sibling's.
- **When `LACE_DIR` is unset there is no owner id, and this agent stamps nothing and reaps nothing.** See below.

## Migration — stated explicitly

Containers created before this change carry no `lace.owner` label and are now **reaped by nobody.**

That is deliberate: a leaked container is recoverable by hand, a wrongly-reaped one is not. The reaper logs them at WARN with their ids so an operator can clean up. The same fail-closed rule applies when `daemonInspect` errors.

There is no flag to restore the previous behaviour — a flag defaulting to the old behaviour would leave the bug on by default.

## Ownership when `LACE_DIR` is unset — fail closed

An earlier revision of this PR derived the owner id from `getLaceDir()`, which falls back to `~/.lace`. That was wrong, and it was wrong precisely where the bug was observed: on a dev box nobody sets `LACE_DIR`, so every agent one OS user runs computed the *same* owner id, matched every sibling's label and reaped it exactly as before. The headline guarantee did not hold in the default configuration. (Thanks to the reviewer who caught this.)

**Both properties cannot hold without a configured `LACE_DIR`.** The id has to be durable across a restart *and* distinct per agent. With `LACE_DIR` unset, anything durable lives under the one shared `~/.lace` and is therefore shared; anything distinct at boot (pid, boot timestamp, a fresh random, the process's cwd) dies with the process, so a restarted agent would no longer recognize its own leaks — which is the property this PR is built on. A lock-slot scheme in the shared directory gets close but needs liveness detection of sibling processes to decide whether a slot is free, and getting that wrong destroys live containers. That is the wrong risk to take to automate cleanup of leaked ones.

So `containerOwnerId()` returns `null` when `LACE_DIR` is not explicitly set, and a `ContainerManager` with a null owner:

- **stamps no `lace.owner` label.** Stamping the shared `~/.lace` value would be worse than no label — the next agent, or an operator who does set `LACE_DIR=~/.lace`, would match it and destroy live containers.
- **reaps nothing**, and logs at WARN why, naming `LACE_DIR` as the way to turn reaping on.

Net behaviour change for an unset `LACE_DIR`: the reaper goes from "destroys every `lace-` container on the host" to "destroys nothing". Orphans accumulate until an operator removes them. That is the same trade this PR already makes for unlabelled containers: a leak is recoverable by hand, a wrong destroy is not.

## `path.resolve`, not `realpathSync`

The owner id is now `path.resolve`d. `realpathSync` was chosen so two spellings of one directory would not read as two agents, but its cost is worse than the problem: under the standard `current -> releases/N` deploy shape, retargeting the symlink changes the agent's identity at every release, and every container created before the swap becomes permanently unownable — and, under this PR's fail-closed rule, unreapable by anyone.

`path.resolve` inverts the failure direction. It can *split* one agent's identity across two spellings (cost: a leak), where `realpathSync` can *merge* two identities and strand history (cost: an unreapable container now, and a wrong destroy if a future reader ever trusts a merged id). Splitting is the safe direction, and it is the same principle the rest of this PR follows. It also drops the `fs` dependency and the "directory does not exist yet" fallback branch.

That branch was untested; swapping the implementations left the suite green. There is now a test that distinguishes them (`survives a deploy retargeting the LACE_DIR symlink`).

## Known limitation

The granularity is the `LACE_DIR`, not the process. Root agent and delegate lace processes share one, so the owner id does not distinguish parent from delegate; nor does it distinguish two agents an operator deliberately points at the same `LACE_DIR`. **This is the one residual case where two lace processes still reap each other's containers.** No path was found where it bites in practice — a delegate boots either with the plane runtime (reaper skipped) or inside a container with no docker socket (`list()` fails, returns `[]`) — but it is a real hole and it is not closed by this PR.

The other residual is the one above: with `LACE_DIR` unset nothing is reaped, ever.

## Mutation evidence

Each mutation was applied, run, and reverted; each went red on exactly the intended tests.

| Mutation | Tests that failed |
|---|---|
| M1 never stamp the owner label | spec-fields passthrough; `propagates spec.labels`; `stamps the owner label even when the spec carries none`; `reaps an orphan it created itself before restarting` |
| M2 drop the owner check in `reapOrphans` | `leaves another agent's container alone` |
| M3 treat unlabelled as ours | `leaves an unlabelled container alone and warns about it`; `leaves a container alone when its ownership cannot be inspected` |
| M4 drop the live-set exclusion | three live-set tests |
| M5 stamp owner onto verbatim-id boxes | `leaves labels alone for a verbatim-id spec (a persistent box)` |
| M6 inspect failure reads as "ours" | `leaves a container alone when its ownership cannot be inspected` |
| M7 `containerOwnerId` returns a constant | all three `containerOwnerId` tests |
| M8 no fallback when LACE_DIR is missing | `still yields an id when LACE_DIR does not exist yet` |
| N1 `containerOwnerId` falls back to `~/.lace` when LACE_DIR is unset | `is null when LACE_DIR is unset`; `treats an empty LACE_DIR as unset`; `does not let two agents in the default configuration reap each other` |
| N2 resolve the owner id with `fs.realpathSync` | `survives a deploy retargeting the LACE_DIR symlink`; `still yields an id when LACE_DIR does not exist yet` |
| N3 factory passes a constant owner id instead of `containerOwnerId()` | `is the owner id the constructed manager stamps and reaps by` |
| N4 stamp the owner label even with a null owner id | `stamps no owner label when the agent has no distinct identity` |
| N5 drop the null-owner early return in `reapOrphans` | `reaps nothing when the agent has no distinct identity` |

M2 and M3 were re-applied after this change to confirm the original coverage still bites; both still go red on exactly their listed tests.

One harness change was needed for fidelity: `MockContainerRuntime` now remembers create-time labels (as a daemon does) and its `list()` strips them (as `docker ps` does), so ownership genuinely resolves through the inspect path rather than being handed to the code under test.

## Verification

- typecheck and lint clean.
- `src/containers` (194 passed, 13 skipped) and `src/jobs` (308 passed) fully green — **including the real-docker `docker-container.integration.test.ts` and all 8 `persona-container-sharing.integration.test.ts` cases. `resume after TTL spawns fresh container` passed on both runs.**
- Full agent suite shows 24 files failing, all in the spawned-agent-process E2E family plus `resource-resolver.test.ts` (which asserts against a built `dist/` this fresh worktree never produced). Confirmed pre-existing by checking out the base commit in the same worktree and re-running `system-prompt-injection.test.ts`: identical `7 failed | 5 passed`. Zero container or job failures.

## Not verified

- Not exercised against a real second agent booting concurrently — doing that means starting an agent that reaps, on a box with live containers. The evidence is the unit tests plus the real-docker integration suites.
- macOS: `AppleContainerRuntime.list()` returns only its in-process cache, so after a restart it lists nothing and reaps nothing. That was already true; the label check does not make it worse. Unconfirmed on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

