### PR TITLE
docs: remove dead link to a helper-agents doc that was never written

### DIFF
--- a/docs/HELPER-AGENTS.md
+++ b/docs/HELPER-AGENTS.md
@@ -108,8 +108,6 @@ registry.removeHelper('analysis-task');
   guide
 - **[Code Examples](./examples/helper-patterns.ts)** - Practical implementation
   patterns
-- **[Integration Examples](./examples/integration-examples.md)** - Real-world
-  system integration
 
 ### Quick Start
 


### PR DESCRIPTION
HELPER-AGENTS.md links to `./examples/integration-examples.md`, but that file has never existed anywhere in the repo's history (confirmed with `git log --all`). This drops the dead reference so the doc doesn't point readers at a 404.

Small, mechanical fix opened to verify fork-originated CI now runs post-#396.